### PR TITLE
Replace memchr in BufferInputSource::findAndSkipNextEOL with manual memory search

### DIFF
--- a/libqpdf/BufferInputSource.cc
+++ b/libqpdf/BufferInputSource.cc
@@ -61,14 +61,15 @@ BufferInputSource::findAndSkipNextEOL()
     }
 
     qpdf_offset_t result = 0;
-    size_t len = QIntC::to_size(end_pos - this->m->cur_offset);
     unsigned char const* buffer = this->m->buf->getBuffer();
+    unsigned char const* end = buffer + end_pos;
+    unsigned char const* p = buffer + this->m->cur_offset;
 
-    void* start = const_cast<unsigned char*>(buffer) + this->m->cur_offset;
-    unsigned char* p1 = static_cast<unsigned char*>(memchr(start, '\r', len));
-    unsigned char* p2 = static_cast<unsigned char*>(memchr(start, '\n', len));
-    unsigned char* p = (p1 && p2) ? std::min(p1, p2) : p1 ? p1 : p2;
-    if (p)
+    while ((p < end) && !((*p == '\r') || (*p == '\n')))
+    {
+        ++p;
+    }
+    if (p < end)
     {
         result = p - buffer;
         this->m->cur_offset = result + 1;


### PR DESCRIPTION
On large files with predominantly `\n` line endings, `memchr(..'\r'..)`
may waste a considerable amount of time searching for a line
ending candidate that we won't need.

On the Adobe PDF Reference 6th ed (31 MB), this commit is 8x faster
at `QPDF::processMemoryFile()` (about 1.1s compared to 8.2s).

<hr/>

For some context in pikepdf, I have a custom input source to handle objects that
implement the IO stream protocol in Python, which means all reads and seeks
involve some Python overhead. For small reads and seeks this is expensive;
for large ones bulk storage is the overhead.

I got curious if `mmap()` would improve matters and found it to be about
2x faster when combined with this patch (without this patch, `mmap()` was
a fair bit slower, a surprising result that prompted my investigation). I thought
it's an interesting data point that QPDF might benefit from `mmap` too, although,
hard to say much.

Cheers.