### PR TITLE
Fix QPDFObjectHandle::isOrHasName

### DIFF
--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1055,9 +1055,21 @@ QPDFObjectHandle::getDictAsMap()
 bool
 QPDFObjectHandle::isOrHasName(std::string const& value)
 {
-    return isNameAndEquals(value) ||
-           (isArray() && (getArrayNItems() > 0) && 
-            getArrayItem(0).isNameAndEquals(value));
+    if (isNameAndEquals(value))
+    {
+        return true;
+    }
+    else if (isArray())
+    {
+        for (auto& item: aitems())
+        {
+            if (item.isNameAndEquals(value))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 void

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -3128,6 +3128,15 @@ static void test_82(QPDF& pdf, char const* arg2)
     assert(stream.isStreamOfType("/ObjStm"));
     assert(! stream.isStreamOfType("/Test"));
     assert(! pdf.getObjectByID(2,0).isStreamOfType("/Pages"));
+    auto array = QPDFObjectHandle::parse("[/Blah /Blaah /Blaaah]");
+    assert(array.isOrHasName("/Blah"));
+    assert(array.isOrHasName("/Blaaah"));
+    assert(! array.isOrHasName("/Blaaaah"));
+    assert(array.getArrayItem(0).isOrHasName("/Blah"));
+    assert(! array.getArrayItem(1).isOrHasName("/Blah"));
+    array = QPDFObjectHandle::parse("[]");
+    assert(! array.isOrHasName("/Blah"));
+    assert(! str.isOrHasName("/Marvin"));
 }
 
 void runtest(int n, char const* filename1, char const* arg2)


### PR DESCRIPTION
Ensure isOrHasName returns true if object is an array and the name is
present anywhere in the array.