### PR TITLE
Refactor QPDFObject creation and cloning

### DIFF
--- a/include/qpdf/QPDFObject.hh
+++ b/include/qpdf/QPDFObject.hh
@@ -63,6 +63,7 @@ class QPDFObject
     static constexpr object_type_e ot_inlineimage = ::ot_inlineimage;
 
     virtual ~QPDFObject() = default;
+    virtual std::shared_ptr<QPDFObject> shallowCopy() = 0;
     virtual std::string unparse() = 0;
     virtual JSON getJSON(int json_version) = 0;
 
@@ -102,6 +103,7 @@ class QPDFObject
     releaseResolved()
     {
     }
+    static std::shared_ptr<QPDFObject> do_create(QPDFObject*);
 
   private:
     QPDFObject(QPDFObject const&) = delete;

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1551,7 +1551,7 @@ class QPDFObjectHandle
 
   private:
     QPDFObjectHandle(QPDF*, int objid, int generation);
-    QPDFObjectHandle(QPDFObject*);
+    QPDFObjectHandle(std::shared_ptr<QPDFObject> const&);
 
     enum parser_state_e {
         st_top,

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1989,7 +1989,7 @@ QPDF::resolve(int objid, int generation)
             this->m->file->getLastOffset(),
             ("loop detected resolving object " + QUtil::int_to_string(objid) +
              " " + QUtil::int_to_string(generation)));
-        return std::shared_ptr<QPDFObject>(new QPDF_Null);
+        return QPDF_Null::create();
     }
     ResolveRecorder rr(this, og);
 

--- a/libqpdf/QPDFObject.cc
+++ b/libqpdf/QPDFObject.cc
@@ -6,6 +6,13 @@ QPDFObject::QPDFObject() :
 {
 }
 
+std::shared_ptr<QPDFObject>
+QPDFObject::do_create(QPDFObject* object)
+{
+    std::shared_ptr<QPDFObject> obj(object);
+    return obj;
+}
+
 void
 QPDFObject::setDescription(QPDF* qpdf, std::string const& description)
 {

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -14,6 +14,24 @@ QPDF_Array::QPDF_Array(SparseOHArray const& items) :
 {
 }
 
+std::shared_ptr<QPDFObject>
+QPDF_Array::create(std::vector<QPDFObjectHandle> const& items)
+{
+    return do_create(new QPDF_Array(items));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Array::create(SparseOHArray const& items)
+{
+    return do_create(new QPDF_Array(items));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Array::shallowCopy()
+{
+    return create(elements);
+}
+
 void
 QPDF_Array::releaseResolved()
 {
@@ -119,12 +137,6 @@ void
 QPDF_Array::eraseItem(int at)
 {
     this->elements.erase(QIntC::to_size(at));
-}
-
-SparseOHArray const&
-QPDF_Array::getElementsForShallowCopy() const
-{
-    return this->elements;
 }
 
 void

--- a/libqpdf/QPDF_Bool.cc
+++ b/libqpdf/QPDF_Bool.cc
@@ -5,6 +5,18 @@ QPDF_Bool::QPDF_Bool(bool val) :
 {
 }
 
+std::shared_ptr<QPDFObject>
+QPDF_Bool::create(bool value)
+{
+    return do_create(new QPDF_Bool(value));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Bool::shallowCopy()
+{
+    return create(val);
+}
+
 std::string
 QPDF_Bool::unparse()
 {

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -9,6 +9,18 @@ QPDF_Dictionary::QPDF_Dictionary(
 {
 }
 
+std::shared_ptr<QPDFObject>
+QPDF_Dictionary::create(std::map<std::string, QPDFObjectHandle> const& items)
+{
+    return do_create(new QPDF_Dictionary(items));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Dictionary::shallowCopy()
+{
+    return create(items);
+}
+
 void
 QPDF_Dictionary::releaseResolved()
 {

--- a/libqpdf/QPDF_InlineImage.cc
+++ b/libqpdf/QPDF_InlineImage.cc
@@ -1,10 +1,20 @@
 #include <qpdf/QPDF_InlineImage.hh>
 
-#include <qpdf/QUtil.hh>
-
 QPDF_InlineImage::QPDF_InlineImage(std::string const& val) :
     val(val)
 {
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_InlineImage::create(std::string const& val)
+{
+    return do_create(new QPDF_InlineImage(val));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_InlineImage::shallowCopy()
+{
+    return create(val);
 }
 
 std::string

--- a/libqpdf/QPDF_Integer.cc
+++ b/libqpdf/QPDF_Integer.cc
@@ -7,6 +7,18 @@ QPDF_Integer::QPDF_Integer(long long val) :
 {
 }
 
+std::shared_ptr<QPDFObject>
+QPDF_Integer::create(long long value)
+{
+    return do_create(new QPDF_Integer(value));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Integer::shallowCopy()
+{
+    return create(val);
+}
+
 std::string
 QPDF_Integer::unparse()
 {

--- a/libqpdf/QPDF_Name.cc
+++ b/libqpdf/QPDF_Name.cc
@@ -9,6 +9,18 @@ QPDF_Name::QPDF_Name(std::string const& name) :
 {
 }
 
+std::shared_ptr<QPDFObject>
+QPDF_Name::create(std::string const& name)
+{
+    return do_create(new QPDF_Name(name));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Name::shallowCopy()
+{
+    return create(name);
+}
+
 std::string
 QPDF_Name::normalizeName(std::string const& name)
 {

--- a/libqpdf/QPDF_Null.cc
+++ b/libqpdf/QPDF_Null.cc
@@ -1,5 +1,17 @@
 #include <qpdf/QPDF_Null.hh>
 
+std::shared_ptr<QPDFObject>
+QPDF_Null::create()
+{
+    return do_create(new QPDF_Null());
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Null::shallowCopy()
+{
+    return create();
+}
+
 std::string
 QPDF_Null::unparse()
 {

--- a/libqpdf/QPDF_Operator.cc
+++ b/libqpdf/QPDF_Operator.cc
@@ -1,10 +1,20 @@
 #include <qpdf/QPDF_Operator.hh>
 
-#include <qpdf/QUtil.hh>
-
 QPDF_Operator::QPDF_Operator(std::string const& val) :
     val(val)
 {
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Operator::create(std::string const& val)
+{
+    return do_create(new QPDF_Operator(val));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Operator::shallowCopy()
+{
+    return create(val);
 }
 
 std::string

--- a/libqpdf/QPDF_Real.cc
+++ b/libqpdf/QPDF_Real.cc
@@ -13,6 +13,25 @@ QPDF_Real::QPDF_Real(
 {
 }
 
+std::shared_ptr<QPDFObject>
+QPDF_Real::create(std::string const& val)
+{
+    return do_create(new QPDF_Real(val));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Real::create(double value, int decimal_places, bool trim_trailing_zeroes)
+{
+    return do_create(
+        new QPDF_Real(value, decimal_places, trim_trailing_zeroes));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Real::shallowCopy()
+{
+    return create(val);
+}
+
 std::string
 QPDF_Real::unparse()
 {

--- a/libqpdf/QPDF_Reserved.cc
+++ b/libqpdf/QPDF_Reserved.cc
@@ -2,6 +2,18 @@
 
 #include <stdexcept>
 
+std::shared_ptr<QPDFObject>
+QPDF_Reserved::create()
+{
+    return do_create(new QPDF_Reserved());
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Reserved::shallowCopy()
+{
+    return create();
+}
+
 std::string
 QPDF_Reserved::unparse()
 {

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -134,6 +134,25 @@ QPDF_Stream::QPDF_Stream(
             QUtil::int_to_string(this->generation));
 }
 
+std::shared_ptr<QPDFObject>
+QPDF_Stream::create(
+    QPDF* qpdf,
+    int objid,
+    int generation,
+    QPDFObjectHandle stream_dict,
+    qpdf_offset_t offset,
+    size_t length)
+{
+    return do_create(
+        new QPDF_Stream(qpdf, objid, generation, stream_dict, offset,length));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Stream::shallowCopy()
+{
+    throw std::logic_error("stream objects cannot be cloned");
+}
+
 void
 QPDF_Stream::registerStreamFilter(
     std::string const& filter_name,

--- a/libqpdf/QPDF_String.cc
+++ b/libqpdf/QPDF_String.cc
@@ -1,6 +1,5 @@
 #include <qpdf/QPDF_String.hh>
 
-#include <qpdf/QTC.hh>
 #include <qpdf/QUtil.hh>
 
 // DO NOT USE ctype -- it is locale dependent for some things, and
@@ -26,14 +25,26 @@ QPDF_String::QPDF_String(std::string const& val) :
 {
 }
 
-QPDF_String*
-QPDF_String::new_utf16(std::string const& utf8_val)
+std::shared_ptr<QPDFObject>
+QPDF_String::create(std::string const& val)
+{
+    return do_create(new QPDF_String(val));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_String::create_utf16(std::string const& utf8_val)
 {
     std::string result;
     if (!QUtil::utf8_to_pdf_doc(utf8_val, result, '?')) {
         result = QUtil::utf8_to_utf16(utf8_val);
     }
-    return new QPDF_String(result);
+    return do_create(new QPDF_String(result));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_String::shallowCopy()
+{
+    return create(val);
 }
 
 std::string

--- a/libqpdf/qpdf/QPDF_Array.hh
+++ b/libqpdf/qpdf/QPDF_Array.hh
@@ -10,9 +10,10 @@
 class QPDF_Array: public QPDFObject
 {
   public:
-    QPDF_Array(std::vector<QPDFObjectHandle> const& items);
-    QPDF_Array(SparseOHArray const& items);
     virtual ~QPDF_Array() = default;
+    static std::shared_ptr<QPDFObject> create(std::vector<QPDFObjectHandle> const& items);
+    static std::shared_ptr<QPDFObject> create(SparseOHArray const& items);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -31,13 +32,14 @@ class QPDF_Array: public QPDFObject
     // Helper methods for QPDF and QPDFObjectHandle -- these are
     // public methods since the whole class is not part of the public
     // API. Otherwise, these would be wrapped in accessor classes.
-    SparseOHArray const& getElementsForShallowCopy() const;
     void addExplicitElementsToList(std::list<QPDFObjectHandle>&) const;
 
   protected:
     virtual void releaseResolved();
 
   private:
+    QPDF_Array(std::vector<QPDFObjectHandle> const& items);
+    QPDF_Array(SparseOHArray const& items);
     SparseOHArray elements;
 };
 

--- a/libqpdf/qpdf/QPDF_Bool.hh
+++ b/libqpdf/qpdf/QPDF_Bool.hh
@@ -6,8 +6,9 @@
 class QPDF_Bool: public QPDFObject
 {
   public:
-    QPDF_Bool(bool val);
     virtual ~QPDF_Bool() = default;
+    static std::shared_ptr<QPDFObject> create(bool val);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -15,6 +16,7 @@ class QPDF_Bool: public QPDFObject
     bool getVal() const;
 
   private:
+    QPDF_Bool(bool val);
     bool val;
 };
 

--- a/libqpdf/qpdf/QPDF_Dictionary.hh
+++ b/libqpdf/qpdf/QPDF_Dictionary.hh
@@ -11,8 +11,9 @@
 class QPDF_Dictionary: public QPDFObject
 {
   public:
-    QPDF_Dictionary(std::map<std::string, QPDFObjectHandle> const& items);
     virtual ~QPDF_Dictionary() = default;
+    static std::shared_ptr<QPDFObject> create(std::map<std::string, QPDFObjectHandle> const& items);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -36,6 +37,7 @@ class QPDF_Dictionary: public QPDFObject
     virtual void releaseResolved();
 
   private:
+    QPDF_Dictionary(std::map<std::string, QPDFObjectHandle> const& items);
     std::map<std::string, QPDFObjectHandle> items;
 };
 

--- a/libqpdf/qpdf/QPDF_InlineImage.hh
+++ b/libqpdf/qpdf/QPDF_InlineImage.hh
@@ -6,8 +6,9 @@
 class QPDF_InlineImage: public QPDFObject
 {
   public:
-    QPDF_InlineImage(std::string const& val);
     virtual ~QPDF_InlineImage() = default;
+    static std::shared_ptr<QPDFObject> create(std::string const& val);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -15,6 +16,7 @@ class QPDF_InlineImage: public QPDFObject
     std::string getVal() const;
 
   private:
+    QPDF_InlineImage(std::string const& val);
     std::string val;
 };
 

--- a/libqpdf/qpdf/QPDF_Integer.hh
+++ b/libqpdf/qpdf/QPDF_Integer.hh
@@ -6,8 +6,9 @@
 class QPDF_Integer: public QPDFObject
 {
   public:
-    QPDF_Integer(long long val);
     virtual ~QPDF_Integer() = default;
+    static std::shared_ptr<QPDFObject> create(long long value);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -15,6 +16,7 @@ class QPDF_Integer: public QPDFObject
     long long getVal() const;
 
   private:
+    QPDF_Integer(long long val);
     long long val;
 };
 

--- a/libqpdf/qpdf/QPDF_Name.hh
+++ b/libqpdf/qpdf/QPDF_Name.hh
@@ -6,8 +6,9 @@
 class QPDF_Name: public QPDFObject
 {
   public:
-    QPDF_Name(std::string const& name);
     virtual ~QPDF_Name() = default;
+    static std::shared_ptr<QPDFObject> create(std::string const& name);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -18,6 +19,7 @@ class QPDF_Name: public QPDFObject
     static std::string normalizeName(std::string const& name);
 
   private:
+    QPDF_Name(std::string const& name);
     std::string name;
 };
 

--- a/libqpdf/qpdf/QPDF_Null.hh
+++ b/libqpdf/qpdf/QPDF_Null.hh
@@ -7,10 +7,14 @@ class QPDF_Null: public QPDFObject
 {
   public:
     virtual ~QPDF_Null() = default;
+    static std::shared_ptr<QPDFObject> create();
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
     virtual char const* getTypeName() const;
+  private:
+    QPDF_Null() = default;
 };
 
 #endif // QPDF_NULL_HH

--- a/libqpdf/qpdf/QPDF_Operator.hh
+++ b/libqpdf/qpdf/QPDF_Operator.hh
@@ -6,8 +6,9 @@
 class QPDF_Operator: public QPDFObject
 {
   public:
-    QPDF_Operator(std::string const& val);
     virtual ~QPDF_Operator() = default;
+    static std::shared_ptr<QPDFObject> create(std::string const& val);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -15,6 +16,7 @@ class QPDF_Operator: public QPDFObject
     std::string getVal() const;
 
   private:
+    QPDF_Operator(std::string const& val);
     std::string val;
 };
 

--- a/libqpdf/qpdf/QPDF_Real.hh
+++ b/libqpdf/qpdf/QPDF_Real.hh
@@ -6,9 +6,11 @@
 class QPDF_Real: public QPDFObject
 {
   public:
-    QPDF_Real(std::string const& val);
-    QPDF_Real(double value, int decimal_places, bool trim_trailing_zeroes);
     virtual ~QPDF_Real() = default;
+    static std::shared_ptr<QPDFObject> create(std::string const& val);
+    static std::shared_ptr<QPDFObject> create(
+        double value, int decimal_places, bool trim_trailing_zeroes);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -16,6 +18,8 @@ class QPDF_Real: public QPDFObject
     std::string getVal();
 
   private:
+    QPDF_Real(std::string const& val);
+    QPDF_Real(double value, int decimal_places, bool trim_trailing_zeroes);
     // Store reals as strings to avoid roundoff errors.
     std::string val;
 };

--- a/libqpdf/qpdf/QPDF_Reserved.hh
+++ b/libqpdf/qpdf/QPDF_Reserved.hh
@@ -7,10 +7,14 @@ class QPDF_Reserved: public QPDFObject
 {
   public:
     virtual ~QPDF_Reserved() = default;
+    static std::shared_ptr<QPDFObject> create();
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
     virtual char const* getTypeName() const;
+  private:
+    QPDF_Reserved() = default;
 };
 
 #endif // QPDF_RESERVED_HH

--- a/libqpdf/qpdf/QPDF_Stream.hh
+++ b/libqpdf/qpdf/QPDF_Stream.hh
@@ -16,14 +16,15 @@ class QPDF;
 class QPDF_Stream: public QPDFObject
 {
   public:
-    QPDF_Stream(
+    virtual ~QPDF_Stream() = default;
+    static std::shared_ptr<QPDFObject> create(
         QPDF*,
         int objid,
         int generation,
         QPDFObjectHandle stream_dict,
         qpdf_offset_t offset,
         size_t length);
-    virtual ~QPDF_Stream() = default;
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual QPDFObject::object_type_e getTypeCode() const;
@@ -83,6 +84,13 @@ class QPDF_Stream: public QPDFObject
     virtual void releaseResolved();
 
   private:
+    QPDF_Stream(
+        QPDF*,
+        int objid,
+        int generation,
+        QPDFObjectHandle stream_dict,
+        qpdf_offset_t offset,
+        size_t length);
     static std::map<std::string, std::string> filter_abbreviations;
     static std::
         map<std::string, std::function<std::shared_ptr<QPDFStreamFilter>()>>

--- a/libqpdf/qpdf/QPDF_String.hh
+++ b/libqpdf/qpdf/QPDF_String.hh
@@ -7,10 +7,13 @@
 
 class QPDF_String: public QPDFObject
 {
+    friend class QPDFWriter;
+
   public:
-    QPDF_String(std::string const& val);
-    static QPDF_String* new_utf16(std::string const& utf8_val);
     virtual ~QPDF_String() = default;
+    static std::shared_ptr<QPDFObject> create(std::string const& val);
+    static std::shared_ptr<QPDFObject> create_utf16(std::string const& utf8_val);
+    virtual std::shared_ptr<QPDFObject> shallowCopy();
     virtual std::string unparse();
     virtual QPDFObject::object_type_e getTypeCode() const;
     virtual char const* getTypeName() const;
@@ -20,6 +23,7 @@ class QPDF_String: public QPDFObject
     std::string getUTF8Val() const;
 
   private:
+    QPDF_String(std::string const& val);
     bool useHexString() const;
     std::string val;
 };

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -70,14 +70,6 @@ QPDFTokenizer null in name 0
 QPDFTokenizer bad name 0
 QPDF_Stream invalid filter 0
 QPDF UseOutlines but no Outlines 0
-QPDFObjectHandle clone bool 0
-QPDFObjectHandle clone null 0
-QPDFObjectHandle clone integer 0
-QPDFObjectHandle clone real 0
-QPDFObjectHandle clone name 0
-QPDFObjectHandle clone string 0
-QPDFObjectHandle clone array 0
-QPDFObjectHandle clone dictionary 0
 QPDFObjectHandle makeDirect loop 0
 QPDFObjectHandle copy stream 1
 QPDF default for xref stream field 0 0
@@ -199,9 +191,6 @@ QPDF updateAllPagesCache 0
 QPDF insert non-indirect page 0
 QPDF insert indirect page 0
 QPDFObjectHandle ERR shallow copy stream 0
-QPDFObjectHandle shallow copy array 0
-QPDFObjectHandle shallow copy dictionary 0
-QPDFObjectHandle shallow copy scalar 0
 QPDFObjectHandle newStream with string 0
 QPDF unknown key not inherited 0
 QPDF_Stream provider length not provided 0


### PR DESCRIPTION
Move responsibility for creating shared pointers to objects and cloning from QPDFObjectHandle to QPDFObject.