### PR TITLE
Ensure consistency QPDF::getRoot vs QPDF::getTrailer

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2769,7 +2769,15 @@ QPDF::getExtensionLevel()
 QPDFObjectHandle
 QPDF::getTrailer()
 {
-    return this->m->trailer;
+    QPDFObjectHandle trailer = this->m->trailer;
+    if (! trailer.isDictionary() 
+        || this->m->file->getName() == "closed input source")
+    {
+        throw QPDFExc(qpdf_e_damaged_pdf, this->m->file->getName(),
+                      "", this->m->file->getLastOffset(),
+                      "unable to find trailer dictionary");
+    }
+    return trailer;
 }
 
 QPDFObjectHandle

--- a/qpdf/qtest/qpdf.test
+++ b/qpdf/qtest/qpdf.test
@@ -1493,11 +1493,17 @@ $td->runtest("check output",
 show_ntests();
 # ----------
 $td->notify("--- Invalid objects ---");
-$n_tests += 3;
+$n_tests += 4;
 
 $td->runtest("closed input source",
 	     {$td->COMMAND => "test_driver 73 minimal.pdf"},
 	     {$td->FILE => "test73.out",
+	      $td->EXIT_STATUS => 2},
+	     $td->NORMALIZE_NEWLINES);
+
+$td->runtest("closed input source trailer",
+	     {$td->COMMAND => "test_driver 81 minimal.pdf"},
+	     {$td->FILE => "test81.out",
 	      $td->EXIT_STATUS => 2},
 	     $td->NORMALIZE_NEWLINES);
 

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -2724,7 +2724,6 @@ void runtest(int n, char const* filename1, char const* arg2)
         {
             std::cerr << "getRoot: " << e.what() << std::endl;
         }
-
         pdf.closeInputSource();
         pdf.getRoot().getKey("/Pages").unparseResolved();
     }
@@ -3048,6 +3047,20 @@ void runtest(int n, char const* filename1, char const* arg2)
         w2.setStaticID(true);
         w2.setQDFMode(true);
         w2.write();
+    }
+    else if (n == 81)
+    {
+        try
+        {
+            QPDF pdf2;
+            pdf2.getTrailer();
+        }
+        catch (std::exception& e)
+        {
+            std::cerr << "getTrailer: " << e.what() << std::endl;
+        }
+        pdf.closeInputSource();
+        pdf.getTrailer().getKey("/Root").unparseResolved();
     }
     else
     {


### PR DESCRIPTION
`qpdf->getTrailer()->getKey("/Root")` and `qpdf->getRoot()` should display similar behaviour for non-opened `qpdf`'s re throwing exceptions.
