### PR TITLE
include math.h

### DIFF
--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -31,6 +31,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <map>
+#include <math.h>
 
 static char const* whoami = 0;
 


### PR DESCRIPTION
Otherwise, compilation fails with `error: call of overloaded 'abs(double)' is ambiguous`