### PR TITLE
Fix QPDFPageObjectHelper::getCropBox and getTrimBox

### DIFF
--- a/libqpdf/QPDFPageObjectHelper.cc
+++ b/libqpdf/QPDFPageObjectHelper.cc
@@ -367,7 +367,13 @@ QPDFPageObjectHelper::getTrimBox(bool copy_if_shared)
     QPDFObjectHandle result = getAttribute("/TrimBox", copy_if_shared);
     if (result.isNull())
     {
-        result = getCropBox(copy_if_shared);
+        QTC::TC("qpdf", "QPDFPageObjectHelper getTrimBox");
+        result = getCropBox();
+        if (copy_if_shared)
+        {
+            result = result.shallowCopy();
+            this->oh.replaceKey("/TrimBox", result);
+        }
     }
     return result;
 }
@@ -378,7 +384,13 @@ QPDFPageObjectHelper::getCropBox(bool copy_if_shared)
     QPDFObjectHandle result = getAttribute("/CropBox", copy_if_shared);
     if (result.isNull())
     {
+        QTC::TC("qpdf", "QPDFPageObjectHelper getCropBox");
         result = getMediaBox();
+        if (copy_if_shared)
+        {
+            result = result.shallowCopy();
+            this->oh.replaceKey("/CropBox", result);
+        }
     }
     return result;
 }

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -417,6 +417,8 @@ QPDFFormFieldObjectHelper replaced BMC at EOF 0
 QPDFFormFieldObjectHelper fallback Tf 0
 QPDFPageObjectHelper non-trivial inheritance 0
 QPDFPageObjectHelper copy shared attribute 1
+QPDFPageObjectHelper getCropBox 0
+QPDFPageObjectHelper getTrimBox 0
 QPDFJob from_nr from repeat_nr 0
 QPDF resolve duplicated page object 0
 QPDF handle direct page object 0

--- a/qpdf/qtest/qpdf.test
+++ b/qpdf/qtest/qpdf.test
@@ -5471,6 +5471,19 @@ $td->runtest("parsed offset with object streams",
 
 show_ntests();
 # ----------
+$td->notify("--- PageObjectHelper ---");
+$n_tests += 2;
+
+$td->runtest("modify shared Boxes",
+             {$td->COMMAND => "test_driver 87 minimal-inherit.pdf"},
+             {$td->STRING => "test 87 done\n", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
+$td->runtest("compare files",
+             {$td->FILE => "a.pdf"},
+             {$td->FILE => "minimal-inherit-out.pdf"});
+
+show_ntests();
+# ----------
 $td->notify("--- Large File Tests ---");
 my $nlarge = 1;
 if (defined $large_file_test_path)

--- a/qpdf/qtest/qpdf/minimal-inherit-out.pdf
+++ b/qpdf/qtest/qpdf/minimal-inherit-out.pdf
@@ -1,0 +1,119 @@
+%PDF-1.3
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /MediaBox [
+    13
+    42
+    642
+    792
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /CropBox [
+    13
+    26
+    642
+    780
+  ]
+  /MediaBox [
+    13
+    42
+    642
+    780
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 6 0 R
+    >>
+    /ProcSet 7 0 R
+  >>
+  /TrimBox [
+    7
+    42
+    642
+    792
+  ]
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Potato) Tj
+ET
+endstream
+endobj
+
+5 0 obj
+44
+endobj
+
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /BaseFont /Helvetica
+  /Encoding /WinAnsiEncoding
+  /Name /F1
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 7 0
+7 0 obj
+[
+  /PDF
+  /Text
+]
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000290 00000 n 
+0000000627 00000 n 
+0000000726 00000 n 
+0000000772 00000 n 
+0000000917 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 8
+  /ID [<2d6e9c982d62b021e6becef91079ae80><31415926535897932384626433832795>]
+>>
+startxref
+952
+%%EOF

--- a/qpdf/qtest/qpdf/minimal-inherit.pdf
+++ b/qpdf/qtest/qpdf/minimal-inherit.pdf
@@ -1,0 +1,101 @@
+%PDF-1.3
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 6 0 R
+    >>
+    /ProcSet 7 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Potato) Tj
+ET
+endstream
+endobj
+
+5 0 obj
+44
+endobj
+
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /BaseFont /Helvetica
+  /Encoding /WinAnsiEncoding
+  /Name /F1
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 5 0
+7 0 obj
+[
+  /PDF
+  /Text
+]
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000288 00000 n 
+0000000484 00000 n 
+0000000583 00000 n 
+0000000629 00000 n 
+0000000774 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 8
+  /ID [<2d6e9c982d62b021e6becef91079ae80><2d6e9c982d62b021e6becef91079ae80>]
+>>
+startxref
+809
+%%EOF

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -3345,6 +3345,25 @@ static void test_86(QPDF& pdf, char const* arg2)
     assert(h.getUTF8Value() == utf8_val);
 }
 
+static void test_87(QPDF& pdf, char const* arg2)
+{
+    // Test QPDFPageObjectHelper::get[Media|Trim|Crop]Box
+
+    auto pdh = QPDFPageDocumentHelper(pdf);
+    auto p = pdh.getAllPages().at(0);
+    p.getTrimBox().setArrayItem(0, "13"_qpdf);
+    p.getCropBox().setArrayItem(1, "42"_qpdf);
+    p.getMediaBox().setArrayItem(2, "642"_qpdf);
+    p.getTrimBox(true).setArrayItem(0, "7"_qpdf);
+    p.getMediaBox(true).setArrayItem(3, "780"_qpdf);
+    p.getCropBox(true).setArrayItem(1, "26"_qpdf);
+
+    QPDFWriter w(pdf, "a.pdf");
+    w.setQDFMode(true);
+    w.setStaticID(true);
+    w.write();
+}
+
 void runtest(int n, char const* filename1, char const* arg2)
 {
     // Most tests here are crafted to work on specific files.  Look at
@@ -3461,7 +3480,7 @@ void runtest(int n, char const* filename1, char const* arg2)
         {72, test_72}, {73, test_73}, {74, test_74}, {75, test_75},
         {76, test_76}, {77, test_77}, {78, test_78}, {79, test_79},
         {80, test_80}, {81, test_81}, {82, test_82}, {83, test_83},
-        {84, test_84}, {85, test_85}, {86, test_86},
+        {84, test_84}, {85, test_85}, {86, test_86}, {87, test_87},
     };
 
     auto fn = test_functions.find(n);


### PR DESCRIPTION
Ensure the correct boxes are created/updated.