### PR TITLE
Included <cstdlib> in libqpdf/QPDFTokenizer.cc for strtol()

### DIFF
--- a/examples/pdf-split-pages.cc
+++ b/examples/pdf-split-pages.cc
@@ -64,14 +64,17 @@ int main(int argc, char* argv[])
     {
         std::cerr << "Usage: " << whoami << " infile outprefix" << std::endl;
     }
-    try
+    else
     {
-        process(whoami, argv[1], argv[2]);
-    }
-    catch (std::exception e)
-    {
-        std::cerr << whoami << ": exception: " << e.what() << std::endl;
-        return 2;
+        try
+        {
+            process(whoami, argv[1], argv[2]);
+        }
+        catch (std::exception e)
+        {
+            std::cerr << whoami << ": exception: " << e.what() << std::endl;
+            return 2;
+        }
     }
     return 0;
 }

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -10,6 +10,7 @@
 
 #include <stdexcept>
 #include <string.h>
+#include <cstdlib>
 
 QPDFTokenizer::QPDFTokenizer() :
     pound_special_in_name(true),


### PR DESCRIPTION
Solves Make error in libqpdf/QPDFTokenizer.cc and removes SIGSEGV from pdf-split-pages example