### PR TITLE
GNU TLS support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -488,6 +488,36 @@ AC_ARG_ENABLE(show-failed-test-output,
     fi],
    [SHOW_FAILED_TEST_OUTPUT=0])
 
+AC_PATH_TOOL(PKGCONFIG, pkg-config)
+
+AC_MSG_CHECKING(if cryptography will be supplied by GNU TLS)
+AC_ARG_ENABLE(gnutls,
+   AS_HELP_STRING([--enable-gnutls],
+                  [enable cryptography by GNUTLS]),
+   [if test "$enableval" = "yes"; then
+      if test "x$PKGCONFIG" != x ; then
+        AC_TRY_COMPILE([
+        #include <gnutls/crypto.h>], , , AC_MSG_ERROR([GNU TLS development headers are needed.]))
+        GNUTLSFLAGS=`pkg-config --cflags gnutls`
+        GNUTLSLIBS=`pkg-config --libs gnutls`
+        LIBS="$LIBS $GNUTLSLIBS"
+        CPPFLAGS="$CPPFLAGS $GNUTLSFLAGS"
+        AC_DEFINE([HAVE_GNUTLS], [1], [If cryptography will be supplied by GNU TLS])
+        HAVE_GNUTLS=1
+      else
+        HAVE_GNUTLS=0
+        AC_MSG_ERROR([pkg-config is needed to configure compilation with GNU TLS.])
+      fi
+    else
+      HAVE_GNUTLS=0
+    fi],
+   [HAVE_GNUTLS=0])
+if test "$HAVE_GNUTLS" = "1" ; then
+   AC_MSG_RESULT(yes)
+else
+   AC_MSG_RESULT(no)
+fi
+
 AC_ARG_WITH(docbook-xsl,
    AS_HELP_STRING([--with-docbook-xsl=DIR],
 		  [location of docbook 4.x xml stylesheets]),

--- a/libqpdf/MD5-gnutls.cc
+++ b/libqpdf/MD5-gnutls.cc
@@ -1,0 +1,58 @@
+#include <gnutls/crypto.h>
+#include <qpdf/MD5.hh>
+#include <qpdf/QUtil.hh>
+
+
+// MD5 initialization. Begins an MD5 operation, writing a new context.
+void MD5::init()
+{
+    int ret;
+
+    ret = gnutls_hash_init(&ctx, GNUTLS_DIG_MD5);
+    if (ret < 0) {
+	QUtil::throw_system_error(
+	    std::string("GNU TLS: MD5 error:") + std::string(gnutls_strerror(ret)));
+	ctx = nullptr;
+    }
+
+    finalized = false;
+    memset(digest_val, 0, sizeof(digest_val));
+}
+
+// MD5 block update operation. Continues an MD5 message-digest
+// operation, processing another message block, and updating the
+// context.
+
+void MD5::update(unsigned char *input,
+		 size_t inputLen)
+{
+    if (ctx != nullptr && input != nullptr)
+	gnutls_hash(ctx, input, inputLen);
+}
+
+// MD5 finalization. Ends an MD5 message-digest operation, writing the
+// the message digest and zeroizing the context.
+void MD5::final()
+{
+    if (finalized)
+	return;
+
+    if (ctx != nullptr)
+	gnutls_hash_deinit(ctx, digest_val);
+
+    finalized = true;
+}
+
+// MD5 basic transformation. Transforms state based on block.
+void MD5::transform(UINT4 state[4], unsigned char block[64])
+{}
+
+// Encodes input (UINT4) into output (unsigned char). Assumes len is a
+// multiple of 4.
+void MD5::encode(unsigned char *output, UINT4 *input, size_t len)
+{}
+
+// Decodes input (unsigned char) into output (UINT4). Assumes len is a
+// multiple of 4.
+void MD5::decode(UINT4 *output, unsigned char *input, size_t len)
+{}

--- a/libqpdf/MD5.cc
+++ b/libqpdf/MD5.cc
@@ -37,6 +37,10 @@
 #include <string.h>
 #include <errno.h>
 
+#ifdef HAVE_GNUTLS
+# include "MD5-gnutls.cc"
+#else
+
 int const S11 = 7;
 int const S12 = 12;
 int const S13 = 17;
@@ -294,6 +298,8 @@ void MD5::decode(UINT4 *output, unsigned char *input, size_t len)
 	    (static_cast<UINT4>(input[j+2]) << 16) |
             (static_cast<UINT4>(input[j+3]) << 24);
 }
+
+#endif /* HAVE_GNUTLS */
 
 // Public functions
 

--- a/libqpdf/Pl_AES_PDF-gnutls.cc
+++ b/libqpdf/Pl_AES_PDF-gnutls.cc
@@ -1,16 +1,8 @@
 #include <qpdf/Pl_AES_PDF.hh>
-#include <qpdf/QUtil.hh>
-#include <cstring>
-#include <assert.h>
-#include <stdexcept>
+#include <gnutls/crypto.h>
 #include <qpdf/QIntC.hh>
-#include <string>
-#include <stdlib.h>
-
-#ifdef HAVE_GNUTLS
-# include "Pl_AES_PDF-gnutls.cc"
-#else
-# include <qpdf/rijndael.h>
+#include <qpdf/QUtil.hh>
+#include <qpdf/rijndael-gnutls.h>
 
 bool Pl_AES_PDF::use_static_iv = false;
 
@@ -28,6 +20,8 @@ Pl_AES_PDF::Pl_AES_PDF(char const* identifier, Pipeline* next,
     disable_padding(false)
 {
     size_t keybits = 8 * key_bytes;
+    this->keylen = key_bytes;
+    this->ctx = nullptr;
     assert(key_bytes == KEYLENGTH(keybits));
     this->key = PointerHolder<unsigned char>(
         true, new unsigned char[key_bytes]);
@@ -39,17 +33,6 @@ Pl_AES_PDF::Pl_AES_PDF(char const* identifier, Pipeline* next,
     std::memset(this->inbuf, 0, this->buf_size);
     std::memset(this->outbuf, 0, this->buf_size);
     std::memset(this->cbc_block, 0, this->buf_size);
-    if (encrypt)
-    {
-	this->nrounds = rijndaelSetupEncrypt(
-            this->rk.getPointer(), this->key.getPointer(), keybits);
-    }
-    else
-    {
-	this->nrounds = rijndaelSetupDecrypt(
-            this->rk.getPointer(), this->key.getPointer(), keybits);
-    }
-    assert(this->nrounds == NROUNDS(keybits));
 }
 
 Pl_AES_PDF::~Pl_AES_PDF()
@@ -152,6 +135,10 @@ Pl_AES_PDF::finish()
 	}
 	flush(! this->disable_padding);
     }
+
+    if (this->cbc_mode)
+	rijndaelFinish(this->ctx);
+
     getNext()->finish();
 }
 
@@ -214,39 +201,26 @@ Pl_AES_PDF::flush(bool strip_padding)
 		// vector.  There's nothing to write at this time.
 		memcpy(this->cbc_block, this->inbuf, this->buf_size);
 		this->offset = 0;
+		rijndaelInit(&(this->ctx), this->key.getPointer(), this->keylen, this->cbc_block, this->buf_size);
 		return;
 	    }
+	    rijndaelInit(&(this->ctx), this->key.getPointer(), this->keylen, this->cbc_block, this->buf_size);
 	}
     }
 
     if (this->encrypt)
     {
 	if (this->cbc_mode)
-	{
-	    for (unsigned int i = 0; i < this->buf_size; ++i)
-	    {
-		this->inbuf[i] ^= this->cbc_block[i];
-	    }
-	}
-	rijndaelEncrypt(this->rk.getPointer(),
-                        this->nrounds, this->inbuf, this->outbuf);
-	if (this->cbc_mode)
-	{
-	    memcpy(this->cbc_block, this->outbuf, this->buf_size);
-	}
+	    rijndaelCBCEncrypt(this->ctx, this->inbuf, this->outbuf, this->buf_size);
+	else
+	    rijndaelECBEncrypt(this->key.getPointer(), this->keylen, this->cbc_block, this->inbuf, this->outbuf, this->buf_size);
     }
     else
     {
-	rijndaelDecrypt(this->rk.getPointer(),
-                        this->nrounds, this->inbuf, this->outbuf);
 	if (this->cbc_mode)
-	{
-	    for (unsigned int i = 0; i < this->buf_size; ++i)
-	    {
-		this->outbuf[i] ^= this->cbc_block[i];
-	    }
-	    memcpy(this->cbc_block, this->inbuf, this->buf_size);
-	}
+	    rijndaelCBCDecrypt(this->ctx, this->inbuf, this->outbuf, this->buf_size);
+	else
+	    rijndaelECBDecrypt(this->key.getPointer(), this->keylen, this->cbc_block, this->inbuf, this->outbuf, this->buf_size);
     }
     unsigned int bytes = this->buf_size;
     if (strip_padding)
@@ -272,4 +246,3 @@ Pl_AES_PDF::flush(bool strip_padding)
     getNext()->write(this->outbuf, bytes);
     this->offset = 0;
 }
-#endif /* HAVE_GNUTLS */

--- a/libqpdf/RC4-gnutls.cc
+++ b/libqpdf/RC4-gnutls.cc
@@ -1,0 +1,54 @@
+#include <qpdf/RC4.hh>
+#include <qpdf/QIntC.hh>
+#include <qpdf/QUtil.hh>
+#include <gnutls/crypto.h>
+
+
+RC4::RC4(unsigned char const* key_data, int key_len)
+{
+    if (key_len == -1)
+    {
+	key_len = QIntC::to_int(
+            strlen(reinterpret_cast<char const*>(key_data)));
+    }
+
+    int ret;
+    gnutls_cipher_algorithm_t alg = GNUTLS_CIPHER_ARCFOUR_128;
+    gnutls_datum_t key;
+
+    key.data = const_cast<unsigned char*>(key_data);
+    key.size = QIntC::to_uint(key_len);
+
+    ret = gnutls_cipher_init(&(this->ctx),
+                             alg,
+                             &key,
+                             NULL);
+    if (ret < 0)
+    {
+	QUtil::throw_system_error(
+	    std::string("GNU TLS: RC4 error: ") + std::string(gnutls_strerror(ret)));
+	this->ctx = nullptr;
+    }
+}
+
+RC4::~RC4()
+{
+    if (this->ctx != nullptr)
+    {
+	gnutls_cipher_deinit(this->ctx);
+	this->ctx = nullptr;
+    }
+}
+
+void
+RC4::process(unsigned char *in_data, size_t len, unsigned char* out_data)
+{
+    if (out_data == 0)
+    {
+	// Convert in place
+	out_data = in_data;
+    }
+
+    if (this->ctx != nullptr && in_data != nullptr)
+	gnutls_cipher_encrypt2(this->ctx, in_data, len, out_data, len);
+}

--- a/libqpdf/RC4.cc
+++ b/libqpdf/RC4.cc
@@ -3,6 +3,10 @@
 
 #include <string.h>
 
+#ifdef HAVE_GNUTLS
+# include "RC4-gnutls.cc"
+#else
+
 static void swap_byte(unsigned char &a, unsigned char &b)
 {
     unsigned char t;
@@ -55,3 +59,5 @@ RC4::process(unsigned char *in_data, size_t len, unsigned char* out_data)
 	out_data[i] = in_data[i] ^ key.state[xor_index];
     }
 }
+
+#endif /* HAVE_GNUTLS */

--- a/libqpdf/SecureRandomDataProvider.cc
+++ b/libqpdf/SecureRandomDataProvider.cc
@@ -11,6 +11,10 @@
 # endif
 #endif
 
+#ifdef HAVE_GNUTLS
+# include <gnutls/crypto.h>
+#endif
+
 SecureRandomDataProvider::SecureRandomDataProvider()
 {
 }
@@ -111,7 +115,19 @@ class WindowsCryptProvider
 void
 SecureRandomDataProvider::provideRandomData(unsigned char* data, size_t len)
 {
-#if defined(_WIN32)
+#if defined(HAVE_GNUTLS)
+
+    int ret = 0;
+
+    ret = gnutls_rnd(GNUTLS_RND_NONCE, data, len);
+    if (ret < 0)
+    {
+        throw std::runtime_error(
+            "GNU TLS: unable to generate secure random data " +
+            std::string(gnutls_strerror(ret)));
+    }
+
+#elif defined(_WIN32)
 
     // Optimization: make the WindowsCryptProvider static as long as
     // it can be done in a thread-safe fashion.

--- a/libqpdf/qpdf/MD5.hh
+++ b/libqpdf/qpdf/MD5.hh
@@ -12,6 +12,10 @@
 #endif
 #include <string>
 
+#ifdef HAVE_GNUTLS
+# include <gnutls/crypto.h>
+#endif
+
 class MD5
 {
   public:
@@ -89,6 +93,9 @@ class MD5
 
     bool finalized;
     Digest digest_val;
+#ifdef HAVE_GNUTLS
+    gnutls_hash_hd_t ctx;
+#endif
 };
 
 #endif // MD5_HH

--- a/libqpdf/qpdf/Pl_AES_PDF.hh
+++ b/libqpdf/qpdf/Pl_AES_PDF.hh
@@ -7,6 +7,10 @@
 # include <stdint.h>
 #endif
 
+#ifdef HAVE_GNUTLS
+# include <gnutls/crypto.h>
+#endif
+
 // This pipeline implements AES-128 and AES-256 with CBC and block
 // padding as specified in the PDF specification.
 
@@ -65,6 +69,11 @@ class Pl_AES_PDF: public Pipeline
     bool use_zero_iv;
     bool use_specified_iv;
     bool disable_padding;
+
+#ifdef HAVE_GNUTLS
+    gnutls_cipher_hd_t ctx;
+    size_t keylen;
+#endif
 };
 
 #endif // PL_AES_PDF_HH

--- a/libqpdf/qpdf/RC4.hh
+++ b/libqpdf/qpdf/RC4.hh
@@ -3,6 +3,12 @@
 
 #include <stddef.h>
 
+#include <qpdf/qpdf-config.h>
+
+#ifdef HAVE_GNUTLS
+# include <gnutls/crypto.h>
+#endif
+
 class RC4
 {
   public:
@@ -12,6 +18,10 @@ class RC4
     // out_data = 0 means to encrypt/decrypt in place
     void process(unsigned char* in_data, size_t len,
                  unsigned char* out_data = 0);
+
+#ifdef HAVE_GNUTLS
+    ~RC4();
+#endif
 
   private:
     class RC4Key
@@ -23,6 +33,11 @@ class RC4
     };
 
     RC4Key key;
+
+
+#ifdef HAVE_GNUTLS
+    gnutls_cipher_hd_t ctx;
+#endif
 };
 
 #endif // RC4_HH

--- a/libqpdf/qpdf/qpdf-config.h.in
+++ b/libqpdf/qpdf/qpdf-config.h.in
@@ -12,6 +12,9 @@
 /* Define to 1 if you have the `fseeko64' function. */
 #undef HAVE_FSEEKO64
 
+/* If cryptography will be supplied by GNU TLS */
+#undef HAVE_GNUTLS
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 

--- a/libqpdf/qpdf/rijndael-gnutls.h
+++ b/libqpdf/qpdf/rijndael-gnutls.h
@@ -1,0 +1,32 @@
+#ifdef HAVE_INTTYPES_H
+# include <inttypes.h>
+#endif
+#ifdef HAVE_STDINT_H
+# include <stdint.h>
+#endif
+
+#include <gnutls/crypto.h>
+
+void rijndaelInit(gnutls_cipher_hd_t * context, unsigned char * key,
+  size_t keylen, unsigned char cbc_block[16], unsigned int buf_size);
+int rijndaelSetupEncrypt(uint32_t *rk, const unsigned char *key,
+  int keybits);
+int rijndaelSetupDecrypt(uint32_t *rk, const unsigned char *key,
+  int keybits);
+void rijndaelCBCEncrypt(gnutls_cipher_hd_t context,
+  const unsigned char plaintext[16], unsigned char ciphertext[16],
+  unsigned int buf_size);
+void rijndaelCBCDecrypt(gnutls_cipher_hd_t context,
+  const unsigned char ciphertext[16], unsigned char plaintext[16],
+  unsigned int buf_size);
+void rijndaelECBEncrypt(unsigned char * key, size_t keylen,
+  unsigned char cbc_block[16], const unsigned char plaintext[16],
+  unsigned char ciphertext[16], unsigned int buf_size);
+void rijndaelECBDecrypt(unsigned char * key, size_t keylen,
+  unsigned char cbc_block[16], const unsigned char ciphertext[16],
+  unsigned char plaintext[16], unsigned int buf_size);
+void rijndaelFinish(gnutls_cipher_hd_t context);
+
+#define KEYLENGTH(keybits) ((keybits)/8)
+#define RKLENGTH(keybits)  ((keybits)/8+28)
+#define NROUNDS(keybits)   ((keybits)/32+6)

--- a/libqpdf/qpdf/rijndael.h
+++ b/libqpdf/qpdf/rijndael.h
@@ -10,6 +10,10 @@
 #endif
 #include <stddef.h>
 
+#ifdef HAVE_GNUTLS
+# include "qpdf/rijndael-gnutls.h"
+#else
+
 unsigned int rijndaelSetupEncrypt(uint32_t *rk, const unsigned char *key,
   size_t keybits);
 unsigned int rijndaelSetupDecrypt(uint32_t *rk, const unsigned char *key,
@@ -22,5 +26,7 @@ void rijndaelDecrypt(const uint32_t *rk, unsigned int nrounds,
 #define KEYLENGTH(keybits) ((keybits)/8)
 #define RKLENGTH(keybits)  ((keybits)/8+28)
 #define NROUNDS(keybits)   ((keybits)/32+6)
+
+#endif /* HAVE_GNUTLS */
 
 #endif

--- a/libqpdf/rijndael-gnutls.cc
+++ b/libqpdf/rijndael-gnutls.cc
@@ -1,0 +1,116 @@
+#include <cstring>
+#include <gnutls/crypto.h>
+#include <qpdf/QUtil.hh>
+#include <qpdf/rijndael-gnutls.h>
+
+typedef uint32_t u32;
+
+/**
+ * Init cryptographic context
+ */
+void rijndaelInit(gnutls_cipher_hd_t * ctx, unsigned char * key,
+  size_t keylen, unsigned char cbc_block[16],
+  unsigned int buf_size)
+{
+  int ret;
+  gnutls_cipher_algorithm_t alg;
+  gnutls_datum_t cipher_key;
+  gnutls_datum_t iv;
+
+  cipher_key.data = key;
+
+  switch(keylen) {
+    case 16:
+      alg = GNUTLS_CIPHER_AES_128_CBC;
+      break;
+    case 32:
+      alg = GNUTLS_CIPHER_AES_256_CBC;
+      break;
+    case 24:
+      alg = GNUTLS_CIPHER_AES_192_CBC;
+      break;
+    default:
+      alg = GNUTLS_CIPHER_AES_128_CBC;
+      break;
+  }
+
+  cipher_key.size = gnutls_cipher_get_key_size(alg);
+
+  iv.data = cbc_block;
+  iv.size = buf_size;
+
+  ret = gnutls_cipher_init(ctx, alg, &cipher_key, &iv);
+  if (ret < 0)
+  {
+    QUtil::throw_system_error(
+      std::string("GNU TLS: AES error: ") + std::string(gnutls_strerror(ret)));
+    ctx = nullptr;
+    return;
+  }
+}
+
+/**
+ * Encrypt string by AES CBC by GNU TLS.
+ */
+void rijndaelCBCEncrypt(gnutls_cipher_hd_t ctx,
+  const unsigned char plaintext[16], unsigned char ciphertext[16],
+  unsigned int buf_size)
+{
+  if (ctx != nullptr)
+    gnutls_cipher_encrypt2(ctx, plaintext, buf_size, ciphertext, buf_size);
+}
+
+/**
+ * Decrypt string by AES CBC by GNU TLS.
+ */
+void rijndaelCBCDecrypt(gnutls_cipher_hd_t ctx,
+  const unsigned char ciphertext[16], unsigned char plaintext[16],
+  unsigned int buf_size)
+{
+  if (ctx != nullptr)
+    gnutls_cipher_decrypt2(ctx, ciphertext, buf_size, plaintext, buf_size);
+}
+
+/**
+ * Encrypt string by AES ECB by GNU TLS.
+ */
+void rijndaelECBEncrypt(unsigned char * key, size_t keylen,
+  unsigned char cbc_block[16], const unsigned char ciphertext[16],
+  unsigned char plaintext[16], unsigned int buf_size)
+{
+  gnutls_cipher_hd_t ctx;
+
+  rijndaelInit(&ctx, key, keylen, cbc_block, buf_size);
+
+  rijndaelCBCEncrypt(ctx, ciphertext, plaintext, buf_size);
+
+  rijndaelFinish(ctx);
+}
+
+/**
+ * Decrypt string by AES ECB by GNU TLS.
+ */
+void rijndaelECBDecrypt(unsigned char * key, size_t keylen,
+  unsigned char cbc_block[16], const unsigned char ciphertext[16],
+  unsigned char plaintext[16], unsigned int buf_size)
+{
+  gnutls_cipher_hd_t ctx;
+
+  rijndaelInit(&ctx, key, keylen, cbc_block, buf_size);
+
+  rijndaelCBCDecrypt(ctx, ciphertext, plaintext, buf_size);
+
+  rijndaelFinish(ctx);
+}
+
+/**
+ * Finish cryptography context
+ */
+void rijndaelFinish(gnutls_cipher_hd_t ctx)
+{
+  if (ctx != nullptr)
+  {
+    gnutls_cipher_deinit(ctx);
+    ctx = nullptr;
+  }
+}

--- a/libqpdf/rijndael.cc
+++ b/libqpdf/rijndael.cc
@@ -2,6 +2,10 @@
 
 #include "qpdf/rijndael.h"
 
+#ifdef HAVE_GNUTLS
+# include "rijndael-gnutls.cc"
+#else
+
 typedef uint32_t u32;
 typedef unsigned char u8;
 
@@ -1208,3 +1212,4 @@ void rijndaelDecrypt(const u32 *rk, unsigned int nrounds,
     rk[3];
   PUTU32(plaintext + 12, s3);
 }
+#endif /* HAVE_GNUTLS */

--- a/libqpdf/sha2-gnutls.c
+++ b/libqpdf/sha2-gnutls.c
@@ -1,0 +1,41 @@
+#include <gnutls/crypto.h>
+#include <stdio.h>
+#include "sph/sph_sha2_gnutls.h"
+
+
+/* see sph_sha2.h */
+void
+sph_sha256_init(void * cc)
+{
+	int ret;
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	ret = gnutls_hash_init(ctx, GNUTLS_DIG_SHA256);
+	if (ret < 0)
+	{
+		fprintf(stderr, "GNU TLS: SHA256 error : %s\n", gnutls_strerror(ret));
+		cc = NULL;
+	}
+}
+
+/* see sph_sha2.h */
+void
+sph_sha256_close(void * cc, void *dst)
+{
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	if (ctx != NULL)
+	{
+		gnutls_hash_deinit(*(ctx), dst);
+		cc = NULL;
+	}
+}
+
+/* see sph_sha2.h */
+void sph_sha256(void * cc, const void * data, size_t len)
+{
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	if (ctx != NULL && data != NULL)
+		gnutls_hash(*(ctx), data, len);
+}

--- a/libqpdf/sha2.c
+++ b/libqpdf/sha2.c
@@ -35,6 +35,10 @@
 
 #include "sph/sph_sha2.h"
 
+#ifdef HAVE_GNUTLS
+# include "sha2-gnutls.c"
+#else
+
 #if SPH_SMALL_FOOTPRINT && !defined SPH_SMALL_FOOTPRINT_SHA2
 #define SPH_SMALL_FOOTPRINT_SHA2   1
 #endif
@@ -688,3 +692,5 @@ sph_sha224_comp(const sph_u32 msg[16], sph_u32 val[8])
 	SHA2_ROUND_BODY(SHA2_IN, val);
 #undef SHA2_IN
 }
+
+#endif /* HAVE_GNUTLS */

--- a/libqpdf/sha2big-gnutls.c
+++ b/libqpdf/sha2big-gnutls.c
@@ -1,0 +1,80 @@
+#include <gnutls/crypto.h>
+#include <stdio.h>
+#include "sph/sph_sha2_gnutls.h"
+
+
+/* see sph_sha3.h */
+void
+sph_sha384_init(void * cc)
+{
+	int ret;
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	ret = gnutls_hash_init(ctx, GNUTLS_DIG_SHA384);
+	if (ret < 0)
+	{
+		fprintf(stderr, "GNU TLS: SHA384 error: %s\n", gnutls_strerror(ret));
+		cc = NULL;
+	}
+}
+
+/* see sph_sha3.h */
+void
+sph_sha384_close(void * cc, void *dst)
+{
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	if (ctx != NULL && dst != NULL)
+	{
+		gnutls_hash_deinit(*(ctx), dst);
+		cc = NULL;
+	}
+}
+
+/* see sph_sha3.h */
+void
+sph_sha384(void * cc, const void * data, size_t len)
+{
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	if (ctx != NULL && data != NULL)
+		gnutls_hash(*(ctx), data, len);
+}
+
+/* see sph_sha3.h */
+void
+sph_sha512_init(void * cc)
+{
+	int ret;
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	ret = gnutls_hash_init(ctx, GNUTLS_DIG_SHA512);
+	if (ret < 0)
+	{
+		fprintf(stderr, "GNU TLS: SHA512 error: %s\n", gnutls_strerror(ret));
+		cc = NULL;
+	}
+}
+
+/* see sph_sha3.h */
+void
+sph_sha512_close(void * cc, void * dst)
+{
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	if (ctx != NULL && dst != NULL)
+	{
+		gnutls_hash_deinit(*(ctx), dst);
+		cc = NULL;
+	}
+}
+
+/* see sph_sha3.h */
+void
+sph_sha512(void * cc, const void * data, size_t len)
+{
+	gnutls_hash_hd_t * ctx = (gnutls_hash_hd_t*) cc;
+
+	if (ctx != NULL && data != NULL)
+		gnutls_hash(*(ctx), data, len);
+}

--- a/libqpdf/sha2big.c
+++ b/libqpdf/sha2big.c
@@ -35,6 +35,10 @@
 
 #include "sph/sph_sha2.h"
 
+#ifdef HAVE_GNUTLS
+# include "sha2big-gnutls.c"
+#else
+
 #if SPH_64
 
 #define CH(X, Y, Z)    ((((Y) ^ (Z)) & (X)) ^ (Z))
@@ -245,3 +249,5 @@ sph_sha384_comp(const sph_u64 msg[16], sph_u64 val[8])
 }
 
 #endif
+
+#endif /* HAVE_GNUTLS */

--- a/libqpdf/sph/sph_sha2.h
+++ b/libqpdf/sph/sph_sha2.h
@@ -47,6 +47,12 @@ extern "C" {
 #include <stddef.h>
 #include "sph_types.h"
 
+#include <qpdf/qpdf-config.h>
+
+#ifdef HAVE_GNUTLS
+# include "sph_sha2_gnutls.h"
+#else
+
 /**
  * Output size (in bits) for SHA-224.
  */
@@ -370,6 +376,8 @@ void sph_sha512_comp(const sph_u64 msg[16], sph_u64 val[8]);
 #endif
 
 #endif
+
+#endif /* HAVE_GNUTLS */
 
 #ifdef __cplusplus
 }

--- a/libqpdf/sph/sph_sha2_gnutls.h
+++ b/libqpdf/sph/sph_sha2_gnutls.h
@@ -1,0 +1,88 @@
+#include <qpdf/qpdf-config.h>
+#include <gnutls/crypto.h>
+
+typedef gnutls_hash_hd_t sph_sha256_context;
+typedef gnutls_hash_hd_t sph_sha384_context;
+typedef gnutls_hash_hd_t sph_sha512_context;
+
+/**
+ * Initialize a SHA-256 context.
+ *
+ * @param cc   the SHA-256 context (pointer to
+ *             a <code>sph_sha256_context</code>)
+ */
+void sph_sha256_init(void *cc);
+
+/**
+ * Process some data bytes, for SHA-256.
+ *
+ * @param cc     the SHA-224 context
+ * @param data   the input data
+ * @param len    the input data length (in bytes)
+ */
+void sph_sha256(void *cc, const void *data, size_t len);
+
+/**
+ * Terminate the current SHA-256 computation and output the result into the
+ * provided buffer. The destination buffer must be wide enough to
+ * accomodate the result (32 bytes).
+ *
+ * @param cc    the SHA-256 context
+ * @param dst   the destination buffer
+ */
+void sph_sha256_close(void *cc, void *dst);
+
+/**
+ * Initialize a SHA-384 context.
+ *
+ * @param cc   the SHA-384 context (pointer to
+ *             a <code>sph_sha384_context</code>)
+ */
+void sph_sha384_init(void *cc);
+
+/**
+ * Process some data bytes. It is acceptable that <code>len</code> is zero
+ * (in which case this function does nothing).
+ *
+ * @param cc     the SHA-384 context
+ * @param data   the input data
+ * @param len    the input data length (in bytes)
+ */
+void sph_sha384(void *cc, const void *data, size_t len);
+
+/**
+ * Terminate the current SHA-384 computation and output the result into the
+ * provided buffer. The destination buffer must be wide enough to
+ * accomodate the result (48 bytes).
+ *
+ * @param cc    the SHA-384 context
+ * @param dst   the destination buffer
+ */
+void sph_sha384_close(void *cc, void *dst);
+
+/**
+ * Initialize a SHA-512 context.
+ *
+ * @param cc   the SHA-512 context (pointer to
+ *             a <code>sph_sha512_context</code>)
+ */
+void sph_sha512_init(void *cc);
+
+/**
+ * Process some data bytes, for SHA-512.
+ *
+ * @param cc     the SHA-384 context
+ * @param data   the input data
+ * @param len    the input data length (in bytes)
+ */
+void sph_sha512(void *cc, const void *data, size_t len);
+
+/**
+ * Terminate the current SHA-512 computation and output the result into the
+ * provided buffer. The destination buffer must be wide enough to
+ * accomodate the result (64 bytes).
+ *
+ * @param cc    the SHA-512 context
+ * @param dst   the destination buffer
+ */
+void sph_sha512_close(void *cc, void *dst);

--- a/libqpdf/sph/sph_types.h
+++ b/libqpdf/sph/sph_types.h
@@ -48,6 +48,7 @@
 #define SPH_TYPES_H
 
 #include <limits.h>
+#include <qpdf/qpdf-config.h>
 
 /*
  * All our I/O functions are defined over octet streams. We do not know


### PR DESCRIPTION
Hi Jay,

I created a patch for #218 with usage of GNU TLS,  which is available on Linux and Windows too. I tried to avoid using ifdefs as much as I was able - I took CUPS as reference for implementing the support - they solve it by:
#ifdef gnutls
#  include "gnutls.c"
#else 
...internal implementation
#endif 

Most of those ifdefs are in files which implements hashes and ciphers, but I needed to 'ifdef' Pl_AES_PDF too, because there is internal implementation of CBC mode there.

Please tell me if there is something I should enhance, change, rewrite etc. and I'll change the code according to it.
I ran qpdf test suite with the changes and it passes.