### PR TITLE
std::list<QPDFOutlineObjectHelper> didn't compile in C++Builder.

### DIFF
--- a/examples/pdf-bookmarks.cc
+++ b/examples/pdf-bookmarks.cc
@@ -135,23 +135,23 @@ void show_bookmark_details(QPDFOutlineObjectHelper outline,
     std::cout << outline.getTitle() << std::endl;
 }
 
-void extract_bookmarks(std::list<QPDFOutlineObjectHelper> outlines,
+void extract_bookmarks(std::list<PointerHolder<QPDFOutlineObjectHelper> > outlines,
                        std::vector<int>& numbers)
 {
     numbers.push_back(0);
-    for (std::list<QPDFOutlineObjectHelper>::iterator iter = outlines.begin();
+    for (std::list<PointerHolder<QPDFOutlineObjectHelper> >::iterator iter = outlines.begin();
          iter != outlines.end(); ++iter)
     {
         ++(numbers.back());
-        show_bookmark_details(*iter, numbers);
-        std::list<QPDFOutlineObjectHelper>::iterator next = iter;
+        show_bookmark_details(**iter, numbers);
+        std::list<PointerHolder<QPDFOutlineObjectHelper> >::iterator next = iter;
         ++next;
         bool has_next = (next != outlines.end());
         if ((style == st_lines) && (! has_next))
         {
             numbers.back() = 0;
         }
-        extract_bookmarks((*iter).getKids(), numbers);
+        extract_bookmarks((**iter).getKids(), numbers);
     }
     numbers.pop_back();
 }

--- a/examples/pdf-bookmarks.cc
+++ b/examples/pdf-bookmarks.cc
@@ -135,23 +135,23 @@ void show_bookmark_details(QPDFOutlineObjectHelper outline,
     std::cout << outline.getTitle() << std::endl;
 }
 
-void extract_bookmarks(std::list<PointerHolder<QPDFOutlineObjectHelper> > outlines,
+void extract_bookmarks(std::vector<QPDFOutlineObjectHelper> outlines,
                        std::vector<int>& numbers)
 {
     numbers.push_back(0);
-    for (std::list<PointerHolder<QPDFOutlineObjectHelper> >::iterator iter = outlines.begin();
+    for (std::vector<QPDFOutlineObjectHelper>::iterator iter = outlines.begin();
          iter != outlines.end(); ++iter)
     {
         ++(numbers.back());
-        show_bookmark_details(**iter, numbers);
-        std::list<PointerHolder<QPDFOutlineObjectHelper> >::iterator next = iter;
+        show_bookmark_details(*iter, numbers);
+        std::vector<QPDFOutlineObjectHelper>::iterator next = iter;
         ++next;
         bool has_next = (next != outlines.end());
         if ((style == st_lines) && (! has_next))
         {
             numbers.back() = 0;
         }
-        extract_bookmarks((**iter).getKids(), numbers);
+        extract_bookmarks((*iter).getKids(), numbers);
     }
     numbers.pop_back();
 }

--- a/include/qpdf/QPDFOutlineDocumentHelper.hh
+++ b/include/qpdf/QPDFOutlineDocumentHelper.hh
@@ -28,8 +28,8 @@
 
 #include <qpdf/QPDF.hh>
 #include <map>
-#include <list>
 #include <set>
+#include <vector>
 
 #include <qpdf/DLL.h>
 
@@ -51,7 +51,7 @@ class QPDFOutlineDocumentHelper: public QPDFDocumentHelper
     bool hasOutlines();
 
     QPDF_DLL
-    std::list<PointerHolder<QPDFOutlineObjectHelper> > getTopLevelOutlines();
+    std::vector<QPDFOutlineObjectHelper> getTopLevelOutlines();
 
     // If the name is a name object, look it up in the /Dests key of
     // the document catalog. If the name is a string, look it up in
@@ -64,7 +64,7 @@ class QPDFOutlineDocumentHelper: public QPDFDocumentHelper
     // Return a list outlines that are known to target the specified
     // page
     QPDF_DLL
-    std::list<QPDFOutlineObjectHelper> getOutlinesForPage(QPDFObjGen const&);
+    std::vector<QPDFOutlineObjectHelper> getOutlinesForPage(QPDFObjGen const&);
 
     class Accessor
     {
@@ -95,11 +95,11 @@ class QPDFOutlineDocumentHelper: public QPDFDocumentHelper
         Members();
         Members(Members const&);
 
-        std::list<PointerHolder<QPDFOutlineObjectHelper> > outlines;
+        std::vector<QPDFOutlineObjectHelper> outlines;
         std::set<QPDFObjGen> seen;
         QPDFObjectHandle dest_dict;
         PointerHolder<QPDFNameTreeObjectHelper> names_dest;
-        std::map<QPDFObjGen, std::list<QPDFOutlineObjectHelper> > by_page;
+        std::map<QPDFObjGen, std::vector<QPDFOutlineObjectHelper> > by_page;
     };
 
     PointerHolder<Members> m;

--- a/include/qpdf/QPDFOutlineDocumentHelper.hh
+++ b/include/qpdf/QPDFOutlineDocumentHelper.hh
@@ -51,7 +51,7 @@ class QPDFOutlineDocumentHelper: public QPDFDocumentHelper
     bool hasOutlines();
 
     QPDF_DLL
-    std::list<QPDFOutlineObjectHelper> getTopLevelOutlines();
+    std::list<PointerHolder<QPDFOutlineObjectHelper> > getTopLevelOutlines();
 
     // If the name is a name object, look it up in the /Dests key of
     // the document catalog. If the name is a string, look it up in
@@ -95,7 +95,7 @@ class QPDFOutlineDocumentHelper: public QPDFDocumentHelper
         Members();
         Members(Members const&);
 
-        std::list<QPDFOutlineObjectHelper> outlines;
+        std::list<PointerHolder<QPDFOutlineObjectHelper> > outlines;
         std::set<QPDFObjGen> seen;
         QPDFObjectHandle dest_dict;
         PointerHolder<QPDFNameTreeObjectHelper> names_dest;

--- a/include/qpdf/QPDFOutlineObjectHelper.hh
+++ b/include/qpdf/QPDFOutlineObjectHelper.hh
@@ -55,7 +55,7 @@ class QPDFOutlineObjectHelper: public QPDFObjectHelper
 
     // Return children as a list.
     QPDF_DLL
-    std::list<QPDFOutlineObjectHelper> getKids();
+    std::list<PointerHolder<QPDFOutlineObjectHelper> > getKids();
 
     // Return the destination, regardless of whether it is named or
     // explicit and whether it is directly provided or in a GoTo
@@ -87,10 +87,10 @@ class QPDFOutlineObjectHelper: public QPDFObjectHelper
     {
         friend class QPDFOutlineDocumentHelper;
 
-        static QPDFOutlineObjectHelper
+        static PointerHolder<QPDFOutlineObjectHelper>
         create(QPDFObjectHandle oh, QPDFOutlineDocumentHelper& dh, int depth)
         {
-            return QPDFOutlineObjectHelper(oh, dh, depth);
+            return new QPDFOutlineObjectHelper(oh, dh, depth);
         }
     };
     friend class Accessor;
@@ -113,7 +113,7 @@ class QPDFOutlineObjectHelper: public QPDFObjectHelper
 
         QPDFOutlineDocumentHelper& dh;
         PointerHolder<QPDFOutlineObjectHelper> parent;
-        std::list<QPDFOutlineObjectHelper> kids;
+        std::list<PointerHolder<QPDFOutlineObjectHelper> > kids;
     };
 
     PointerHolder<Members> m;

--- a/include/qpdf/QPDFOutlineObjectHelper.hh
+++ b/include/qpdf/QPDFOutlineObjectHelper.hh
@@ -24,7 +24,7 @@
 
 #include <qpdf/QPDFObjectHelper.hh>
 #include <qpdf/QPDFObjGen.hh>
-#include <list>
+#include <vector>
 
 class QPDFOutlineDocumentHelper;
 
@@ -55,7 +55,7 @@ class QPDFOutlineObjectHelper: public QPDFObjectHelper
 
     // Return children as a list.
     QPDF_DLL
-    std::list<PointerHolder<QPDFOutlineObjectHelper> > getKids();
+    std::vector<QPDFOutlineObjectHelper> getKids();
 
     // Return the destination, regardless of whether it is named or
     // explicit and whether it is directly provided or in a GoTo
@@ -87,10 +87,10 @@ class QPDFOutlineObjectHelper: public QPDFObjectHelper
     {
         friend class QPDFOutlineDocumentHelper;
 
-        static PointerHolder<QPDFOutlineObjectHelper>
+        static QPDFOutlineObjectHelper
         create(QPDFObjectHandle oh, QPDFOutlineDocumentHelper& dh, int depth)
         {
-            return new QPDFOutlineObjectHelper(oh, dh, depth);
+            return QPDFOutlineObjectHelper(oh, dh, depth);
         }
     };
     friend class Accessor;
@@ -113,7 +113,7 @@ class QPDFOutlineObjectHelper: public QPDFObjectHelper
 
         QPDFOutlineDocumentHelper& dh;
         PointerHolder<QPDFOutlineObjectHelper> parent;
-        std::list<PointerHolder<QPDFOutlineObjectHelper> > kids;
+        std::vector<QPDFOutlineObjectHelper> kids;
     };
 
     PointerHolder<Members> m;

--- a/libqpdf/QPDFOutlineDocumentHelper.cc
+++ b/libqpdf/QPDFOutlineDocumentHelper.cc
@@ -42,7 +42,7 @@ QPDFOutlineDocumentHelper::hasOutlines()
     return ! this->m->outlines.empty();
 }
 
-std::list<QPDFOutlineObjectHelper>
+std::list<PointerHolder<QPDFOutlineObjectHelper> >
 QPDFOutlineDocumentHelper::getTopLevelOutlines()
 {
     return this->m->outlines;
@@ -51,15 +51,15 @@ QPDFOutlineDocumentHelper::getTopLevelOutlines()
 void
 QPDFOutlineDocumentHelper::initializeByPage()
 {
-    std::list<QPDFOutlineObjectHelper> queue;
+    std::list<PointerHolder<QPDFOutlineObjectHelper> > queue;
     queue.insert(queue.end(), this->m->outlines.begin(), this->m->outlines.end());
 
     while (! queue.empty())
     {
-        QPDFOutlineObjectHelper oh = queue.front();
+        PointerHolder<QPDFOutlineObjectHelper> oh = queue.front();
         queue.pop_front();
-        this->m->by_page[oh.getDestPage().getObjGen()].push_back(oh);
-        std::list<QPDFOutlineObjectHelper> kids = oh.getKids();
+        this->m->by_page[oh->getDestPage().getObjGen()].push_back(*oh);
+        std::list<PointerHolder<QPDFOutlineObjectHelper> > kids = oh->getKids();
         queue.insert(queue.end(), kids.begin(), kids.end());
     }
 }

--- a/libqpdf/QPDFOutlineDocumentHelper.cc
+++ b/libqpdf/QPDFOutlineDocumentHelper.cc
@@ -42,7 +42,7 @@ QPDFOutlineDocumentHelper::hasOutlines()
     return ! this->m->outlines.empty();
 }
 
-std::list<PointerHolder<QPDFOutlineObjectHelper> >
+std::vector<QPDFOutlineObjectHelper>
 QPDFOutlineDocumentHelper::getTopLevelOutlines()
 {
     return this->m->outlines;
@@ -51,27 +51,27 @@ QPDFOutlineDocumentHelper::getTopLevelOutlines()
 void
 QPDFOutlineDocumentHelper::initializeByPage()
 {
-    std::list<PointerHolder<QPDFOutlineObjectHelper> > queue;
+    std::list<QPDFOutlineObjectHelper> queue;
     queue.insert(queue.end(), this->m->outlines.begin(), this->m->outlines.end());
 
     while (! queue.empty())
     {
-        PointerHolder<QPDFOutlineObjectHelper> oh = queue.front();
+        QPDFOutlineObjectHelper oh = queue.front();
         queue.pop_front();
-        this->m->by_page[oh->getDestPage().getObjGen()].push_back(*oh);
-        std::list<PointerHolder<QPDFOutlineObjectHelper> > kids = oh->getKids();
+        this->m->by_page[oh.getDestPage().getObjGen()].push_back(oh);
+        std::vector<QPDFOutlineObjectHelper> kids = oh.getKids();
         queue.insert(queue.end(), kids.begin(), kids.end());
     }
 }
 
-std::list<QPDFOutlineObjectHelper>
+std::vector<QPDFOutlineObjectHelper>
 QPDFOutlineDocumentHelper::getOutlinesForPage(QPDFObjGen const& og)
 {
     if (this->m->by_page.empty())
     {
         initializeByPage();
     }
-    std::list<QPDFOutlineObjectHelper> result;
+    std::vector<QPDFOutlineObjectHelper> result;
     if (this->m->by_page.count(og))
     {
         result = this->m->by_page[og];

--- a/libqpdf/QPDFOutlineObjectHelper.cc
+++ b/libqpdf/QPDFOutlineObjectHelper.cc
@@ -32,8 +32,8 @@ QPDFOutlineObjectHelper::QPDFOutlineObjectHelper(
     QPDFObjectHandle cur = oh.getKey("/First");
     while (! cur.isNull())
     {
-        PointerHolder<QPDFOutlineObjectHelper> new_ooh = new QPDFOutlineObjectHelper(cur, dh, 1 + depth);
-        new_ooh->m->parent = new QPDFOutlineObjectHelper(*this);
+        QPDFOutlineObjectHelper new_ooh(cur, dh, 1 + depth);
+        new_ooh.m->parent = new QPDFOutlineObjectHelper(*this);
         this->m->kids.push_back(new_ooh);
         cur = cur.getKey("/Next");
     }
@@ -45,7 +45,7 @@ QPDFOutlineObjectHelper::getParent()
     return this->m->parent;
 }
 
-std::list<PointerHolder<QPDFOutlineObjectHelper> >
+std::vector<QPDFOutlineObjectHelper>
 QPDFOutlineObjectHelper::getKids()
 {
     return this->m->kids;

--- a/libqpdf/QPDFOutlineObjectHelper.cc
+++ b/libqpdf/QPDFOutlineObjectHelper.cc
@@ -32,8 +32,8 @@ QPDFOutlineObjectHelper::QPDFOutlineObjectHelper(
     QPDFObjectHandle cur = oh.getKey("/First");
     while (! cur.isNull())
     {
-        QPDFOutlineObjectHelper new_ooh(cur, dh, 1 + depth);
-        new_ooh.m->parent = new QPDFOutlineObjectHelper(*this);
+        PointerHolder<QPDFOutlineObjectHelper> new_ooh = new QPDFOutlineObjectHelper(cur, dh, 1 + depth);
+        new_ooh->m->parent = new QPDFOutlineObjectHelper(*this);
         this->m->kids.push_back(new_ooh);
         cur = cur.getKey("/Next");
     }
@@ -45,7 +45,7 @@ QPDFOutlineObjectHelper::getParent()
     return this->m->parent;
 }
 
-std::list<QPDFOutlineObjectHelper>
+std::list<PointerHolder<QPDFOutlineObjectHelper> >
 QPDFOutlineObjectHelper::getKids()
 {
     return this->m->kids;

--- a/qpdf/qpdf.cc
+++ b/qpdf/qpdf.cc
@@ -3437,9 +3437,9 @@ static void do_json_pages(QPDF& pdf, Options& o, JSON& j)
             "label", pldh.getLabelForPage(pageno).getJSON());
         JSON j_outlines = j_page.addDictionaryMember(
             "outlines", JSON::makeArray());
-        std::list<QPDFOutlineObjectHelper> outlines =
+        std::vector<QPDFOutlineObjectHelper> outlines =
             odh.getOutlinesForPage(page.getObjGen());
-        for (std::list<QPDFOutlineObjectHelper>::iterator oiter =
+        for (std::vector<QPDFOutlineObjectHelper>::iterator oiter =
                  outlines.begin();
              oiter != outlines.end(); ++oiter)
         {
@@ -3486,19 +3486,19 @@ static void do_json_page_labels(QPDF& pdf, Options& o, JSON& j)
 }
 
 static void add_outlines_to_json(
-    std::list<PointerHolder<QPDFOutlineObjectHelper> > outlines, JSON& j,
+    std::vector<QPDFOutlineObjectHelper> outlines, JSON& j,
     std::map<QPDFObjGen, int>& page_numbers)
 {
-    for (std::list<PointerHolder<QPDFOutlineObjectHelper> >::iterator iter = outlines.begin();
+    for (std::vector<QPDFOutlineObjectHelper>::iterator iter = outlines.begin();
          iter != outlines.end(); ++iter)
     {
-        PointerHolder<QPDFOutlineObjectHelper>& ol = *iter;
+        QPDFOutlineObjectHelper& ol = *iter;
         JSON jo = j.addArrayElement(JSON::makeDictionary());
-        jo.addDictionaryMember("object", ol->getObjectHandle().getJSON());
-        jo.addDictionaryMember("title", JSON::makeString(ol->getTitle()));
-        jo.addDictionaryMember("dest", ol->getDest().getJSON(true));
-        jo.addDictionaryMember("open", JSON::makeBool(ol->getCount() >= 0));
-        QPDFObjectHandle page = ol->getDestPage();
+        jo.addDictionaryMember("object", ol.getObjectHandle().getJSON());
+        jo.addDictionaryMember("title", JSON::makeString(ol.getTitle()));
+        jo.addDictionaryMember("dest", ol.getDest().getJSON(true));
+        jo.addDictionaryMember("open", JSON::makeBool(ol.getCount() >= 0));
+        QPDFObjectHandle page = ol.getDestPage();
         JSON j_destpage = JSON::makeNull();
         if (page.isIndirect())
         {
@@ -3510,7 +3510,7 @@ static void add_outlines_to_json(
         }
         jo.addDictionaryMember("destpageposfrom1", j_destpage);
         JSON j_kids = jo.addDictionaryMember("kids", JSON::makeArray());
-        add_outlines_to_json(ol->getKids(), j_kids, page_numbers);
+        add_outlines_to_json(ol.getKids(), j_kids, page_numbers);
     }
 }
 

--- a/qpdf/qpdf.cc
+++ b/qpdf/qpdf.cc
@@ -3486,19 +3486,19 @@ static void do_json_page_labels(QPDF& pdf, Options& o, JSON& j)
 }
 
 static void add_outlines_to_json(
-    std::list<QPDFOutlineObjectHelper> outlines, JSON& j,
+    std::list<PointerHolder<QPDFOutlineObjectHelper> > outlines, JSON& j,
     std::map<QPDFObjGen, int>& page_numbers)
 {
-    for (std::list<QPDFOutlineObjectHelper>::iterator iter = outlines.begin();
+    for (std::list<PointerHolder<QPDFOutlineObjectHelper> >::iterator iter = outlines.begin();
          iter != outlines.end(); ++iter)
     {
-        QPDFOutlineObjectHelper& ol = *iter;
+        PointerHolder<QPDFOutlineObjectHelper>& ol = *iter;
         JSON jo = j.addArrayElement(JSON::makeDictionary());
-        jo.addDictionaryMember("object", ol.getObjectHandle().getJSON());
-        jo.addDictionaryMember("title", JSON::makeString(ol.getTitle()));
-        jo.addDictionaryMember("dest", ol.getDest().getJSON(true));
-        jo.addDictionaryMember("open", JSON::makeBool(ol.getCount() >= 0));
-        QPDFObjectHandle page = ol.getDestPage();
+        jo.addDictionaryMember("object", ol->getObjectHandle().getJSON());
+        jo.addDictionaryMember("title", JSON::makeString(ol->getTitle()));
+        jo.addDictionaryMember("dest", ol->getDest().getJSON(true));
+        jo.addDictionaryMember("open", JSON::makeBool(ol->getCount() >= 0));
+        QPDFObjectHandle page = ol->getDestPage();
         JSON j_destpage = JSON::makeNull();
         if (page.isIndirect())
         {
@@ -3510,7 +3510,7 @@ static void add_outlines_to_json(
         }
         jo.addDictionaryMember("destpageposfrom1", j_destpage);
         JSON j_kids = jo.addDictionaryMember("kids", JSON::makeArray());
-        add_outlines_to_json(ol.getKids(), j_kids, page_numbers);
+        add_outlines_to_json(ol->getKids(), j_kids, page_numbers);
     }
 }
 

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1826,9 +1826,9 @@ void runtest(int n, char const* filename1, char const* arg2)
         for (std::vector<QPDFPageObjectHelper>::iterator iter = pages.begin();
              iter != pages.end(); ++iter, ++pageno)
         {
-            std::list<QPDFOutlineObjectHelper> outlines =
+            std::vector<QPDFOutlineObjectHelper> outlines =
                 odh.getOutlinesForPage((*iter).getObjectHandle().getObjGen());
-            for (std::list<QPDFOutlineObjectHelper>::iterator oiter =
+            for (std::vector<QPDFOutlineObjectHelper>::iterator oiter =
                      outlines.begin();
                  oiter != outlines.end(); ++oiter)
             {


### PR DESCRIPTION
The class `QPDFOutlineObjectHelper` contains a private member class storing some data and containing the following line:

> std::list\<QPDFOutlineObjectHelper\> kids;

That line doesn't compile in my C++Builder 10.2 because the type is not fully defined at the time it's needed for the list. Not sure why this works elsewhere, but it's a known limitation in theory:

http://www.drdobbs.com/the-standard-librarian-containers-of-inc/184403814
http://codeverge.com/embarcadero.cppbuilder.cpp/e2450-undefined-structure/1053917
https://stackoverflow.com/a/45554279/2055163

Because you are using `PointerHolder` at the same place for `parent` already, I simply suggest moving to that for the `std::list` as well. Because things get pretty long and difficult to maintain this way, I introduced two new `typedef`s shortening names a lot and making future replacements easier. At some places method signatures now even fully align! ;-)

I didn't care about breaking API/ABI-changes, but didn't get anything else to work as well. So if you have another solution, please let me know. Thanks!