### PR TITLE
libtests/cxx11.cc: fix build with gcc 4.8

### DIFF
--- a/libtests/cxx11.cc
+++ b/libtests/cxx11.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cassert>
+#include <cstring>
 #include <functional>
 #include <type_traits>
 #include <cstdint>


### PR DESCRIPTION
Build fails on gcc 4.8 since version 9.1.1 and commit
752416554086d5d34323bc14164d5084db83cfbd:

```
libtests/cxx11.cc: In function 'void do_regex()':
libtests/cxx11.cc:347:42: error: 'strlen' is not a member of 'std'
     std::cregex_iterator m3(str7, str7 + std::strlen(str7), expr4);
                                          ^
```

To fix the build failure, add missing include on cstring

Fixes:
 - http://autobuild.buildroot.org/results/ad7fb68ae87850a85509eed80fd0cae8721b10c5

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>