### PR TITLE
Undefined functions because of missing std:: or header.

### DIFF
--- a/examples/pdf-split-pages.cc
+++ b/examples/pdf-split-pages.cc
@@ -8,9 +8,10 @@
 #include <qpdf/QPDFPageDocumentHelper.hh>
 #include <qpdf/QPDFWriter.hh>
 #include <qpdf/QUtil.hh>
-#include <string>
+
 #include <iostream>
-#include <cstdlib>
+#include <stdlib.h>
+#include <string>
 
 static char const* whoami = 0;
 static bool static_id = false;
@@ -49,7 +50,7 @@ static void process(char const* whoami,
 void usage()
 {
     std::cerr << "Usage: " << whoami << " infile outprefix" << std::endl;
-    std::exit(2);
+    exit(2);
 }
 
 int main(int argc, char* argv[])

--- a/examples/pdf-split-pages.cc
+++ b/examples/pdf-split-pages.cc
@@ -49,7 +49,7 @@ static void process(char const* whoami,
 void usage()
 {
     std::cerr << "Usage: " << whoami << " infile outprefix" << std::endl;
-    exit(2);
+    std::exit(2);
 }
 
 int main(int argc, char* argv[])

--- a/ispell-words
+++ b/ispell-words
@@ -400,7 +400,6 @@ cso
 csoe
 css
 cstdio
-cstdlib
 cstr
 cstring
 ctest

--- a/libqpdf/Pl_DCT.cc
+++ b/libqpdf/Pl_DCT.cc
@@ -2,10 +2,11 @@
 
 #include <qpdf/QUtil.hh>
 #include <qpdf/QTC.hh>
+
 #include <setjmp.h>
-#include <string>
 #include <stdexcept>
-#include <cstdlib>
+#include <stdlib.h>
+#include <string>
 
 #if BITS_IN_JSAMPLE != 8
 # error "qpdf does not support libjpeg built with BITS_IN_JSAMPLE != 8"

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <stdlib.h>
 #include <string.h>
 #include <memory.h>
 

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -10,8 +10,8 @@
 #include <qpdf/QPDFObjectHandle.hh>
 
 #include <stdexcept>
+#include <stdlib.h>
 #include <string.h>
-#include <cstdlib>
 
 static bool is_delimiter(char ch)
 {
@@ -180,7 +180,7 @@ QPDFTokenizer::resolveLiteral()
                     num[0] = p[1];
                     num[1] = p[2];
                     num[2] = '\0';
-                    char ch = static_cast<char>(std::strtol(num, 0, 16));
+                    char ch = static_cast<char>(strtol(num, 0, 16));
                     if (ch == '\0')
                     {
                         this->m->type = tt_bad;
@@ -412,7 +412,7 @@ QPDFTokenizer::presentCharacter(char ch)
 	    // We've accumulated \ddd.  PDF Spec says to ignore
 	    // high-order overflow.
 	    this->m->val += static_cast<char>(
-                std::strtol(this->m->bs_num_register, 0, 8));
+                strtol(this->m->bs_num_register, 0, 8));
 	    memset(this->m->bs_num_register, '\0',
                    sizeof(this->m->bs_num_register));
 	    bs_num_count = 0;
@@ -584,7 +584,7 @@ QPDFTokenizer::presentCharacter(char ch)
 	    {
 		num[0] = this->m->val.at(i);
 		num[1] = this->m->val.at(i+1);
-		char nch = static_cast<char>(std::strtol(num, 0, 16));
+		char nch = static_cast<char>(strtol(num, 0, 16));
 		nval += nch;
 	    }
 	    this->m->val = nval;

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -180,7 +180,7 @@ QPDFTokenizer::resolveLiteral()
                     num[0] = p[1];
                     num[1] = p[2];
                     num[2] = '\0';
-                    char ch = static_cast<char>(strtol(num, 0, 16));
+                    char ch = static_cast<char>(std::strtol(num, 0, 16));
                     if (ch == '\0')
                     {
                         this->m->type = tt_bad;
@@ -412,7 +412,7 @@ QPDFTokenizer::presentCharacter(char ch)
 	    // We've accumulated \ddd.  PDF Spec says to ignore
 	    // high-order overflow.
 	    this->m->val += static_cast<char>(
-                strtol(this->m->bs_num_register, 0, 8));
+                std::strtol(this->m->bs_num_register, 0, 8));
 	    memset(this->m->bs_num_register, '\0',
                    sizeof(this->m->bs_num_register));
 	    bs_num_count = 0;
@@ -584,7 +584,7 @@ QPDFTokenizer::presentCharacter(char ch)
 	    {
 		num[0] = this->m->val.at(i);
 		num[1] = this->m->val.at(i+1);
-		char nch = static_cast<char>(strtol(num, 0, 16));
+		char nch = static_cast<char>(std::strtol(num, 0, 16));
 		nval += nch;
 	    }
 	    this->m->val = nval;


### PR DESCRIPTION
My Embarcadero C++Builder RAD 10.2 was missing either headers or the explicit namespace `std::` on some function calls. Again, I think being explicit here shouldn't interfere with other compilers.