### PR TITLE
Improve compability with Embarcadero C++-Builder 10 Seattle

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -17,17 +17,17 @@
 #include <list>
 #include <iostream>
 
-#include <qpdf/QPDFObjGen.hh>
-#include <qpdf/QPDFXRefEntry.hh>
+#include <qpdf/QPDFExc.hh>
 #include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFObjGen.hh>
 #include <qpdf/QPDFTokenizer.hh>
+#include <qpdf/QPDFXRefEntry.hh>
 #include <qpdf/Buffer.hh>
 #include <qpdf/InputSource.hh>
 
 class QPDF_Stream;
 class BitStream;
 class BitWriter;
-class QPDFExc;
 
 class QPDF
 {

--- a/include/qpdf/QPDFWriter.hh
+++ b/include/qpdf/QPDFWriter.hh
@@ -24,6 +24,7 @@
 
 #include <qpdf/Constants.h>
 
+#include <qpdf/QPDFObjectHandle.hh>
 #include <qpdf/QPDFObjGen.hh>
 #include <qpdf/QPDFXRefEntry.hh>
 
@@ -33,7 +34,6 @@
 #include <qpdf/Buffer.hh>
 
 class QPDF;
-class QPDFObjectHandle;
 class Pl_Count;
 class Pl_MD5;
 

--- a/libqpdf/QUtil.cc
+++ b/libqpdf/QUtil.cc
@@ -164,7 +164,7 @@ QUtil::seek(FILE* stream, qpdf_offset_t offset, int whence)
 #elif HAVE_FSEEKO64
     return fseeko64(stream, offset, whence);
 #else
-# ifdef _MSC_VER
+# if defined _MSC_VER || defined __BORLANDC__
     return _fseeki64(stream, offset, whence);
 # else
     return fseek(stream, static_cast<long>(offset), whence);
@@ -180,7 +180,7 @@ QUtil::tell(FILE* stream)
 #elif HAVE_FSEEKO64
     return static_cast<qpdf_offset_t>(ftello64(stream));
 #else
-# ifdef _MSC_VER
+# if defined _MSC_VER || defined __BORLANDC__
     return _ftelli64(stream);
 # else
     return static_cast<qpdf_offset_t>(ftell(stream));

--- a/libtests/bits.cc
+++ b/libtests/bits.cc
@@ -3,6 +3,7 @@
 #include <qpdf/Pl_Buffer.hh>
 #include <iostream>
 #include <stdio.h>
+#include <stdlib.h>
 
 // See comments in bits.cc
 #define BITS_TESTING 1

--- a/libtests/qtest/qutil.test
+++ b/libtests/qtest/qutil.test
@@ -13,6 +13,6 @@ $td->runtest("QUtil",
 	     {$td->COMMAND => "qutil"},
 	     {$td->FILE => "qutil.out",
 	      $td->EXIT_STATUS => 0},
-	     $td->NORMALIZE_NEWLINES);
+	     $td->NORMALIZE_NEWLINES | $td->RM_WS_ONLY_LINES);
 
 $td->report(1);

--- a/qtest/module/TestDriver.pm
+++ b/qtest/module/TestDriver.pm
@@ -824,15 +824,15 @@ sub runtest
 	{
 	    &QTC::TC("testdriver", "TestDriver no normalize newlines");
 	}
-  if ($flags & $rep->RM_WS_ONLY_LINES)
-  {
-      &QTC::TC("testdriver", "TestDriver remove empty lines");
-      $line =~ s/^\s+$//;
-  }
-  else
-  {
-      &QTC::TC("testdriver", "TestDriver no remove empty lines");
-  }
+    if ($flags & $rep->RM_WS_ONLY_LINES)
+    {
+        &QTC::TC("testdriver", "TestDriver remove whitespace only lines");
+        $line =~ s/^\s+$//;
+    }
+    else
+    {
+        &QTC::TC("testdriver", "TestDriver no remove whitespace only lines");
+    }
 	$actual->print($line);
 	$actual->flush();
 	last if defined $exit_status;

--- a/qtest/module/TestDriver.pm
+++ b/qtest/module/TestDriver.pm
@@ -65,9 +65,10 @@ use constant TD_THREADS => 'TD_THREADS';
 use constant TD_SEQGROUPS => 'TD_SEQGROUPS';
 
 # Flags
-use constant NORMALIZE_NEWLINES =>   1 << 0;
+use constant NORMALIZE_NEWLINES   => 1 << 0;
 use constant NORMALIZE_WHITESPACE => 1 << 1;
-use constant EXPECT_FAILURE =>       1 << 2;
+use constant EXPECT_FAILURE       => 1 << 2;
+use constant RM_WS_ONLY_LINES     => 1 << 3;
 
 # Field names
 use vars qw($f_socket $f_origdir $f_tempdir $f_testlog $f_testxml $f_suitename);
@@ -550,6 +551,12 @@ sub get_start_dir
 #      place-holder test cases that exercise a known bug that cannot
 #      yet be fixed.
 
+#      RM_WS_ONLY_LINES: If specified, all lines only containing any
+#      whitespace character like newlines, spaces or tabs are removed
+#      from the input.  This is done before writing through any
+#      filter and is especially useful if some tests output more e.g.
+#      newlines on some platforms than on others.
+
 sub runtest
 {
     my $rep = shift;
@@ -817,6 +824,15 @@ sub runtest
 	{
 	    &QTC::TC("testdriver", "TestDriver no normalize newlines");
 	}
+  if ($flags & $rep->RM_WS_ONLY_LINES)
+  {
+      &QTC::TC("testdriver", "TestDriver remove empty lines");
+      $line =~ s/^\s+$//;
+  }
+  else
+  {
+      &QTC::TC("testdriver", "TestDriver no remove empty lines");
+  }
 	$actual->print($line);
 	$actual->flush();
 	last if defined $exit_status;


### PR DESCRIPTION
I'm using Embarcadero C++-Builder 10 Seattle to build QPDF 6.0.0, which fails in some places because of missing includes, different behavior of the compiler regarding forward declarations and such. In this issue I would like to keep track of the changes needed to get your code compiled in my environment, because I'm pretty sure that most of them can easily be merged without any negative side effects. So I would love to see them considered for merging. Thanks!