### PR TITLE
Fix build with libc++

### DIFF
--- a/libqpdf/Pl_PNGFilter.cc
+++ b/libqpdf/Pl_PNGFilter.cc
@@ -1,5 +1,6 @@
 #include <qpdf/Pl_PNGFilter.hh>
 #include <qpdf/QTC.hh>
+#include <cstdlib>
 #include <stdexcept>
 #include <string.h>
 #include <limits.h>


### PR DESCRIPTION
Fixes build failure
```
bash-3.2$ make -j1
/bin/bash ./libtool --quiet --mode=compile clang++ -g -O2 -Wold-style-cast -Wall -MD -MF libqpdf/build/Pl_PNGFilter.tdep -MP -Iinclude -Ilibqpdf  -c libqpdf/Pl_PNGFilter.cc -o libqpdf/build/Pl_PNGFilter.o; sed -e 's/\.o:/.lo:/' < libqpdf/build/Pl_PNGFilter.tdep > libqpdf/build/Pl_PNGFilter.dep
libqpdf/Pl_PNGFilter.cc:221:19: error: no member named 'abs' in namespace 'std'
    int pa = std::abs(p - a);
             ~~~~~^
libqpdf/Pl_PNGFilter.cc:222:19: error: no member named 'abs' in namespace 'std'
    int pb = std::abs(p - b);
             ~~~~~^
libqpdf/Pl_PNGFilter.cc:223:19: error: no member named 'abs' in namespace 'std'
    int pc = std::abs(p - c);
             ~~~~~^
3 errors generated.
/bin/bash ./libtool --mode=link clang++ -g -O2 -Wold-style-cast -Wall  -o libqpdf/build/libqpdf.la libqpdf/build/BitStream.lo libqpdf/build/BitWriter.lo libqpdf/build/Buffer.lo libqpdf/build/BufferInputSource.lo libqpdf/build/FileInputSource.lo libqpdf/build/InputSource.lo libqpdf/build/InsecureRandomDataProvider.lo libqpdf/build/MD5.lo libqpdf/build/OffsetInputSource.lo libqpdf/build/Pipeline.lo libqpdf/build/Pl_AES_PDF.lo libqpdf/build/Pl_ASCII85Decoder.lo libqpdf/build/Pl_ASCIIHexDecoder.lo libqpdf/build/Pl_Buffer.lo libqpdf/build/Pl_Concatenate.lo libqpdf/build/Pl_Count.lo libqpdf/build/Pl_DCT.lo libqpdf/build/Pl_Discard.lo libqpdf/build/Pl_Flate.lo libqpdf/build/Pl_LZWDecoder.lo libqpdf/build/Pl_MD5.lo libqpdf/build/Pl_PNGFilter.lo libqpdf/build/Pl_QPDFTokenizer.lo libqpdf/build/Pl_RC4.lo libqpdf/build/Pl_RunLength.lo libqpdf/build/Pl_SHA2.lo libqpdf/build/Pl_StdioFile.lo libqpdf/build/Pl_TIFFPredictor.lo libqpdf/build/QPDF.lo libqpdf/build/QPDFExc.lo libqpdf/build/QPDFObjGen.lo libqpdf/build/QPDFObject.lo libqpdf/build/QPDFObjectHandle.lo libqpdf/build/QPDFTokenizer.lo libqpdf/build/QPDFWriter.lo libqpdf/build/QPDFXRefEntry.lo libqpdf/build/QPDF_Array.lo libqpdf/build/QPDF_Bool.lo libqpdf/build/QPDF_Dictionary.lo libqpdf/build/QPDF_InlineImage.lo libqpdf/build/QPDF_Integer.lo libqpdf/build/QPDF_Name.lo libqpdf/build/QPDF_Null.lo libqpdf/build/QPDF_Operator.lo libqpdf/build/QPDF_Real.lo libqpdf/build/QPDF_Reserved.lo libqpdf/build/QPDF_Stream.lo libqpdf/build/QPDF_String.lo libqpdf/build/QPDF_encryption.lo libqpdf/build/QPDF_linearization.lo libqpdf/build/QPDF_optimization.lo libqpdf/build/QPDF_pages.lo libqpdf/build/QTC.lo libqpdf/build/QUtil.lo libqpdf/build/RC4.lo libqpdf/build/SecureRandomDataProvider.lo libqpdf/build/qpdf-c.lo libqpdf/build/rijndael.lo libqpdf/build/sha2.lo libqpdf/build/sha2big.lo -ljpeg -lz   -rpath /usr/local/Cellar/qpdf/7.1.0/lib -version-info 20:0:2 -no-undefined
libtool:   error: 'libqpdf/build/Pl_PNGFilter.lo' is not a valid libtool object
make: *** [libqpdf/build/libqpdf.la] Error 1
bash-3.2$
```