### PR TITLE
CIFuzz Dog Food

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'qpdf'
+        dry-run: true
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'qpdf'
+        fuzz-seconds: 600
+        dry-run: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
OSS-Fuzz was wondering if qpdf would dogfood CIFuzz, a new feature being rolled out in OSS-Fuzz. It allows for pull requests to be fuzzed in CI using fuzz targets enabled in OSS-Fuzz. It will be active in dry_run mode meaning that it will never fail. Documentation for this feature can be found [here](https://google.github.io/oss-fuzz/getting-started/continuous-integration/). Let us know if you have any questions!