### PR TITLE
Code tidy: remove unnecessary parameter in QPDFObjectHandle::shallowC…

### DIFF
--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1579,7 +1579,7 @@ class QPDFObjectHandle
         bool cross_indirect,
         bool first_level_only,
         bool stop_at_streams);
-    void shallowCopyInternal(QPDFObjectHandle& oh, bool first_level_only);
+    QPDFObjectHandle shallowCopy(bool first_level_only);
     void releaseResolved();
     static void setObjectDescriptionFromInput(
         QPDFObjectHandle,

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -2804,25 +2804,20 @@ QPDFObjectHandle::hasObjectDescription()
 QPDFObjectHandle
 QPDFObjectHandle::shallowCopy()
 {
-    QPDFObjectHandle result;
-    shallowCopyInternal(result, false);
-    return result;
+    return shallowCopy(false);
 }
 
 QPDFObjectHandle
 QPDFObjectHandle::unsafeShallowCopy()
 {
-    QPDFObjectHandle result;
-    shallowCopyInternal(result, true);
-    return result;
+    return shallowCopy(true);
 }
 
-void
-QPDFObjectHandle::shallowCopyInternal(
-    QPDFObjectHandle& new_obj, bool first_level_only)
+QPDFObjectHandle
+QPDFObjectHandle::shallowCopy(bool first_level_only)
 {
     assertInitialized();
-
+    QPDFObjectHandle new_obj;
     if (isStream()) {
         QTC::TC("qpdf", "QPDFObjectHandle ERR shallow copy stream");
         throw std::runtime_error("attempt to make a shallow copy of a stream");
@@ -2844,6 +2839,7 @@ QPDFObjectHandle::shallowCopyInternal(
 
     std::set<QPDFObjGen> visited;
     new_obj.copyObject(visited, false, first_level_only, false);
+    return new_obj;
 }
 
 void


### PR DESCRIPTION
…opyInternal and rename shallowCopy



(change to  shallowCopy(bool first_level_only = false) for qpdf11?)