### PR TITLE
libqpdf/QUtil.cc: fix build without wchar

### DIFF
--- a/libqpdf/QUtil.cc
+++ b/libqpdf/QUtil.cc
@@ -2366,6 +2366,7 @@ QUtil::possible_repaired_encodings(std::string supplied)
 int
 QUtil::call_main_from_wmain(int argc, wchar_t* argv[], std::function<int(int, char*[])> realmain)
 {
+#ifdef WINDOWS_WMAIN
     // argv contains UTF-16-encoded strings with a 16-bit wchar_t.
     // Convert this to UTF-8-encoded strings for compatibility with
     // other systems. That way the rest of qpdf.cc can just act like
@@ -2396,4 +2397,7 @@ QUtil::call_main_from_wmain(int argc, wchar_t* argv[], std::function<int(int, ch
     argc = QIntC::to_int(utf8_argv.size());
     new_argv[argc] = 0;
     return realmain(argc, new_argv);
+#else
+    return -1;
+#endif
 }


### PR DESCRIPTION
Build on Linux toolchains without wchar fails since version 9.1.1 and a44b5a34a07b9f2905d419d5571fd53832c1f6c0 on:

```
libqpdf/QUtil.cc: In function 'int QUtil::call_main_from_wmain(int, wchar_t**, std::function<int(int, char**)>)':
libqpdf/QUtil.cc:2378:32: error: 'wcslen' was not declared in this scope
         for (size_t j = 0; j < wcslen(argv[i]); ++j)
                                ^~~~~~
```
To fix this error, return -1 if `WINDOWS_WMAIN` is not defined

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>