### PR TITLE
Always insert newlines when newline-before-endstream (fixes #133)

### DIFF
--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -1587,7 +1587,12 @@ QPDFWriter::unparseObject(QPDFObjectHandle object, int level,
 	char last_char = this->pipeline->getLastChar();
 	popPipelineStack();
 
-	if (this->qdf_mode || this->newline_before_endstream)
+	if (this->newline_before_endstream)
+	{
+		writeString("\n");
+	}
+
+	if (this->qdf_mode)
 	{
 	    if (last_char != '\n')
 	    {


### PR DESCRIPTION
I have drilled down into #133 and found the problem.

The current implementation of the `--newline-before-endstream` option re-used the option to write newlines when working in `qdf` mode. In that mode, the newline before `endstream` is only added if the stream content itself does not end with a newline. This may be fine for `qdf`, but it does *not* comply with the PDF/A rules (which mandate that a newline should always be added before `endstream`, disregarding whether the stream itself ends with a newline or not).

This pull request fixes the issue for me and passes all the current tests, but it can be improved in two ways:

1. A test case should probably be added to verify that the functionality doesn't break in the future. I don't know how to create a simple (minimal) pdf that has a stream whose content ends with a newline, and hence I haven't added the test. If you can help on that I will add a test to the test suite.

2. The interaction between `--newline-before-endstream` and `qdf` mode may be broken now. I don't know much about `qdf` mode and how it should operate in this instance, so I've preferred to not mess around with it (at least it will operate exactly the same as before without the `--newline-before-endstream` option.