### PR TITLE
Inline QPDFObjectHandle::getObjGen etc

### DIFF
--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -319,7 +319,7 @@ class QPDFObjectHandle
     QPDF_DLL
     QPDFObjectHandle& operator=(QPDFObjectHandle const&) = default;
     QPDF_DLL
-    bool isInitialized() const;
+    inline bool isInitialized() const;
 
     // Return type code and type name of underlying object.  These are
     // useful for doing rapid type tests (like switch statements) or
@@ -367,7 +367,7 @@ class QPDFObjectHandle
     // This returns true in addition to the query for the specific
     // type for indirect objects.
     QPDF_DLL
-    bool isIndirect();
+    inline bool isIndirect() const;
 
     // True for everything except array, dictionary, stream, word, and
     // inline image.
@@ -1300,11 +1300,11 @@ class QPDFObjectHandle
     // QPDFObjGen instead.
 
     QPDF_DLL
-    QPDFObjGen getObjGen() const;
+    inline QPDFObjGen getObjGen() const;
     QPDF_DLL
-    int getObjectID() const;
+    inline int getObjectID() const;
     QPDF_DLL
-    int getGeneration() const;
+    inline int getGeneration() const;
 
     QPDF_DLL
     std::string unparse();
@@ -1845,5 +1845,35 @@ class QPDFObjectHandle::QPDFArrayItems
   private:
     QPDFObjectHandle oh;
 };
+
+inline QPDFObjGen
+QPDFObjectHandle::getObjGen() const
+{
+    return og;
+}
+
+inline int
+QPDFObjectHandle::getObjectID() const
+{
+    return og.getObj();
+}
+
+inline int
+QPDFObjectHandle::getGeneration() const
+{
+    return og.getGen();
+}
+
+inline bool
+QPDFObjectHandle::isIndirect() const
+{
+    return initialized && (getObjectID() != 0);
+}
+
+inline bool
+QPDFObjectHandle::isInitialized() const
+{
+    return initialized;
+}
 
 #endif // QPDFOBJECTHANDLE_HH

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -286,12 +286,6 @@ QPDFObjectHandle::setObjectDescriptionFromInput(
          QUtil::int_to_string(offset)));
 }
 
-bool
-QPDFObjectHandle::isInitialized() const
-{
-    return this->initialized;
-}
-
 QPDFObject::object_type_e
 QPDFObjectHandle::getTypeCode()
 {
@@ -432,12 +426,6 @@ QPDFObjectHandle::isReserved()
 {
     // dereference will clear reserved if this has been replaced
     return dereference() && this->reserved;
-}
-
-bool
-QPDFObjectHandle::isIndirect()
-{
-    return this->initialized && (getObjectID() != 0);
 }
 
 bool
@@ -1497,24 +1485,6 @@ QPDFObjectHandle::replaceStreamData(
         std::shared_ptr<StreamDataProvider>(new FunctionProvider(provider));
     dynamic_cast<QPDF_Stream*>(obj.get())->replaceStreamData(
         sdp, filter, decode_parms);
-}
-
-QPDFObjGen
-QPDFObjectHandle::getObjGen() const
-{
-    return og;
-}
-
-int
-QPDFObjectHandle::getObjectID() const
-{
-    return og.getObj();
-}
-
-int
-QPDFObjectHandle::getGeneration() const
-{
-    return og.getGen();
 }
 
 std::map<std::string, QPDFObjectHandle>


### PR DESCRIPTION
Also, make QPDFObjectHandle::isIndirect const.

In-lining the methods reduces runtime by somewhere between 1.5% and 2%.