### PR TITLE
libqpdf/Pl_AES_PDF.cc: remove duplicated if branch

### DIFF
--- a/libqpdf/Pl_AES_PDF.cc
+++ b/libqpdf/Pl_AES_PDF.cc
@@ -209,14 +209,7 @@ Pl_AES_PDF::flush(bool strip_padding)
         }
     }
 
-    if (this->encrypt)
-    {
-	this->crypto->rijndael_process(this->inbuf, this->outbuf);
-    }
-    else
-    {
-	this->crypto->rijndael_process(this->inbuf, this->outbuf);
-    }
+    this->crypto->rijndael_process(this->inbuf, this->outbuf);
     unsigned int bytes = this->buf_size;
     if (strip_padding)
     {


### PR DESCRIPTION
Check for this->encrypt seems to be moved to plugged crypto
implementations, so it can be removed from Pl_AES_PDF.cc.

The issue was found out by our internal coverity scanner, here is the message:

```
Error: IDENTICAL_BRANCHES (CWE-398):
qpdf-10.3.1/libqpdf/Pl_AES_PDF.cc:212: identical_branches: The same code is executed regardless of whether "this->encrypt" is true, because the 'then' and 'else' branches are identical. Should one of the branches be modified, or the entire 'if' statement replaced?
#  210|       }
#  211|   
#  212|->     if (this->encrypt)
#  213|       {
#  214|   	this->crypto->rijndael_process(this->inbuf, this->outbuf);
```