### PR TITLE
Add QPDF::getObject to replace getObjectByObjGen and getObjectByID

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -385,6 +385,10 @@ class QPDF
     // Retrieve an object by object ID and generation.  Returns an
     // indirect reference to it.
     QPDF_DLL
+    QPDFObjectHandle getObject(QPDFObjGen const&);
+    QPDF_DLL
+    QPDFObjectHandle getObject(int objid, int generation);
+    QPDF_DLL
     QPDFObjectHandle getObjectByObjGen(QPDFObjGen const&);
     QPDF_DLL
     QPDFObjectHandle getObjectByID(int objid, int generation);

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2148,7 +2148,7 @@ QPDF::reserveObjectIfNotExists(QPDFObjGen const& og)
         resolve(og);
         replaceObject(og, QPDFObjectHandle::Factory::makeReserved());
     }
-    return getObjectByObjGen(og);
+    return getObject(og);
 }
 
 QPDFObjectHandle
@@ -2159,15 +2159,27 @@ QPDF::reserveStream(QPDFObjGen const& og)
 }
 
 QPDFObjectHandle
-QPDF::getObjectByObjGen(QPDFObjGen const& og)
+QPDF::getObject(QPDFObjGen const& og)
 {
     return QPDFObjectHandle::Factory::newIndirect(this, og);
 }
 
 QPDFObjectHandle
+QPDF::getObject(int objid, int generation)
+{
+    return getObject(QPDFObjGen(objid, generation));
+}
+
+QPDFObjectHandle
+QPDF::getObjectByObjGen(QPDFObjGen const& og)
+{
+    return getObject(og);
+}
+
+QPDFObjectHandle
 QPDF::getObjectByID(int objid, int generation)
 {
-    return getObjectByObjGen(QPDFObjGen(objid, generation));
+    return getObject(QPDFObjGen(objid, generation));
 }
 
 void

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -183,7 +183,7 @@ QPDFAcroFormDocumentHelper::getFormFields()
     analyze();
     std::vector<QPDFFormFieldObjectHelper> result;
     for (auto const& iter: this->m->field_to_annotations) {
-        result.push_back(this->qpdf.getObjectByObjGen(iter.first));
+        result.push_back(this->qpdf.getObject(iter.first));
     }
     return result;
 }

--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -1897,7 +1897,7 @@ QPDFWriter::writeObjectStream(QPDFObjectHandle object)
                 // pass 1.
                 indicateProgress(true, false);
             }
-            QPDFObjectHandle obj_to_write = this->m->pdf.getObjectByObjGen(obj);
+            QPDFObjectHandle obj_to_write = this->m->pdf.getObject(obj);
             if (obj_to_write.isStream()) {
                 // This condition occurred in a fuzz input. Ideally we
                 // should block it at at parse time, but it's not

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -394,7 +394,7 @@ QPDF::JSONReactor::replaceObject(
     auto og = to_replace.getObjGen();
     this->reserved.erase(og);
     this->pdf.replaceObject(og, replacement);
-    auto oh = pdf.getObjectByObjGen(og);
+    auto oh = pdf.getObject(og);
     setObjectDescription(oh, value);
 }
 

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -706,7 +706,7 @@ QPDF::getUncompressedObject(
         return obj;
     } else {
         int repl = (*(object_stream_data.find(obj.getObjectID()))).second;
-        return getObjectByObjGen(QPDFObjGen(repl, 0));
+        return getObject(repl, 0);
     }
 }
 
@@ -1381,9 +1381,9 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
         stopOnError("found other than one root while"
                     " calculating linearization data");
     }
-    this->m->part4.push_back(getObjectByObjGen(*(lc_root.begin())));
+    this->m->part4.push_back(getObject(*(lc_root.begin())));
     for (auto const& og: lc_open_document) {
-        this->m->part4.push_back(getObjectByObjGen(og));
+        this->m->part4.push_back(getObject(og));
     }
 
     // Part 6: first page objects.  Note: implementation note 124
@@ -1412,11 +1412,11 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
     // hint tables.
 
     for (auto const& og: lc_first_page_private) {
-        this->m->part6.push_back(getObjectByObjGen(og));
+        this->m->part6.push_back(getObject(og));
     }
 
     for (auto const& og: lc_first_page_shared) {
-        this->m->part6.push_back(getObjectByObjGen(og));
+        this->m->part6.push_back(getObject(og));
     }
 
     // Place the outline dictionary if it goes in the first page section.
@@ -1462,7 +1462,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
         for (auto const& og: this->m->obj_user_to_objects[ou]) {
             if (lc_other_page_private.count(og)) {
                 lc_other_page_private.erase(og);
-                this->m->part7.push_back(getObjectByObjGen(og));
+                this->m->part7.push_back(getObject(og));
                 ++this->m->c_page_offset_data.entries.at(i).nobjects;
             }
         }
@@ -1479,7 +1479,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
 
     // Order is unimportant.
     for (auto const& og: lc_other_page_shared) {
-        this->m->part8.push_back(getObjectByObjGen(og));
+        this->m->part8.push_back(getObject(og));
     }
 
     // Part 9: other objects
@@ -1501,7 +1501,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
     for (auto const& og: pages_ogs) {
         if (lc_other.count(og)) {
             lc_other.erase(og);
-            this->m->part9.push_back(getObjectByObjGen(og));
+            this->m->part9.push_back(getObject(og));
         }
     }
 
@@ -1531,7 +1531,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
             for (auto const& og: ogs) {
                 if (lc_thumbnail_private.count(og)) {
                     lc_thumbnail_private.erase(og);
-                    this->m->part9.push_back(getObjectByObjGen(og));
+                    this->m->part9.push_back(getObject(og));
                 }
             }
         }
@@ -1544,7 +1544,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
 
     // Place shared thumbnail objects
     for (auto const& og: lc_thumbnail_shared) {
-        this->m->part9.push_back(getObjectByObjGen(og));
+        this->m->part9.push_back(getObject(og));
     }
 
     // Place outlines unless in first page
@@ -1554,7 +1554,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
 
     // Place all remaining objects
     for (auto const& og: lc_other) {
-        this->m->part9.push_back(getObjectByObjGen(og));
+        this->m->part9.push_back(getObject(og));
     }
 
     // Make sure we got everything exactly once.
@@ -1656,7 +1656,7 @@ QPDF::pushOutlinesToPart(
     lc_outlines.erase(outlines_og);
     part.push_back(outlines);
     for (auto const& og: lc_outlines) {
-        part.push_back(getObjectByObjGen(og));
+        part.push_back(getObject(og));
         ++this->m->c_outline_data.nobjects;
     }
 }


### PR DESCRIPTION
For consistency with similar methods, e.g. replaceObject.