### PR TITLE
The kfo-PDF files for testing need to be copied using "binmode"…

### DIFF
--- a/qpdf/qtest/qpdf.test
+++ b/qpdf/qtest/qpdf.test
@@ -1675,6 +1675,7 @@ $n_tests += 4;
     for (my $i = 1; $i <= 201; ++$i)
     {
         open(F, sprintf(">%03d-kfo.pdf", $i)) or die;
+        binmode F;
         print F $content;
         close(F);
     }


### PR DESCRIPTION
…or Windows will introduce "\r\n". The following is an example for errors logged during running the tests after they failed, which were fixed after adding "binmode" for copying the files.

    qpdf: selecting --keep-open-files=n
    qpdf: processing 001-kfo.pdf
    WARNING: 001-kfo.pdf: file is damaged
    WARNING: 001-kfo.pdf (offset 556): xref not found
    WARNING: 001-kfo.pdf: Attempting to reconstruct cross-reference table