### PR TITLE
pkg-config: Correct the Cflags variable

### DIFF
--- a/libqpdf.pc.in
+++ b/libqpdf.pc.in
@@ -8,4 +8,4 @@ Description: PDF transformation library
 Version: @PACKAGE_VERSION@
 Requires.private: zlib, libjpeg
 Libs: -L${libdir} -lqpdf
-Cflags: -I${includedir}
+Cflags: -I${includedir}/libqpdf


### PR DESCRIPTION
I'm using Fedora 29, with the system-supplied libqpdf package (version 8.4.0). The provided `.pc` file is equivalent as the one in this repository.

The output of `pkg-config libqpdf --cflags` before this commit is empty. This is insufficient, since the include directory is missing, and (some?) build systems won't be able to find it (CMake using the pkg-config module, in my case).

As a comparative example, for the Poppler library, the output of `pkg-config poppler --cflags` is `-I/usr/include/poppler`. For reference, [here is the Poppler `.pc` file](https://gitlab.freedesktop.org/poppler/poppler/blob/master/poppler.pc.cmake).

This patch fixes the Cflags variable so the output of `pkg-config libqpdf --cflags` is `-I/usr/include/qpdf`, which makes my build system work correctly.