### PR TITLE
Clarify intent in readObjectAtOffset

### DIFF
--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -328,7 +328,7 @@ QPDF::readHintStream(Pipeline& pl, qpdf_offset_t offset, size_t length)
     int obj;
     int gen;
     QPDFObjectHandle H = readObjectAtOffset(
-        false, offset, "linearization hint stream", -1, 0, obj, gen);
+        false, offset, "linearization hint stream", 0, 0, obj, gen);
     ObjCache& oc = this->m->obj_cache[QPDFObjGen(obj, gen)];
     qpdf_offset_t min_end_offset = oc.end_before_space;
     qpdf_offset_t max_end_offset = oc.end_after_space;


### PR DESCRIPTION
Rather than using object id -1 to mean "don't care", use object ID 0,
and clarify the difference between that use and indication of a direct
object.

@m-holger This is the commit I refer to in the comments on #731.