### PR TITLE
Add missing include to fix building with Clang and libc++.

### DIFF
--- a/include/qpdf/QPDFExc.hh
+++ b/include/qpdf/QPDFExc.hh
@@ -8,6 +8,8 @@
 #ifndef __QPDFEXC_HH__
 #define __QPDFEXC_HH__
 
+#include <string>
+
 #include <qpdf/DLL.h>
 #include <qpdf/Types.h>
 


### PR DESCRIPTION
- Add "#include <string>" to QPDFExc.hh.
