### PR TITLE
Add option for specifying RC4 40-bit key instead of password

### DIFF
--- a/qpdf/qpdf.cc
+++ b/qpdf/qpdf.cc
@@ -68,6 +68,7 @@ Basic Options\n\
 -------------\n\
 \n\
 --password=password     specify a password for accessing encrypted files\n\
+--key=key     specify a RC4 40-bit key for accessing encrypted files\n\
 --linearize             generated a linearized (web optimized) file\n\
 --copy-encryption=file  copy encryption parameters from specified file\n\
 --encryption-file-password=password\n\
@@ -938,6 +939,9 @@ int main(int argc, char* argv[])
     char const* infilename = 0;
     char const* outfilename = 0;
 
+    extern char *raw_key;
+    extern int have_raw_key;
+
     for (int i = 1; i < argc; ++i)
     {
 	char const* arg = argv[i];
@@ -969,6 +973,18 @@ int main(int argc, char* argv[])
 		    usage("--password must be given as --password=pass");
 		}
 		password = parameter;
+	    }
+	    else if (strcmp(arg, "key") == 0)
+	    {
+		if (parameter == 0)
+		{
+		    usage("--key must be given as --key=key");
+		}
+		raw_key = parameter;
+		if(strlen(raw_key) != 10) {
+		    usage("key must be 40-bit long (string length == 10)");
+		}
+		have_raw_key = 1;
 	    }
             else if (strcmp(arg, "empty") == 0)
             {


### PR DESCRIPTION
Hi,

After applying this patch, it is possible to use RC4 40-bit key directly instead of password.

```
./qpdf/build/qpdf --key=9296c944ee --decrypt test.pdf output.pdf
```

```
Get test.pdf from http://dl.dropbox.com/u/1522424/test.pdf
```

This patch is useful since RC4 40-bit key can be cracked in under 3 days (with 100% success rate) on processors like AMD FX-8120.

Cheers,
Dhiru
