### PR TITLE
Allow upscaling of the form XObject in placeFormXObject()

### DIFF
--- a/libqpdf/QPDFPageObjectHelper.cc
+++ b/libqpdf/QPDFPageObjectHelper.cc
@@ -753,10 +753,6 @@ QPDFPageObjectHelper::placeFormXObject(
     double xscale = rect_w / t_w;
     double yscale = rect_h / t_h;
     double scale = (xscale < yscale ? xscale : yscale);
-    if (scale > 1.0)
-    {
-        scale = 1.0;
-    }
 
     // Step 2: figure out what translation is required to get the
     // rectangle to the right spot: centered within the destination.


### PR DESCRIPTION
Hi, I'm the developer of PDF Mix Tool [1]. It would be useful if form XObject could be also upscaled in placeFormXObject(). I would need this for a 'resize page' feature.

I don't know if there was some reason to keep that limitation, but I tested the patch and it seems to work properly.

[1] https://gitlab.com/scarpetta/pdfmixtool