### PR TITLE
QUtil.hh: time_t needs #include <time.h>

### DIFF
--- a/include/qpdf/QUtil.hh
+++ b/include/qpdf/QUtil.hh
@@ -14,6 +14,7 @@
 #include <list>
 #include <stdexcept>
 #include <stdio.h>
+#include <time.h>
 
 class RandomDataProvider;
 


### PR DESCRIPTION
Fixes build on uClibc without threads:

http://autobuild.buildroot.net/results/af8/af857caef0c622aa9cfb1859b344880971ff263c/build-end.log

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>