### PR TITLE
Remove libjpeg dependency from pkg-config

### DIFF
--- a/libqpdf.pc.in
+++ b/libqpdf.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: libqpdf
 Description: PDF transformation library
 Version: @PACKAGE_VERSION@
-Requires.private: zlib, libjpeg
+Requires.private: zlib
 Libs: -L${libdir} -lqpdf
 Cflags: -I${includedir}


### PR DESCRIPTION
Linking QPDF with the original libjpeg-9a from http://ijg.org works well, but when I then compile cups-filters with QPDF support, cups-filters' configure is confused about it, because libjpeg does not ship pkg-config definitions:

```
[...]
checking for ZLIB... yes
checking for LIBQPDF... no
configure: error: Package requirements (libqpdf >= 3.0.2) were not met:

Package 'libjpeg', required by 'libqpdf', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.
```

We cannot solve this problem in QPDF, so just remove the libjpeg dependency from the `Requires.private` variable.