### PR TITLE
Useless use of a constant in void context

### DIFF
--- a/qtest/module/TestDriver.pm
+++ b/qtest/module/TestDriver.pm
@@ -386,7 +386,7 @@ sub report
     push(@vals, map { $rep->{+__PACKAGE__}{$_} } ($f_passes, $f_fails,
 						  $f_xpasses, $f_xfails));
     my $socket = $rep->_socket();
-    $socket->print(join(' ', @vals)), "\n";
+    $socket->print(join(' ', @vals), "\n");
 }
 
 # Usage: notify(string)


### PR DESCRIPTION
Any statement after line 390 showed the warning: Useless use of a constant in void context at /c/Users/[...]/src/qtest/module/TestDriver.pm line 390. The problem was the "\n" which surely should be included in the call to "print".