### PR TITLE
Add PCLm support to QPDF.

### DIFF
--- a/include/qpdf/QPDFWriter.hh
+++ b/include/qpdf/QPDFWriter.hh
@@ -308,6 +308,11 @@ class QPDFWriter
     QPDF_DLL
     void setLinearization(bool);
 
+    // Create PCLm output. Enables writing unreferenced objects,
+    // set PCLm header and writes pages before file catalog and page tree.
+    QPDF_DLL
+    void setPCLm(bool);
+
     QPDF_DLL
     void write();
 
@@ -372,9 +377,11 @@ class QPDFWriter
     void prepareFileForWrite();
     void writeStandard();
     void writeLinearized();
+    void writePCLm();
     void enqueuePart(std::vector<QPDFObjectHandle>& part);
     void writeEncryptionDictionary();
     void writeHeader();
+    void writePCLmHeader();
     void writeHintStream(int hint_id);
     qpdf_offset_t writeXRefTable(
         trailer_e which, int first, int last, int size);
@@ -446,6 +453,7 @@ class QPDFWriter
     bool encrypted;
     bool preserve_encryption;
     bool linearized;
+    bool pclm;
     qpdf_object_stream_e object_stream_mode;
     std::string encryption_key;
     bool encrypt_metadata;

--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -66,6 +66,7 @@ QPDFWriter::init()
     encrypted = false;
     preserve_encryption = true;
     linearized = false;
+    pclm = false;
     object_stream_mode = qpdf_o_preserve;
     encrypt_metadata = true;
     encrypt_use_aes = false;
@@ -318,6 +319,20 @@ void
 QPDFWriter::setLinearization(bool val)
 {
     this->linearized = val;
+    if (val)
+    {
+        this->pclm = false;
+    }
+}
+
+void
+QPDFWriter::setPCLm(bool val)
+{
+    this->pclm = val;
+    if (val)
+    {
+        this->linearized = false;
+    }
 }
 
 void
@@ -2254,6 +2269,13 @@ QPDFWriter::write()
 	this->qdf_mode = false;
     }
 
+    if (this->pclm)
+    {
+        this->stream_data_mode_set = true;
+        this->stream_data_mode = qpdf_s_preserve;
+        this->encrypted = false;
+    }
+
     if (this->qdf_mode)
     {
 	if (! this->normalize_content_set)
@@ -2388,6 +2410,10 @@ QPDFWriter::write()
     {
 	writeLinearized();
     }
+    else if (this->pclm)
+    {
+        writePCLm();
+    }
     else
     {
 	writeStandard();
@@ -2459,6 +2485,26 @@ QPDFWriter::writeHeader()
     // within the first 1024 characters of the PDF file, so for
     // linearized files, we have to write extra header text after the
     // linearization parameter dictionary.
+}
+
+void
+QPDFWriter::writePCLmHeader()
+{
+    setMinimumPDFVersion(pdf.getPDFVersion(), pdf.getExtensionLevel());
+    this->final_pdf_version = this->min_pdf_version;
+    this->final_extension_level = this->min_extension_level;
+    if (! this->forced_pdf_version.empty())
+    {
+	QTC::TC("qpdf", "QPDFWriter using forced PDF version");
+	this->final_pdf_version = this->forced_pdf_version;
+        this->final_extension_level = this->forced_extension_level;
+    }
+
+    writeString("%PDF-");
+    writeString(this->final_pdf_version);
+    // PCLm version
+    writeString("\n%PCLm 1.0\n");
+    writeStringQDF("%QDF-1.0\n\n");
 }
 
 void
@@ -3161,6 +3207,85 @@ QPDFWriter::writeStandard()
     {
 	QTC::TC("qpdf", "QPDFWriter standard deterministic ID",
                 this->object_stream_to_objects.empty() ? 0 : 1);
+        popPipelineStack();
+        assert(this->md5_pipeline == 0);
+    }
+}
+
+void
+QPDFWriter::writePCLm()
+{
+    if (this->deterministic_id)
+    {
+        pushMD5Pipeline();
+    }
+
+    // Start writing
+
+    writePCLmHeader();
+    writeString(this->extra_header_text);
+
+    // Image transform stream content for page strip images.
+    // Each of this new stream has to come after every page image
+    // strip written in the pclm file.
+    std::string image_transform_content = "q /image Do Q\n";
+
+    // enqueue all pages first
+    std::vector<QPDFObjectHandle> all = this->pdf.getAllPages();
+    for (std::vector<QPDFObjectHandle>::iterator iter = all.begin();
+            iter != all.end(); ++iter)
+    {
+        // enqueue page
+        enqueueObject(*iter);
+
+        // enqueue page contents stream
+        enqueueObject((*iter).getKey("/Contents"));
+
+        // enqueue all the strips for each page
+        QPDFObjectHandle strips = (*iter).getKey("/Resources").getKey("/XObject");
+        std::set<std::string> keys = strips.getKeys();
+        for (std::set<std::string>::iterator image = keys.begin();
+                image != keys.end(); ++image)
+        {
+            enqueueObject(strips.getKey(*image));
+            enqueueObject(QPDFObjectHandle::newStream(&pdf, image_transform_content));
+        }
+    }
+
+    // Put root in queue.
+    QPDFObjectHandle trailer = getTrimmedTrailer();
+    enqueueObject(trailer.getKey("/Root"));
+
+    // Now start walking queue, output each object
+    while (this->object_queue.size())
+    {
+        QPDFObjectHandle cur_object = this->object_queue.front();
+        this->object_queue.pop_front();
+        writeObject(cur_object);
+    }
+
+    // Now write out xref.  next_objid is now the number of objects.
+    qpdf_offset_t xref_offset = this->pipeline->getCount();
+    if (this->object_stream_to_objects.empty())
+    {
+        // Write regular cross-reference table
+        writeXRefTable(t_normal, 0, this->next_objid - 1, this->next_objid);
+    }
+    else
+    {
+        // Write cross-reference stream.
+        int xref_id = this->next_objid++;
+        writeXRefStream(xref_id, xref_id, xref_offset, t_normal,
+                0, this->next_objid - 1, this->next_objid);
+    }
+    writeString("startxref\n");
+    writeString(QUtil::int_to_string(xref_offset));
+    writeString("\n%%EOF\n");
+
+    if (this->deterministic_id)
+    {
+        QTC::TC("qpdf", "QPDFWriter standard deterministic ID",
+                    this->object_stream_to_objects.empty() ? 0 : 1);
         popPipelineStack();
         assert(this->md5_pipeline == 0);
     }


### PR DESCRIPTION
PCLm is a strict subset of PDF. PCLm was created by HP and is a printer friendly language. It is supported by [WifiDirect](http://www.wi-fi.org/discover-wi-fi/wi-fi-direct) and [Mopria](http://mopria.org/) printing standards for printing over the [Internet Printing Protocol](https://en.wikipedia.org/wiki/Internet_Printing_Protocol) and hence is supported by millions of printers for printing. PCLm can also be viewed by a standard PDF viewer.

Since it is a strict subset of PDF, it would be an enhancement for QPDF to support this format. The main structural differences between PDF and PCLm are:

1. For PCLm to be viewed by a normal PDF viewer, it needs some unreferenced objects to exist in the file at specific positions.
2. The file must start with a page rather than a page tree of a file catalog. The contents of every page must end before another page starts. There cannot be any ambiguous ordering in the contents of the PCLm file since the ordering is well defined. Some ambiguous ordering may show up correctly in a PDF viewer, but a printer that supports PCLm will abort the job if it get an ambiguous ordering.
3. The file body catalog and page tree must be at the end of the file just before xref.
4. PCLm files contain a magic number in the second line, which makes it look like:
```
%PDF-1.3
%PCLm-1.0
```

This pull request aims at adding PCLm support for QPDF so that QPDF can produce PCLm files as well.
 
