### PR TITLE
C-API expose new_object as qpdf_oh_new_object

### DIFF
--- a/include/qpdf/qpdf-c.h
+++ b/include/qpdf/qpdf-c.h
@@ -554,6 +554,10 @@ extern "C" {
     QPDF_DLL
     void qpdf_oh_release_all(qpdf_data data);
 
+    /* Clone an object handle */
+    QPDF_DLL
+    qpdf_oh qpdf_oh_new_object(qpdf_data qpdf, qpdf_oh oh);
+
     /* Get trailer and root objects */
     QPDF_DLL
     qpdf_oh qpdf_get_trailer(qpdf_data data);

--- a/libqpdf/qpdf-c.cc
+++ b/libqpdf/qpdf-c.cc
@@ -841,6 +841,12 @@ new_object(qpdf_data qpdf, QPDFObjectHandle const& qoh)
     return oh;
 }
 
+qpdf_oh qpdf_oh_new_object(qpdf_data qpdf, qpdf_oh oh)
+{
+    QTC::TC("qpdf", "qpdf-c called qpdf_new_object");
+    return new_object(qpdf, *(qpdf->oh_cache[oh]));
+}
+
 void qpdf_oh_release(qpdf_data qpdf, qpdf_oh oh)
 {
     QTC::TC("qpdf", "qpdf-c called qpdf_oh_release");

--- a/qpdf/qpdf-ctest.c
+++ b/qpdf/qpdf-ctest.c
@@ -531,14 +531,19 @@ static void test24(char const* infile,
     assert(qpdf_oh_is_array(qpdf, mediabox));
     assert(qpdf_oh_get_array_n_items(qpdf, mediabox) == 4);
     qpdf_oh wrapped_mediabox = qpdf_oh_wrap_in_array(qpdf, mediabox);
+    qpdf_oh cloned_mediabox = qpdf_oh_new_object(qpdf, mediabox);
     assert(wrapped_mediabox != mediabox);
+    assert(cloned_mediabox != mediabox);
     assert(qpdf_oh_get_array_n_items(qpdf, wrapped_mediabox) == 4);
     for (int i = 0; i < 4; ++i)
     {
         qpdf_oh item = qpdf_oh_get_array_item(qpdf, mediabox, i);
         qpdf_oh item2 = qpdf_oh_get_array_item(qpdf, wrapped_mediabox, i);
+        qpdf_oh item3 = qpdf_oh_get_array_item(qpdf, cloned_mediabox, i);
         assert(qpdf_oh_get_int_value_as_int(qpdf, item) ==
                qpdf_oh_get_int_value_as_int(qpdf, item2));
+        assert(qpdf_oh_get_int_value_as_int(qpdf, item) ==
+               qpdf_oh_get_int_value_as_int(qpdf, item3));
         printf("item %d: %d %.2f\n",
                i, qpdf_oh_get_int_value_as_int(qpdf, item),
                qpdf_oh_get_numeric_value(qpdf, item));

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -458,6 +458,7 @@ qpdf pages range omitted with . 0
 qpdf-c invalid object handle 0
 qpdf-c called qpdf_oh_release 0
 qpdf-c called qpdf_oh_release_all 0
+qpdf-c called qpdf_new_object 0
 qpdf-c called qpdf_get_trailer 0
 qpdf-c called qpdf_get_root 0
 qpdf-c called qpdf_oh_is_bool 0


### PR DESCRIPTION
Allow users to clone qpdf_oh handles in order to take advantages of QPDF's reference counting.