### PR TITLE
Fix C++ exception handling when -fvisibility=hidden

### DIFF
--- a/include/qpdf/DLL.h
+++ b/include/qpdf/DLL.h
@@ -26,7 +26,11 @@
 #if defined(_WIN32) && defined(DLL_EXPORT)
 # define QPDF_DLL __declspec(dllexport)
 #else
-# define QPDF_DLL
+  #if __GNUC__ >= 4
+    #define QPDF_DLL __attribute__ ((visibility ("default")))
+  #else
+    #define QPDF_DLL
+  #endif
 #endif
 
 #endif /* QPDF_DLL_HH */

--- a/include/qpdf/DLL.h
+++ b/include/qpdf/DLL.h
@@ -25,12 +25,13 @@
 
 #if defined(_WIN32) && defined(DLL_EXPORT)
 # define QPDF_DLL __declspec(dllexport)
+# define QPDF_DLL_EXCEPTION
+#elif __GNUC__ >= 4
+# define QPDF_DLL __attribute__ ((visibility ("default")))
+# define QPDF_DLL_EXCEPTION __attribute__ ((visibility ("default")))
 #else
-  #if __GNUC__ >= 4
-    #define QPDF_DLL __attribute__ ((visibility ("default")))
-  #else
-    #define QPDF_DLL
-  #endif
+# define QPDF_DLL
+# define QPDF_DLL_EXCEPTION
 #endif
 
 #endif /* QPDF_DLL_HH */

--- a/include/qpdf/QPDFExc.hh
+++ b/include/qpdf/QPDFExc.hh
@@ -29,7 +29,7 @@
 #include <string>
 #include <stdexcept>
 
-class QPDFExc: public std::runtime_error
+class QPDF_DLL QPDFExc: public std::runtime_error
 {
   public:
     QPDF_DLL

--- a/include/qpdf/QPDFExc.hh
+++ b/include/qpdf/QPDFExc.hh
@@ -29,7 +29,7 @@
 #include <string>
 #include <stdexcept>
 
-class QPDF_DLL QPDFExc: public std::runtime_error
+class QPDF_DLL_EXCEPTION QPDFExc: public std::runtime_error
 {
   public:
     QPDF_DLL

--- a/include/qpdf/QPDFSystemError.hh
+++ b/include/qpdf/QPDFSystemError.hh
@@ -29,7 +29,7 @@
 #include <string>
 #include <stdexcept>
 
-class QPDFSystemError: public std::runtime_error
+class QPDF_DLL QPDFSystemError: public std::runtime_error
 {
   public:
     QPDF_DLL

--- a/include/qpdf/QPDFSystemError.hh
+++ b/include/qpdf/QPDFSystemError.hh
@@ -29,7 +29,7 @@
 #include <string>
 #include <stdexcept>
 
-class QPDF_DLL QPDFSystemError: public std::runtime_error
+class QPDF_DLL_EXCEPTION QPDFSystemError: public std::runtime_error
 {
   public:
     QPDF_DLL


### PR DESCRIPTION
Ensure that QPDFExc and QPDFSystemError are marked visible, so that their typeinfo will not be
suppressed compiled with `-fvisibility=hidden`.

Details:
    https://gcc.gnu.org/wiki/Visibility