### PR TITLE
Two operands must evaluate to the same value.

### DIFF
--- a/qpdf/qpdf.cc
+++ b/qpdf/qpdf.cc
@@ -3836,7 +3836,7 @@ ImageOptimizer::makePipeline(std::string const& description, Pipeline* next)
         h_obj.isInteger() ? h_obj.getIntValue() : h_obj.getNumericValue());
     std::string colorspace = (colorspace_obj.isName() ?
                               colorspace_obj.getName() :
-                              "");
+                              std::string());
     int components = 0;
     J_COLOR_SPACE cs = JCS_UNKNOWN;
     if (colorspace == "/DeviceRGB")

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1631,7 +1631,7 @@ void runtest(int n, char const* filename1, char const* arg2)
                 QPDFFormFieldObjectHelper parent(node.getParent());
                 std::cout << "  Parent: "
                           << (parent.isNull()
-                              ? "none"
+                              ? std::string("none")
                               : parent.getObjectHandle().unparse())
                           << std::endl;
                 node = parent;


### PR DESCRIPTION
My Embarcadero C++Builder 10.2 seems unnecessary strict on those statements, but it shouldn't harm being explicit here. Under the hood the same objects should have been created in the past by other compilers already as well.