### PR TITLE
Missing friend-statements in C++Builder.

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1298,6 +1298,7 @@ class QPDF
     class Members
     {
         friend class QPDF;
+        friend class ResolveRecorder;
 
       public:
         QPDF_DLL

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1028,6 +1028,7 @@ class QPDFObjectHandle
 
     class Members
     {
+        friend class ObjAccessor;
         friend class QPDFObjectHandle;
 
       public:


### PR DESCRIPTION
My Embarcadero C++Builder 10.2 was missing some `friend`-statements in some classes. I don't think this harms other compilers, because I guess my compiler is only unnecessary strict.