### PR TITLE
Anonymous namespaces

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2022-04-16  Jay Berkenbilt  <ejb@ql.org>
 
+	* Breaking CLI change: the default value for --json is now
+	"latest" rather than "1". At this moment, "1" is the latest
+	version, but version "2" will be added before the release of
+	qpdf 11.
+
 	* Perform code cleanup including some source-compatible but not
 	binary compatible changes to function signatures.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,7 +6,8 @@
 	qpdf 11.
 
 	* Perform code cleanup including some source-compatible but not
-	binary compatible changes to function signatures.
+	binary compatible changes to function signatures, use of anonymous
+	namespaces, and use of "= default" and "= delete" in declarations.
 
 2022-04-09  Jay Berkenbilt  <ejb@ql.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+2022-04-16  Jay Berkenbilt  <ejb@ql.org>
+
+	* Perform code cleanup including some source-compatible but not
+	binary compatible changes to function signatures.
+
+2022-04-09  Jay Berkenbilt  <ejb@ql.org>
+
+	* Replace PointerHolder with std::shared_ptr through the QPDF API.
+	A backward-compatible interface is provided and enabled by default
+	with a warning that can be turned off. See "Smart Pointers" in the
+	"Design and Library Notes" section of the manual for information
+	including a detailed migration process to assist with migrating
+	code that uses the qpdf library.
+
+2022-04-03  Jay Berkenbilt  <ejb@ql.org>
+
+	* Add automatic code formatting with clang-format. See "Code
+	Formatting" in the "Contributing to qpdf" chapter of the manual.
+
 2022-03-19  Jay Berkenbilt  <ejb@ql.org>
 
 	* 10.6.3.0cmake1: unofficial release

--- a/TODO
+++ b/TODO
@@ -476,9 +476,9 @@ ABI Changes
 ===========
 
 This is a list of changes to make next time there is an ABI change.
-Comments appear in the code prefixed by "ABI"
+Comments appear in the code prefixed by "ABI". Always Search for ABI
+in source and header files to find items not listed here.
 
-* Search for ABI to find items not listed here.
 * See where anonymous namespaces can be used to keep things private to
   a source file. Search for `(class|struct)` in **/*.cc.
 * Having QPDFObjectHandle setters return Class& to allow for

--- a/TODO
+++ b/TODO
@@ -6,7 +6,6 @@ Next
 * Stay on top of https://github.com/pikepdf/pikepdf/pull/315
 
 In order:
-* ABI including --json default is latest
 * json v2
 
 Other (do in any order):
@@ -480,7 +479,6 @@ This is a list of changes to make next time there is an ABI change.
 Comments appear in the code prefixed by "ABI"
 
 * Search for ABI to find items not listed here.
-* Switch default --json to latest
 * See where anonymous namespaces can be used to keep things private to
   a source file. Search for `(class|struct)` in **/*.cc.
 * After removing legacy QPDFNameTreeObjectHelper and

--- a/TODO
+++ b/TODO
@@ -481,10 +481,6 @@ Comments appear in the code prefixed by "ABI"
 * Search for ABI to find items not listed here.
 * See where anonymous namespaces can be used to keep things private to
   a source file. Search for `(class|struct)` in **/*.cc.
-* After removing legacy QPDFNameTreeObjectHelper and
-  QPDFNumberTreeObjectHelper constructors, NNTreeImpl can switch to
-  having a QPDF reference and assume that the reference is always
-  valid.
 * Having QPDFObjectHandle setters return Class& to allow for
   use of fluent interfaces. This includes array and dictionary
   mutators.

--- a/TODO
+++ b/TODO
@@ -490,11 +490,6 @@ in source and header files to find items not listed here.
   oh as the new value and returns it.
 * Add default values to the getters, like getIntValue(default_value).
   If a default value is passed in, you never get a type warning.
-* Added QPDFObjectHandle::ParserCallbacks::handleWarning but had to
-  revert because it was not binary compatible. Consider re-adding. The
-  commit that added this comment includes the reverting of the change.
-  The previous commit removes the code that was calling and using
-  handleWarning.
 * Make it easier to deal with objects that should be indirect. Search
   for makeIndirectObject in the code to find patterns. For example, it
   would be nice to have a one-liner for the case of one or all

--- a/TODO
+++ b/TODO
@@ -479,8 +479,6 @@ This is a list of changes to make next time there is an ABI change.
 Comments appear in the code prefixed by "ABI". Always Search for ABI
 in source and header files to find items not listed here.
 
-* See where anonymous namespaces can be used to keep things private to
-  a source file. Search for `(class|struct)` in **/*.cc.
 * Having QPDFObjectHandle setters return Class& to allow for
   use of fluent interfaces. This includes array and dictionary
   mutators.

--- a/include/qpdf/QPDFAcroFormDocumentHelper.hh
+++ b/include/qpdf/QPDFAcroFormDocumentHelper.hh
@@ -248,19 +248,6 @@ class QPDFAcroFormDocumentHelper: public QPDFDocumentHelper
         QPDFAcroFormDocumentHelper& from_afdh,
         std::set<QPDFObjGen>* new_fields = nullptr);
 
-    // copyFieldsFromForeignPage was added in qpdf 10.2 and made to do
-    // nothing in 10.3. It wasn't actually doing the right thing and
-    // would result in broken files in all but the simplest case of a
-    // single page from one file being added to another file, as
-    // happens with qpdf --split-pages.
-    [[deprecated("Use fixCopiedAnnotations instead")]]
-    // ABI: delete this method
-    QPDF_DLL void
-    copyFieldsFromForeignPage(
-        QPDFPageObjectHelper foreign_page,
-        QPDFAcroFormDocumentHelper& foreign_afdh,
-        std::vector<QPDFObjectHandle>* copied_fields = nullptr);
-
   private:
     void analyze();
     void traverseField(

--- a/include/qpdf/QPDFNameTreeObjectHelper.hh
+++ b/include/qpdf/QPDFNameTreeObjectHelper.hh
@@ -50,13 +50,6 @@ class QPDFNameTreeObjectHelper: public QPDFObjectHelper
     QPDF_DLL
     QPDFNameTreeObjectHelper(QPDFObjectHandle, QPDF&, bool auto_repair = true);
 
-    // ABI: Legacy Constructor will be removed in QPDF 11. A
-    // QPDFNameTreeObjectHelper constructed in this way can't be
-    // modified or repaired and will silently ignore problems in the
-    // structure.
-    [[deprecated("use constructor that takes QPDF&")]] QPDF_DLL
-        QPDFNameTreeObjectHelper(QPDFObjectHandle);
-
     // Create an empty name tree
     QPDF_DLL
     static QPDFNameTreeObjectHelper newEmpty(QPDF&, bool auto_repair = true);
@@ -197,7 +190,7 @@ class QPDFNameTreeObjectHelper: public QPDFObjectHelper
         ~Members() = default;
 
       private:
-        Members(QPDFObjectHandle& oh, QPDF*, bool auto_repair);
+        Members(QPDFObjectHandle& oh, QPDF&, bool auto_repair);
         Members(Members const&) = delete;
 
         std::shared_ptr<NNTreeImpl> impl;

--- a/include/qpdf/QPDFNumberTreeObjectHelper.hh
+++ b/include/qpdf/QPDFNumberTreeObjectHelper.hh
@@ -48,13 +48,6 @@ class QPDFNumberTreeObjectHelper: public QPDFObjectHelper
     QPDFNumberTreeObjectHelper(
         QPDFObjectHandle, QPDF&, bool auto_repair = true);
 
-    // ABI: Legacy Constructor will be removed in QPDF 11. A
-    // QPDFNumberTreeObjectHelper constructed in this way can't be
-    // modified or repaired and will silently ignore problems in the
-    // structure.
-    [[deprecated("use constructor that takes QPDF&")]] QPDF_DLL
-        QPDFNumberTreeObjectHelper(QPDFObjectHandle);
-
     QPDF_DLL
     virtual ~QPDFNumberTreeObjectHelper() = default;
 
@@ -217,7 +210,7 @@ class QPDFNumberTreeObjectHelper: public QPDFObjectHelper
         ~Members() = default;
 
       private:
-        Members(QPDFObjectHandle& oh, QPDF*, bool auto_repair);
+        Members(QPDFObjectHandle& oh, QPDF&, bool auto_repair);
         Members(Members const&) = delete;
 
         std::shared_ptr<NNTreeImpl> impl;

--- a/libqpdf/Pl_DCT.cc
+++ b/libqpdf/Pl_DCT.cc
@@ -14,12 +14,15 @@
 # error "qpdf does not support libjpeg built with BITS_IN_JSAMPLE != 8"
 #endif
 
-struct qpdf_jpeg_error_mgr
+namespace
 {
-    struct jpeg_error_mgr pub;
-    jmp_buf jmpbuf;
-    std::string msg;
-};
+    struct qpdf_jpeg_error_mgr
+    {
+        struct jpeg_error_mgr pub;
+        jmp_buf jmpbuf;
+        std::string msg;
+    };
+} // namespace
 
 static void
 error_handler(j_common_ptr cinfo)
@@ -147,13 +150,16 @@ Pl_DCT::finish()
     }
 }
 
-struct dct_pipeline_dest
+namespace
 {
-    struct jpeg_destination_mgr pub; /* public fields */
-    unsigned char* buffer;
-    size_t size;
-    Pipeline* next;
-};
+    struct dct_pipeline_dest
+    {
+        struct jpeg_destination_mgr pub; /* public fields */
+        unsigned char* buffer;
+        size_t size;
+        Pipeline* next;
+    };
+} // namespace
 
 static void
 init_pipeline_destination(j_compress_ptr)

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -50,60 +50,64 @@ static char const* EMPTY_PDF = (
     "110\n"
     "%%EOF\n");
 
-class InvalidInputSource: public InputSource
+namespace
 {
-  public:
-    virtual ~InvalidInputSource() = default;
-    virtual qpdf_offset_t
-    findAndSkipNextEOL() override
+    class InvalidInputSource: public InputSource
     {
-        throwException();
-        return 0;
-    }
-    virtual std::string const&
-    getName() const override
-    {
-        static std::string name("closed input source");
-        return name;
-    }
-    virtual qpdf_offset_t
-    tell() override
-    {
-        throwException();
-        return 0;
-    }
-    virtual void
-    seek(qpdf_offset_t offset, int whence) override
-    {
-        throwException();
-    }
-    virtual void
-    rewind() override
-    {
-        throwException();
-    }
-    virtual size_t
-    read(char* buffer, size_t length) override
-    {
-        throwException();
-        return 0;
-    }
-    virtual void
-    unreadCh(char ch) override
-    {
-        throwException();
-    }
+      public:
+        virtual ~InvalidInputSource() = default;
+        virtual qpdf_offset_t
+        findAndSkipNextEOL() override
+        {
+            throwException();
+            return 0;
+        }
+        virtual std::string const&
+        getName() const override
+        {
+            static std::string name("closed input source");
+            return name;
+        }
+        virtual qpdf_offset_t
+        tell() override
+        {
+            throwException();
+            return 0;
+        }
+        virtual void
+        seek(qpdf_offset_t offset, int whence) override
+        {
+            throwException();
+        }
+        virtual void
+        rewind() override
+        {
+            throwException();
+        }
+        virtual size_t
+        read(char* buffer, size_t length) override
+        {
+            throwException();
+            return 0;
+        }
+        virtual void
+        unreadCh(char ch) override
+        {
+            throwException();
+        }
 
-  private:
-    void
-    throwException()
-    {
-        throw std::logic_error(
-            "QPDF operation attempted on a QPDF object with no input source."
-            " QPDF operations are invalid before processFile (or another"
-            " process method) or after closeInputSource");
-    }
-};
+      private:
+        void
+        throwException()
+        {
+            throw std::logic_error(
+                "QPDF operation attempted on a QPDF object with no input "
+                "source."
+                " QPDF operations are invalid before processFile (or another"
+                " process method) or after closeInputSource");
+        }
+    };
+} // namespace
 
 QPDF::ForeignStreamData::ForeignStreamData(
     std::shared_ptr<EncryptionParameters> encp,

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -543,20 +543,25 @@ QPDFAcroFormDocumentHelper::adjustInheritedFields(
     }
 }
 
-class ResourceReplacer: public QPDFObjectHandle::TokenFilter
+namespace
 {
-  public:
-    ResourceReplacer(
-        std::map<std::string, std::map<std::string, std::string>> const& dr_map,
-        std::map<std::string, std::map<std::string, std::set<size_t>>> const&
-            rnames);
-    virtual ~ResourceReplacer() = default;
-    virtual void handleToken(QPDFTokenizer::Token const&) override;
+    class ResourceReplacer: public QPDFObjectHandle::TokenFilter
+    {
+      public:
+        ResourceReplacer(
+            std::map<std::string, std::map<std::string, std::string>> const&
+                dr_map,
+            std::map<
+                std::string,
+                std::map<std::string, std::set<size_t>>> const& rnames);
+        virtual ~ResourceReplacer() = default;
+        virtual void handleToken(QPDFTokenizer::Token const&) override;
 
-  private:
-    size_t offset;
-    std::map<std::string, std::map<size_t, std::string>> to_replace;
-};
+      private:
+        size_t offset;
+        std::map<std::string, std::map<size_t, std::string>> to_replace;
+    };
+} // namespace
 
 ResourceReplacer::ResourceReplacer(
     std::map<std::string, std::map<std::string, std::string>> const& dr_map,

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -1144,21 +1144,6 @@ QPDFAcroFormDocumentHelper::transformAnnotations(
 }
 
 void
-QPDFAcroFormDocumentHelper::copyFieldsFromForeignPage(
-    QPDFPageObjectHelper foreign_page,
-    QPDFAcroFormDocumentHelper& foreign_afdh,
-    std::vector<QPDFObjectHandle>* copied_fields)
-{
-    this->qpdf.warn(QPDFExc(
-        qpdf_e_unsupported,
-        "",
-        "",
-        0,
-        "Non-working version of copyFieldsFromForeignPage"
-        " from qpdf 10.2 called; application requires updating"));
-}
-
-void
 QPDFAcroFormDocumentHelper::fixCopiedAnnotations(
     QPDFObjectHandle to_page,
     QPDFObjectHandle from_page,

--- a/libqpdf/QPDFFormFieldObjectHelper.cc
+++ b/libqpdf/QPDFFormFieldObjectHelper.cc
@@ -508,29 +508,32 @@ QPDFFormFieldObjectHelper::generateAppearance(QPDFAnnotationObjectHelper& aoh)
     }
 }
 
-class ValueSetter: public QPDFObjectHandle::TokenFilter
+namespace
 {
-  public:
-    ValueSetter(
-        std::string const& DA,
-        std::string const& V,
-        std::vector<std::string> const& opt,
-        double tf,
-        QPDFObjectHandle::Rectangle const& bbox);
-    virtual ~ValueSetter() = default;
-    virtual void handleToken(QPDFTokenizer::Token const&);
-    virtual void handleEOF();
-    void writeAppearance();
+    class ValueSetter: public QPDFObjectHandle::TokenFilter
+    {
+      public:
+        ValueSetter(
+            std::string const& DA,
+            std::string const& V,
+            std::vector<std::string> const& opt,
+            double tf,
+            QPDFObjectHandle::Rectangle const& bbox);
+        virtual ~ValueSetter() = default;
+        virtual void handleToken(QPDFTokenizer::Token const&);
+        virtual void handleEOF();
+        void writeAppearance();
 
-  private:
-    std::string DA;
-    std::string V;
-    std::vector<std::string> opt;
-    double tf;
-    QPDFObjectHandle::Rectangle bbox;
-    enum { st_top, st_bmc, st_emc, st_end } state;
-    bool replaced;
-};
+      private:
+        std::string DA;
+        std::string V;
+        std::vector<std::string> opt;
+        double tf;
+        QPDFObjectHandle::Rectangle bbox;
+        enum { st_top, st_bmc, st_emc, st_end } state;
+        bool replaced;
+    };
+} // namespace
 
 ValueSetter::ValueSetter(
     std::string const& DA,
@@ -701,27 +704,30 @@ ValueSetter::writeAppearance()
     write("ET\nQ\nEMC");
 }
 
-class TfFinder: public QPDFObjectHandle::TokenFilter
+namespace
 {
-  public:
-    TfFinder();
-    virtual ~TfFinder()
+    class TfFinder: public QPDFObjectHandle::TokenFilter
     {
-    }
-    virtual void handleToken(QPDFTokenizer::Token const&);
-    double getTf();
-    std::string getFontName();
-    std::string getDA();
+      public:
+        TfFinder();
+        virtual ~TfFinder()
+        {
+        }
+        virtual void handleToken(QPDFTokenizer::Token const&);
+        double getTf();
+        std::string getFontName();
+        std::string getDA();
 
-  private:
-    double tf;
-    int tf_idx;
-    std::string font_name;
-    double last_num;
-    int last_num_idx;
-    std::string last_name;
-    std::vector<std::string> DA;
-};
+      private:
+        double tf;
+        int tf_idx;
+        std::string font_name;
+        double last_num;
+        int last_num_idx;
+        std::string last_name;
+        std::vector<std::string> DA;
+    };
+} // namespace
 
 TfFinder::TfFinder() :
     tf(11.0),

--- a/libqpdf/QPDFJob_config.cc
+++ b/libqpdf/QPDFJob_config.cc
@@ -234,10 +234,7 @@ QPDFJob::Config::json()
 QPDFJob::Config*
 QPDFJob::Config::json(std::string const& parameter)
 {
-    if (parameter.empty()) {
-        // The default value is 1 for backward compatibility.
-        o.m->json_version = 1;
-    } else if (parameter == "latest") {
+    if (parameter.empty() || (parameter == "latest")) {
         o.m->json_version = 1;
     } else {
         o.m->json_version = QUtil::string_to_int(parameter.c_str());

--- a/libqpdf/QPDFNameTreeObjectHelper.cc
+++ b/libqpdf/QPDFNameTreeObjectHelper.cc
@@ -32,7 +32,7 @@ class NameTreeDetails: public NNTreeDetails
 static NameTreeDetails name_tree_details;
 
 QPDFNameTreeObjectHelper::Members::Members(
-    QPDFObjectHandle& oh, QPDF* q, bool auto_repair) :
+    QPDFObjectHandle& oh, QPDF& q, bool auto_repair) :
     impl(std::make_shared<NNTreeImpl>(name_tree_details, q, oh, auto_repair))
 {
 }
@@ -40,13 +40,7 @@ QPDFNameTreeObjectHelper::Members::Members(
 QPDFNameTreeObjectHelper::QPDFNameTreeObjectHelper(
     QPDFObjectHandle oh, QPDF& q, bool auto_repair) :
     QPDFObjectHelper(oh),
-    m(new Members(oh, &q, auto_repair))
-{
-}
-
-QPDFNameTreeObjectHelper::QPDFNameTreeObjectHelper(QPDFObjectHandle oh) :
-    QPDFObjectHelper(oh),
-    m(new Members(oh, nullptr, false))
+    m(new Members(oh, q, auto_repair))
 {
 }
 

--- a/libqpdf/QPDFNameTreeObjectHelper.cc
+++ b/libqpdf/QPDFNameTreeObjectHelper.cc
@@ -2,32 +2,35 @@
 
 #include <qpdf/NNTree.hh>
 
-class NameTreeDetails: public NNTreeDetails
+namespace
 {
-  public:
-    virtual std::string const&
-    itemsKey() const override
+    class NameTreeDetails: public NNTreeDetails
     {
-        static std::string k("/Names");
-        return k;
-    }
-    virtual bool
-    keyValid(QPDFObjectHandle oh) const override
-    {
-        return oh.isString();
-    }
-    virtual int
-    compareKeys(QPDFObjectHandle a, QPDFObjectHandle b) const override
-    {
-        if (!(keyValid(a) && keyValid(b))) {
-            // We don't call this without calling keyValid first
-            throw std::logic_error("comparing invalid keys");
+      public:
+        virtual std::string const&
+        itemsKey() const override
+        {
+            static std::string k("/Names");
+            return k;
         }
-        auto as = a.getUTF8Value();
-        auto bs = b.getUTF8Value();
-        return ((as < bs) ? -1 : (as > bs) ? 1 : 0);
-    }
-};
+        virtual bool
+        keyValid(QPDFObjectHandle oh) const override
+        {
+            return oh.isString();
+        }
+        virtual int
+        compareKeys(QPDFObjectHandle a, QPDFObjectHandle b) const override
+        {
+            if (!(keyValid(a) && keyValid(b))) {
+                // We don't call this without calling keyValid first
+                throw std::logic_error("comparing invalid keys");
+            }
+            auto as = a.getUTF8Value();
+            auto bs = b.getUTF8Value();
+            return ((as < bs) ? -1 : (as > bs) ? 1 : 0);
+        }
+    };
+} // namespace
 
 static NameTreeDetails name_tree_details;
 

--- a/libqpdf/QPDFNumberTreeObjectHelper.cc
+++ b/libqpdf/QPDFNumberTreeObjectHelper.cc
@@ -33,7 +33,7 @@ class NumberTreeDetails: public NNTreeDetails
 static NumberTreeDetails number_tree_details;
 
 QPDFNumberTreeObjectHelper::Members::Members(
-    QPDFObjectHandle& oh, QPDF* q, bool auto_repair) :
+    QPDFObjectHandle& oh, QPDF& q, bool auto_repair) :
     impl(std::make_shared<NNTreeImpl>(number_tree_details, q, oh, auto_repair))
 {
 }
@@ -41,13 +41,7 @@ QPDFNumberTreeObjectHelper::Members::Members(
 QPDFNumberTreeObjectHelper::QPDFNumberTreeObjectHelper(
     QPDFObjectHandle oh, QPDF& q, bool auto_repair) :
     QPDFObjectHelper(oh),
-    m(new Members(oh, &q, auto_repair))
-{
-}
-
-QPDFNumberTreeObjectHelper::QPDFNumberTreeObjectHelper(QPDFObjectHandle oh) :
-    QPDFObjectHelper(oh),
-    m(new Members(oh, nullptr, false))
+    m(new Members(oh, q, auto_repair))
 {
 }
 

--- a/libqpdf/QPDFNumberTreeObjectHelper.cc
+++ b/libqpdf/QPDFNumberTreeObjectHelper.cc
@@ -3,32 +3,35 @@
 #include <qpdf/NNTree.hh>
 #include <qpdf/QIntC.hh>
 
-class NumberTreeDetails: public NNTreeDetails
+namespace
 {
-  public:
-    virtual std::string const&
-    itemsKey() const override
+    class NumberTreeDetails: public NNTreeDetails
     {
-        static std::string k("/Nums");
-        return k;
-    }
-    virtual bool
-    keyValid(QPDFObjectHandle oh) const override
-    {
-        return oh.isInteger();
-    }
-    virtual int
-    compareKeys(QPDFObjectHandle a, QPDFObjectHandle b) const override
-    {
-        if (!(keyValid(a) && keyValid(b))) {
-            // We don't call this without calling keyValid first
-            throw std::logic_error("comparing invalid keys");
+      public:
+        virtual std::string const&
+        itemsKey() const override
+        {
+            static std::string k("/Nums");
+            return k;
         }
-        auto as = a.getIntValue();
-        auto bs = b.getIntValue();
-        return ((as < bs) ? -1 : (as > bs) ? 1 : 0);
-    }
-};
+        virtual bool
+        keyValid(QPDFObjectHandle oh) const override
+        {
+            return oh.isInteger();
+        }
+        virtual int
+        compareKeys(QPDFObjectHandle a, QPDFObjectHandle b) const override
+        {
+            if (!(keyValid(a) && keyValid(b))) {
+                // We don't call this without calling keyValid first
+                throw std::logic_error("comparing invalid keys");
+            }
+            auto as = a.getIntValue();
+            auto bs = b.getIntValue();
+            return ((as < bs) ? -1 : (as > bs) ? 1 : 0);
+        }
+    };
+} // namespace
 
 static NumberTreeDetails number_tree_details;
 

--- a/libqpdf/QPDFPageObjectHelper.cc
+++ b/libqpdf/QPDFPageObjectHelper.cc
@@ -11,20 +11,23 @@
 #include <qpdf/QUtil.hh>
 #include <qpdf/ResourceFinder.hh>
 
-class ContentProvider: public QPDFObjectHandle::StreamDataProvider
+namespace
 {
-  public:
-    ContentProvider(QPDFObjectHandle from_page) :
-        from_page(from_page)
+    class ContentProvider: public QPDFObjectHandle::StreamDataProvider
     {
-    }
-    virtual ~ContentProvider() = default;
-    virtual void
-    provideStreamData(int objid, int generation, Pipeline* pipeline);
+      public:
+        ContentProvider(QPDFObjectHandle from_page) :
+            from_page(from_page)
+        {
+        }
+        virtual ~ContentProvider() = default;
+        virtual void
+        provideStreamData(int objid, int generation, Pipeline* pipeline);
 
-  private:
-    QPDFObjectHandle from_page;
-};
+      private:
+        QPDFObjectHandle from_page;
+    };
+} // namespace
 
 void
 ContentProvider::provideStreamData(int, int, Pipeline* p)
@@ -39,23 +42,26 @@ ContentProvider::provideStreamData(int, int, Pipeline* p)
     concat.manualFinish();
 }
 
-class InlineImageTracker: public QPDFObjectHandle::TokenFilter
+namespace
 {
-  public:
-    InlineImageTracker(QPDF*, size_t min_size, QPDFObjectHandle resources);
-    virtual ~InlineImageTracker() = default;
-    virtual void handleToken(QPDFTokenizer::Token const&);
-    QPDFObjectHandle convertIIDict(QPDFObjectHandle odict);
+    class InlineImageTracker: public QPDFObjectHandle::TokenFilter
+    {
+      public:
+        InlineImageTracker(QPDF*, size_t min_size, QPDFObjectHandle resources);
+        virtual ~InlineImageTracker() = default;
+        virtual void handleToken(QPDFTokenizer::Token const&);
+        QPDFObjectHandle convertIIDict(QPDFObjectHandle odict);
 
-    QPDF* qpdf;
-    size_t min_size;
-    QPDFObjectHandle resources;
-    std::string dict_str;
-    std::string bi_str;
-    int min_suffix;
-    bool any_images;
-    enum { st_top, st_bi } state;
-};
+        QPDF* qpdf;
+        size_t min_size;
+        QPDFObjectHandle resources;
+        std::string dict_str;
+        std::string bi_str;
+        int min_suffix;
+        bool any_images;
+        enum { st_top, st_bi } state;
+    };
+} // namespace
 
 InlineImageTracker::InlineImageTracker(
     QPDF* qpdf, size_t min_size, QPDFObjectHandle resources) :

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -20,22 +20,25 @@ is_delimiter(char ch)
     return (strchr(" \t\n\v\f\r()<>[]{}/%", ch) != 0);
 }
 
-class QPDFWordTokenFinder: public InputSource::Finder
+namespace
 {
-  public:
-    QPDFWordTokenFinder(
-        std::shared_ptr<InputSource> is, std::string const& str) :
-        is(is),
-        str(str)
+    class QPDFWordTokenFinder: public InputSource::Finder
     {
-    }
-    virtual ~QPDFWordTokenFinder() = default;
-    virtual bool check();
+      public:
+        QPDFWordTokenFinder(
+            std::shared_ptr<InputSource> is, std::string const& str) :
+            is(is),
+            str(str)
+        {
+        }
+        virtual ~QPDFWordTokenFinder() = default;
+        virtual bool check();
 
-  private:
-    std::shared_ptr<InputSource> is;
-    std::string str;
-};
+      private:
+        std::shared_ptr<InputSource> is;
+        std::string str;
+    };
+} // namespace
 
 bool
 QPDFWordTokenFinder::check()

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -19,38 +19,42 @@
 
 #include <stdexcept>
 
-class SF_Crypt: public QPDFStreamFilter
+namespace
 {
-  public:
-    SF_Crypt() = default;
-    virtual ~SF_Crypt() = default;
-
-    virtual bool
-    setDecodeParms(QPDFObjectHandle decode_parms)
+    class SF_Crypt: public QPDFStreamFilter
     {
-        if (decode_parms.isNull()) {
-            return true;
-        }
-        bool filterable = true;
-        for (auto const& key : decode_parms.getKeys()) {
-            if (((key == "/Type") || (key == "/Name")) &&
-                ((!decode_parms.hasKey("/Type")) ||
-                 decode_parms.isDictionaryOfType("/CryptFilterDecodeParms"))) {
-                // we handle this in decryptStream
-            } else {
-                filterable = false;
+      public:
+        SF_Crypt() = default;
+        virtual ~SF_Crypt() = default;
+
+        virtual bool
+        setDecodeParms(QPDFObjectHandle decode_parms)
+        {
+            if (decode_parms.isNull()) {
+                return true;
             }
+            bool filterable = true;
+            for (auto const& key : decode_parms.getKeys()) {
+                if (((key == "/Type") || (key == "/Name")) &&
+                    ((!decode_parms.hasKey("/Type")) ||
+                     decode_parms.isDictionaryOfType(
+                         "/CryptFilterDecodeParms"))) {
+                    // we handle this in decryptStream
+                } else {
+                    filterable = false;
+                }
+            }
+            return filterable;
         }
-        return filterable;
-    }
 
-    virtual Pipeline*
-    getDecodePipeline(Pipeline*)
-    {
-        // Not used -- handled by pipeStreamData
-        return nullptr;
-    }
-};
+        virtual Pipeline*
+        getDecodePipeline(Pipeline*)
+        {
+            // Not used -- handled by pipeStreamData
+            return nullptr;
+        }
+    };
+} // namespace
 
 std::map<std::string, std::string> QPDF_Stream::filter_abbreviations = {
     // The PDF specification provides these filter abbreviations for

--- a/libqpdf/QUtil.cc
+++ b/libqpdf/QUtil.cc
@@ -251,22 +251,25 @@ static unsigned short mac_roman_to_unicode[] = {
     0x02c7, // 0xff
 };
 
-class FileCloser
+namespace
 {
-  public:
-    FileCloser(FILE* f) :
-        f(f)
+    class FileCloser
     {
-    }
+      public:
+        FileCloser(FILE* f) :
+            f(f)
+        {
+        }
 
-    ~FileCloser()
-    {
-        fclose(f);
-    }
+        ~FileCloser()
+        {
+            fclose(f);
+        }
 
-  private:
-    FILE* f;
-};
+      private:
+        FILE* f;
+    };
+} // namespace
 
 template <typename T>
 static std::string
@@ -1052,17 +1055,20 @@ QUtil::toUTF16(unsigned long uval)
 
 // Random data support
 
-class RandomDataProviderProvider
+namespace
 {
-  public:
-    RandomDataProviderProvider();
-    void setProvider(RandomDataProvider*);
-    RandomDataProvider* getProvider();
+    class RandomDataProviderProvider
+    {
+      public:
+        RandomDataProviderProvider();
+        void setProvider(RandomDataProvider*);
+        RandomDataProvider* getProvider();
 
-  private:
-    RandomDataProvider* default_provider;
-    RandomDataProvider* current_provider;
-};
+      private:
+        RandomDataProvider* default_provider;
+        RandomDataProvider* current_provider;
+    };
+} // namespace
 
 RandomDataProviderProvider::RandomDataProviderProvider() :
     default_provider(CryptoRandomDataProvider::getInstance()),

--- a/libqpdf/SecureRandomDataProvider.cc
+++ b/libqpdf/SecureRandomDataProvider.cc
@@ -31,47 +31,54 @@ SecureRandomDataProvider::getInstance()
 
 # ifdef _WIN32
 
-class WindowsCryptProvider
+namespace
 {
-  public:
-    WindowsCryptProvider()
+    class WindowsCryptProvider
     {
-        if (!CryptAcquireContextW(
-                &crypt_prov, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
-            throw std::runtime_error(
-                "unable to acquire crypt context: " + getErrorMessage());
+      public:
+        WindowsCryptProvider()
+        {
+            if (!CryptAcquireContextW(
+                    &crypt_prov,
+                    NULL,
+                    NULL,
+                    PROV_RSA_FULL,
+                    CRYPT_VERIFYCONTEXT)) {
+                throw std::runtime_error(
+                    "unable to acquire crypt context: " + getErrorMessage());
+            }
         }
-    }
-    ~WindowsCryptProvider()
-    {
-        // Ignore error
-        CryptReleaseContext(crypt_prov, 0);
-    }
+        ~WindowsCryptProvider()
+        {
+            // Ignore error
+            CryptReleaseContext(crypt_prov, 0);
+        }
 
-    HCRYPTPROV crypt_prov;
+        HCRYPTPROV crypt_prov;
 
-  private:
-    std::string
-    getErrorMessage()
-    {
-        DWORD errorMessageID = ::GetLastError();
-        LPSTR messageBuffer = nullptr;
-        size_t size = FormatMessageA(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                FORMAT_MESSAGE_IGNORE_INSERTS,
-            NULL,
-            errorMessageID,
-            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            reinterpret_cast<LPSTR>(&messageBuffer),
-            0,
-            NULL);
-        std::string message(messageBuffer, size);
-        LocalFree(messageBuffer);
-        return (
-            "error number " + QUtil::int_to_string_base(errorMessageID, 16) +
-            ": " + message);
-    }
-};
+      private:
+        std::string
+        getErrorMessage()
+        {
+            DWORD errorMessageID = ::GetLastError();
+            LPSTR messageBuffer = nullptr;
+            size_t size = FormatMessageA(
+                FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                    FORMAT_MESSAGE_IGNORE_INSERTS,
+                NULL,
+                errorMessageID,
+                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                reinterpret_cast<LPSTR>(&messageBuffer),
+                0,
+                NULL);
+            std::string message(messageBuffer, size);
+            LocalFree(messageBuffer);
+            return (
+                "error number " +
+                QUtil::int_to_string_base(errorMessageID, 16) + ": " + message);
+        }
+    };
+} // namespace
 # endif
 
 void

--- a/libqpdf/qpdf-c.cc
+++ b/libqpdf/qpdf-c.cc
@@ -60,17 +60,20 @@ _qpdf_data::_qpdf_data() :
 {
 }
 
-class ProgressReporter: public QPDFWriter::ProgressReporter
+namespace
 {
-  public:
-    ProgressReporter(void (*handler)(int, void*), void* data);
-    virtual ~ProgressReporter() = default;
-    virtual void reportProgress(int);
+    class ProgressReporter: public QPDFWriter::ProgressReporter
+    {
+      public:
+        ProgressReporter(void (*handler)(int, void*), void* data);
+        virtual ~ProgressReporter() = default;
+        virtual void reportProgress(int);
 
-  private:
-    void (*handler)(int, void*);
-    void* data;
-};
+      private:
+        void (*handler)(int, void*);
+        void* data;
+    };
+} // namespace
 
 ProgressReporter::ProgressReporter(void (*handler)(int, void*), void* data) :
     handler(handler),

--- a/libqpdf/qpdf/NNTree.hh
+++ b/libqpdf/qpdf/NNTree.hh
@@ -97,10 +97,9 @@ class NNTreeImpl
   public:
     typedef NNTreeIterator iterator;
 
-    // ABI: for qpdf 11, make qpdf a reference
     NNTreeImpl(
         NNTreeDetails const&,
-        QPDF*,
+        QPDF&,
         QPDFObjectHandle&,
         bool auto_repair = true);
     iterator begin();
@@ -132,7 +131,7 @@ class NNTreeImpl
     int compareKeyKid(QPDFObjectHandle& key, QPDFObjectHandle& items, int idx);
 
     NNTreeDetails const& details;
-    QPDF* qpdf;
+    QPDF& qpdf;
     int split_threshold;
     QPDFObjectHandle oh;
     bool auto_repair;

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -64,6 +64,11 @@ For a detailed list of changes, please see the file
 
   - API: breaking changes
 
+    - Remove
+      ``QPDFAcroFormDocumentHelper::copyFieldsFromForeignPage``. This
+      method never worked and only did something in qpdf version
+      10.2.x.
+
   - Other changes
 
     - A new chapter on contributing to qpdf has been added to the

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -69,6 +69,10 @@ For a detailed list of changes, please see the file
       method never worked and only did something in qpdf version
       10.2.x.
 
+    - Remove ``QPDFNameTreeObjectHelper`` and
+      ``QPDFNumberTreeObjectHelper`` constructors that don't take a
+      ``QPDF&`` argument.
+
   - Other changes
 
     - A new chapter on contributing to qpdf has been added to the

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -57,6 +57,13 @@ For a detailed list of changes, please see the file
 	``autopkgtest`` framework but can be used by others. See
 	:file:`pkg-test/README.md` for details.
 
+  - CLI: breaking changes
+
+    - The default json output version when :qpdf:ref:`--json` is
+      specified has been changed from ``1`` to ``latest``.
+
+  - API: breaking changes
+
   - Other changes
 
     - A new chapter on contributing to qpdf has been added to the

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -6,47 +6,65 @@ Release Notes
 For a detailed list of changes, please see the file
 :file:`ChangeLog` in the source distribution.
 
-10.6.3 + cmake: March 19, 2022
-  - This is an unofficial release and is marked as "pre-release" at
-    github. It is intended for developers and packagers who want to
-    test out the new build system.
+11.0.0
+  - Replacement of ``PointerHolder`` with ``std::shared_ptr``
 
-  - The old autoconf-based build has been replaced with CMake. Version
-    3.16 or newer is required. For all the details, please read
-    :ref:`installing` and, if you package qpdf for a distribution,
-    :ref:`packaging`.
+    - The qpdf-specific ``PointerHolder`` smart pointer implementation
+      has now been completely replaced with ``std::shared_ptr``
+      through the qpdf API. Please see :ref:`smart-pointers` for
+      details about this change and a comprehensive migration plan.
+      Note that a backward-compatible ``PointerHolder`` class is
+      provided and is enabled by default. A warning is issued, but
+      this can be turned off by following the migration steps outlined
+      in the manual.
 
-  - For the most part, other than being familiar with generally how to
-    build things with cmake, what you need to know to convert your
-    build over is described in :ref:`autoconf-to-cmake`. Here are a
-    few changes in behavior to be aware of:
+  - Build replaced with cmake
 
-    - Example sources are installed by default in the documentation
-      directory.
+    - The old autoconf-based build has been replaced with CMake. Version
+      3.16 or newer is required. For all the details, please read
+      :ref:`installing` and, if you package qpdf for a distribution,
+      :ref:`packaging`.
 
-    - The configure options to enable image comparison and large file
-      tests have been replaced by environment variables. The old
-      options set environment variables behind the scenes. Before, to
-      skip image tests, you had to set
-      ``QPDF_SKIP_TEST_COMPARE_IMAGES=1``, which was done by default.
-      Now these are off by default, and you have to set
-      ``QPDF_TEST_COMPARE_IMAGES=1`` to enable them.
+    - For the most part, other than being familiar with generally how to
+      build things with cmake, what you need to know to convert your
+      build over is described in :ref:`autoconf-to-cmake`. Here are a
+      few changes in behavior to be aware of:
 
-    - In the default configuration, the native crypto provider is only
-      selected when explicitly requested or when there are no other
-      options. See :ref:`crypto.build` for a detailed discussion.
+      - Example sources are installed by default in the documentation
+	directory.
 
-    - Windows external libraries are detected by default if the
-      :file:`external-libraries` directory is found. Static libraries
-      for zlib, libjpeg, and openssl are provided as described in
-      :file:`README-windows.md`. They are only compatible with
-      non-debug builds.
+      - The configure options to enable image comparison and large file
+	tests have been replaced by environment variables. The old
+	options set environment variables behind the scenes. Before, to
+	skip image tests, you had to set
+	``QPDF_SKIP_TEST_COMPARE_IMAGES=1``, which was done by default.
+	Now these are off by default, and you have to set
+	``QPDF_TEST_COMPARE_IMAGES=1`` to enable them.
 
-    - A new directory called ``pkg-tests`` has been added which
-      contains short shell scripts that can be used to smoke test an
-      installed qpdf package. These are used by the debian
-      ``autopkgtest`` framework but can be used by others. See
-      :file:`pkg-test/README.md` for details.
+      - In the default configuration, the native crypto provider is only
+	selected when explicitly requested or when there are no other
+	options. See :ref:`crypto.build` for a detailed discussion.
+
+      - Windows external libraries are detected by default if the
+	:file:`external-libraries` directory is found. Static libraries
+	for zlib, libjpeg, and openssl are provided as described in
+	:file:`README-windows.md`. They are only compatible with
+	non-debug builds.
+
+      - A new directory called ``pkg-tests`` has been added which
+	contains short shell scripts that can be used to smoke test an
+	installed qpdf package. These are used by the debian
+	``autopkgtest`` framework but can be used by others. See
+	:file:`pkg-test/README.md` for details.
+
+  - Other changes
+
+    - A new chapter on contributing to qpdf has been added to the
+      documentation. See :ref:`contributing`.
+
+    - The qpdf source code is now formatted automatically with
+      ``clang-format``. See :ref:`code-formatting` for information.
+
 
 10.6.3: March 8, 2022
   - Announcement of upcoming change:

--- a/qpdf/qtest/qpdf/name-tree.out
+++ b/qpdf/qtest/qpdf/name-tree.out
@@ -21,8 +21,6 @@ insertAfter
 4 (4!)
 /Empty1
 /Empty2
-/Bad1: deprecated API
-Name/Number tree node (object 16): item at index 2 is not the right type
 /Bad1 -- wrong key type
 WARNING: name-tree.pdf (Name/Number tree node (object 16)): attempting to repair after error: name-tree.pdf (Name/Number tree node (object 16)): item at index 2 is not the right type
 WARNING: name-tree.pdf (Name/Number tree node (object 16)): item 2 has the wrong type

--- a/qpdf/qtest/qpdf/number-tree.out
+++ b/qpdf/qtest/qpdf/number-tree.out
@@ -29,7 +29,6 @@
 insertAfter
 3 (3!)
 4 (4!)
-/Bad1: deprecated API
 /Bad1
 WARNING: number-tree.pdf (Name/Number tree node (object 14)): name/number tree node has neither non-empty /Nums nor /Kids
 WARNING: number-tree.pdf (Name/Number tree node (object 13)): loop detected while traversing name/number tree

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1733,23 +1733,8 @@ test_46(QPDF& pdf, char const* arg2)
         std::cout << i.first << " " << i.second.unparse() << std::endl;
     }
 
-    // Exercise deprecated API until qpdf 11
-    std::cout << "/Bad1: deprecated API" << std::endl;
-#ifdef _MSC_VER
-# pragma warning(disable : 4996)
-#endif
-#if (defined(__GNUC__) || defined(__clang__))
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    auto bad1 = QPDFNumberTreeObjectHelper(pdf.getTrailer().getKey("/Bad1"));
-#if (defined(__GNUC__) || defined(__clang__))
-# pragma GCC diagnostic pop
-#endif
-    assert(bad1.begin() == bad1.end());
-
     std::cout << "/Bad1" << std::endl;
-    bad1 = QPDFNumberTreeObjectHelper(pdf.getTrailer().getKey("/Bad1"), pdf);
+    auto bad1 = QPDFNumberTreeObjectHelper(pdf.getTrailer().getKey("/Bad1"), pdf);
     assert(bad1.begin() == bad1.end());
     assert(bad1.last() == bad1.end());
 
@@ -1931,28 +1916,8 @@ test_48(QPDF& pdf, char const* arg2)
         assert(empty.last()->second.getStringValue() == "6");
     }
 
-    // Exercise deprecated API until qpdf 11
-    std::cout << "/Bad1: deprecated API" << std::endl;
-#ifdef _MSC_VER
-# pragma warning(disable : 4996)
-#endif
-#if (defined(__GNUC__) || defined(__clang__))
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    auto bad1 = QPDFNameTreeObjectHelper(pdf.getTrailer().getKey("/Bad1"));
-#if (defined(__GNUC__) || defined(__clang__))
-# pragma GCC diagnostic pop
-#endif
-    try {
-        bad1.find("G", true);
-        assert(false);
-    } catch (std::runtime_error& e) {
-        std::cout << e.what() << std::endl;
-    }
-
     std::cout << "/Bad1 -- wrong key type" << std::endl;
-    bad1 = QPDFNameTreeObjectHelper(pdf.getTrailer().getKey("/Bad1"), pdf);
+    auto bad1 = QPDFNameTreeObjectHelper(pdf.getTrailer().getKey("/Bad1"), pdf);
     assert(bad1.find("G", true)->first == "A");
     for (auto const& i : bad1) {
         std::cout << i.first << std::endl;


### PR DESCRIPTION
Use anonymous namespaces for file-local classes where possible to avoid potential name clashes.