### PR TITLE
Fix segmentation fault in QPDF::getFilename

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2730,7 +2730,12 @@ QPDF::getUniqueId() const
 std::string
 QPDF::getFilename() const
 {
-    return this->m->file->getName();
+    std::string fn = "";
+    if (this->m->file.getPointer())
+    {
+        fn = this->m->file->getName();
+    }
+    return fn;
 }
 
 std::string


### PR DESCRIPTION
Code like
```c
    qpdf_data qpdf1 = qpdf_init();
    qpdf_oh_is_bool(qpdf1, 3);
```
causes  segmentation faults.