### PR TITLE
Add 'Categories' key to .desktop file

### DIFF
--- a/appimage/qpdf.desktop
+++ b/appimage/qpdf.desktop
@@ -5,3 +5,4 @@ Exec=qpdf
 Name=qpdf
 Comment=Structural, content-preserving transformations on PDF files
 Icon=qpdf
+Categories=Utility;Office;ConsoleOnly;


### PR DESCRIPTION
Required for automatic validation tools on distros so they add an application to menu entries...
(I hope I got this right.)