### PR TITLE
"_setmode" and "_stricmp" are not available on Borland C++Builder…

### DIFF
--- a/libqpdf/QUtil.cc
+++ b/libqpdf/QUtil.cc
@@ -529,7 +529,9 @@ QUtil::hex_decode(std::string const& input)
 void
 QUtil::binary_stdout()
 {
-#ifdef _WIN32
+#if defined(_WIN32) && defined(__BORLANDC__)
+     setmode(_fileno(stdout), _O_BINARY);
+#elif defined(_WIN32)
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
 }
@@ -537,7 +539,9 @@ QUtil::binary_stdout()
 void
 QUtil::binary_stdin()
 {
-#ifdef _WIN32
+#if defined(_WIN32) && defined(__BORLANDC__)
+     setmode(_fileno(stdin), _O_BINARY);
+#elif defined(_WIN32)
     _setmode(_fileno(stdin), _O_BINARY);
 #endif
 }
@@ -918,7 +922,9 @@ QUtil::read_lines_from_file(std::istream& in)
 int
 QUtil::strcasecmp(char const *s1, char const *s2)
 {
-#ifdef _WIN32
+#if defined(_WIN32) && defined(__BORLANDC__)
+    return stricmp(s1, s2);
+#elif defined(_WIN32)
     return _stricmp(s1, s2);
 #else
     return ::strcasecmp(s1, s2);


### PR DESCRIPTION
…neither the classic one nor newer ones based on CLANG. Those functions have been named "setmode" and "stricmp" always. I've simply redefined `_setmode` to `setmode` in the past in my C++-Builder-specific project file, but thought that providing it UPSTREAM makes more sense on the long term. Especially because you already check for `WIN32` and one additional check shouldn't harm that much.

Would be great if you could merge this as well. Thanks!