### PR TITLE
Missing includes for Embarcadero C++Builder

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -30,6 +30,7 @@
 #include <map>
 #include <list>
 #include <iostream>
+#include <vector>
 
 #include <qpdf/QPDFExc.hh>
 #include <qpdf/QPDFObjGen.hh>

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include <qpdf/QPDFExc.hh>
+#include <qpdf/QPDFObjectHandle.hh>
 #include <qpdf/QPDFObjGen.hh>
 #include <qpdf/QPDFXRefEntry.hh>
 #include <qpdf/QPDFObjectHandle.hh>


### PR DESCRIPTION
My Embarcadero C++Builder 10.2 needed some additional includes to successfully compile.