### PR TITLE
Remove /Type test in QPDFJob::shouldRemoveUnreferencedResources

### DIFF
--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -2743,13 +2743,7 @@ QPDFJob::shouldRemoveUnreferencedResources(QPDF& pdf)
                 for (auto const& k: xobject.getKeys())
                 {
                     QPDFObjectHandle xobj = xobject.getKey(k);
-                    if (xobj.isStream() &&
-                        xobj.getDict().getKey("/Type").isName() &&
-                        ("/XObject" ==
-                         xobj.getDict().getKey("/Type").getName()) &&
-                        xobj.getDict().getKey("/Subtype").isName() &&
-                        ("/Form" ==
-                         xobj.getDict().getKey("/Subtype").getName()))
+                    if (xobj.isFormXObject())
                     {
                         queue.push_back(xobj);
                     }

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -3406,7 +3406,7 @@ QPDFObjectHandle::isPagesObject()
 bool
 QPDFObjectHandle::isFormXObject()
 {
-    return isStreamOfType("/XObject", "/Form");
+    return isStreamOfType("", "/Form");
 }
 
 bool


### PR DESCRIPTION
Remove test for type == /XObject as value is optional
(as per spec 8.10.2).