### PR TITLE
Code tidy: make conversion to bool explicit

### DIFF
--- a/examples/pdf-attach-file.cc
+++ b/examples/pdf-attach-file.cc
@@ -75,7 +75,7 @@ process(
               << std::endl;
     auto fs = QPDFFileSpecObjectHelper::createFileSpec(q, key, attachment);
 
-    if (mimetype) {
+    if (mimetype != nullptr) {
         // Get an embedded file stream and set mimetype
         auto ef = QPDFEFStreamObjectHelper(fs.getEmbeddedFileStream());
         ef.setSubtype(mimetype);
@@ -206,7 +206,8 @@ main(int argc, char* argv[])
             usage("unknown argument " + std::string(arg));
         }
     }
-    if (!(infilename && attachment && outfilename)) {
+    if (!((infilename != nullptr) && (attachment != nullptr) &&
+          (outfilename != nullptr))) {
         usage("required arguments were not provided");
     }
 

--- a/examples/pdf-bookmarks.cc
+++ b/examples/pdf-bookmarks.cc
@@ -40,7 +40,7 @@ void
 print_lines(std::vector<int>& numbers)
 {
     for (unsigned int i = 0; i < numbers.size() - 1; ++i) {
-        if (numbers.at(i)) {
+        if (numbers.at(i) != 0) {
             std::cout << "| ";
         } else {
             std::cout << "  ";
@@ -86,7 +86,7 @@ show_bookmark_details(QPDFOutlineObjectHelper outline, std::vector<int> numbers)
 
     if (show_open) {
         int count = outline.getCount();
-        if (count) {
+        if (count != 0) {
             QTC::TC("examples", "pdf-bookmarks has count");
             if (count > 0) {
                 // hierarchy is open at this point
@@ -109,7 +109,7 @@ show_bookmark_details(QPDFOutlineObjectHelper outline, std::vector<int> numbers)
         if (!dest_page.isNull()) {
             QTC::TC("examples", "pdf-bookmarks dest");
             QPDFObjGen og = dest_page.getObjGen();
-            if (page_map.count(og)) {
+            if (page_map.count(og) != 0u) {
                 target = QUtil::int_to_string(page_map[og]);
             }
         }

--- a/examples/pdf-count-strings.cc
+++ b/examples/pdf-count-strings.cc
@@ -89,7 +89,7 @@ main(int argc, char* argv[])
             // illustrates that you may capture any output generated
             // by the filter, or you may ignore it.
             StringCounter counter;
-            if (pageno % 2) {
+            if ((pageno % 2) != 0) {
                 // Ignore output for odd pages.
                 page.filterContents(&counter);
             } else {

--- a/examples/pdf-custom-filter.cc
+++ b/examples/pdf-custom-filter.cc
@@ -290,7 +290,7 @@ StreamReplacer::maybeReplace(
         return false;
     }
 
-    if (dict_updates) {
+    if (dict_updates != nullptr) {
         // It's not safe to make any modifications to any objects
         // during the writing process since the updated objects may
         // have already been written. In this mode, when dict_updates
@@ -309,7 +309,7 @@ StreamReplacer::maybeReplace(
             (og.getObj() * QIntC::to_int(out->getSize())) & 0xff);
     }
 
-    if (pipeline) {
+    if (pipeline != nullptr) {
         unsigned char key = this->keys[og];
         Pl_XOR p("xor", pipeline, key);
         p.write(out->getBuffer(), out->getSize());
@@ -453,15 +453,15 @@ main(int argc, char* argv[])
     for (int i = 1; i < argc; ++i) {
         if (strcmp(argv[i], "--decode-specialized") == 0) {
             decode_specialized = true;
-        } else if (!infilename) {
+        } else if (infilename == nullptr) {
             infilename = argv[i];
-        } else if (!outfilename) {
+        } else if (outfilename == nullptr) {
             outfilename = argv[i];
         } else {
             usage();
         }
     }
-    if (!(infilename && outfilename)) {
+    if (!((infilename != nullptr) && (outfilename != nullptr))) {
         usage();
     }
 

--- a/examples/pdf-mod-info.cc
+++ b/examples/pdf-mod-info.cc
@@ -67,11 +67,11 @@ main(int argc, char* argv[])
 
     whoami = QUtil::getWhoami(argv[0]);
 
-    if ((argc == 2) && (!strcmp(argv[1], "--version"))) {
+    if ((argc == 2) && (strcmp(argv[1], "--version") == 0)) {
         std::cout << whoami << " version " << version << std::endl;
         exit(0);
     }
-    if ((argc == 3) && (!strcmp(argv[1], "--dump"))) {
+    if ((argc == 3) && (strcmp(argv[1], "--dump") == 0)) {
         QTC::TC("examples", "pdf-mod-info --dump");
         pdfDumpInfoDict(argv[2]);
         exit(0);
@@ -82,21 +82,21 @@ main(int argc, char* argv[])
     std::string cur_key;
 
     for (int i = 1; i < argc; ++i) {
-        if ((!strcmp(argv[i], "--in")) && (++i < argc)) {
+        if ((strcmp(argv[i], "--in") == 0) && (++i < argc)) {
             fl_in = argv[i];
-        } else if ((!strcmp(argv[i], "--out")) && (++i < argc)) {
+        } else if ((strcmp(argv[i], "--out") == 0) && (++i < argc)) {
             fl_out = argv[i];
-        } else if (!strcmp(argv[i], "--static-id")) // don't document
+        } else if (strcmp(argv[i], "--static-id") == 0) // don't document
         {
             static_id = true; // this should be used in test suites only
-        } else if ((!strcmp(argv[i], "--key")) && (++i < argc)) {
+        } else if ((strcmp(argv[i], "--key") == 0) && (++i < argc)) {
             QTC::TC("examples", "pdf-mod-info -key");
             cur_key = argv[i];
             if (!((cur_key.length() > 0) && (cur_key.at(0) == '/'))) {
                 cur_key = "/" + cur_key;
             }
             Keys[cur_key] = "";
-        } else if ((!strcmp(argv[i], "--val")) && (++i < argc)) {
+        } else if ((strcmp(argv[i], "--val") == 0) && (++i < argc)) {
             if (cur_key.empty()) {
                 QTC::TC("examples", "pdf-mod-info usage wrong val");
                 usage();
@@ -109,11 +109,11 @@ main(int argc, char* argv[])
             usage();
         }
     }
-    if (!fl_in) {
+    if (fl_in == nullptr) {
         QTC::TC("examples", "pdf-mod-info no in file");
         usage();
     }
-    if (!fl_out) {
+    if (fl_out == nullptr) {
         QTC::TC("examples", "pdf-mod-info in-place");
         fl_out = fl_in;
     }

--- a/examples/pdf-name-number-tree.cc
+++ b/examples/pdf-name-number-tree.cc
@@ -151,7 +151,7 @@ main(int argc, char* argv[])
     int n = 1;
     for (auto& i: number_tree) {
         std::cout << i.first << " -> " << i.second.getUTF8Value();
-        if (n % 5) {
+        if ((n % 5) != 0) {
             std::cout << ", ";
         } else {
             std::cout << std::endl;
@@ -174,7 +174,7 @@ main(int argc, char* argv[])
     n = 1;
     for (auto& i: number_tree) {
         std::cout << i.first << " -> " << i.second.getUTF8Value();
-        if (n % 5) {
+        if ((n % 5) != 0) {
             std::cout << ", ";
         } else {
             std::cout << std::endl;

--- a/libqpdf/Buffer.cc
+++ b/libqpdf/Buffer.cc
@@ -8,7 +8,7 @@ Buffer::Members::Members(size_t size, unsigned char* buf, bool own_memory) :
     buf(nullptr)
 {
     if (own_memory) {
-        this->buf = (size ? new unsigned char[size] : nullptr);
+        this->buf = (size != 0u ? new unsigned char[size] : nullptr);
     } else {
         this->buf = buf;
     }
@@ -54,7 +54,7 @@ Buffer::copy(Buffer const& rhs)
     if (this != &rhs) {
         this->m =
             std::shared_ptr<Members>(new Members(rhs.m->size, nullptr, true));
-        if (this->m->size) {
+        if (this->m->size != 0u) {
             memcpy(this->m->buf, rhs.m->buf, this->m->size);
         }
     }

--- a/libqpdf/BufferInputSource.cc
+++ b/libqpdf/BufferInputSource.cc
@@ -13,7 +13,7 @@ BufferInputSource::Members::Members(
     description(description),
     buf(buf),
     cur_offset(0),
-    max_offset(buf ? QIntC::to_offset(buf->getSize()) : 0)
+    max_offset(buf != nullptr ? QIntC::to_offset(buf->getSize()) : 0)
 {
 }
 

--- a/libqpdf/ClosedFileInputSource.cc
+++ b/libqpdf/ClosedFileInputSource.cc
@@ -78,7 +78,7 @@ void
 ClosedFileInputSource::rewind()
 {
     this->m->offset = 0;
-    if (this->m->fis.get()) {
+    if (this->m->fis.get() != nullptr) {
         this->m->fis->rewind();
     }
 }
@@ -105,7 +105,7 @@ void
 ClosedFileInputSource::stayOpen(bool val)
 {
     this->m->stay_open = val;
-    if ((!val) && this->m->fis.get()) {
+    if ((!val) && (this->m->fis.get() != nullptr)) {
         after();
     }
 }

--- a/libqpdf/FileInputSource.cc
+++ b/libqpdf/FileInputSource.cc
@@ -13,7 +13,7 @@ FileInputSource::Members::Members(bool close_file) :
 
 FileInputSource::Members::~Members()
 {
-    if (this->file && this->close_file) {
+    if ((this->file != nullptr) && this->close_file) {
         fclose(this->file);
     }
 }
@@ -74,8 +74,10 @@ FileInputSource::findAndSkipNextEOL()
         } else {
             char* p1 = static_cast<char*>(memchr(buf, '\r', len));
             char* p2 = static_cast<char*>(memchr(buf, '\n', len));
-            char* p = (p1 && p2) ? std::min(p1, p2) : p1 ? p1 : p2;
-            if (p) {
+            char* p = ((p1 != nullptr) && (p2 != nullptr)) ? std::min(p1, p2)
+                : p1 != nullptr                            ? p1
+                                                           : p2;
+            if (p != nullptr) {
                 result = cur_offset + (p - buf);
                 // We found \r or \n.  Keep reading until we get past
                 // \r and \n characters.
@@ -129,7 +131,7 @@ FileInputSource::read(char* buffer, size_t length)
     this->last_offset = this->tell();
     size_t len = fread(buffer, 1, length, this->m->file);
     if (len == 0) {
-        if (ferror(this->m->file)) {
+        if (ferror(this->m->file) != 0) {
             throw QPDFExc(
                 qpdf_e_system,
                 this->m->filename,

--- a/libqpdf/InputSource.cc
+++ b/libqpdf/InputSource.cc
@@ -88,7 +88,7 @@ InputSource::findFirst(
         // case regardless of start_chars.
         if ((p == nullptr) ||
             ((p + strlen(start_chars)) > (buf + bytes_read))) {
-            if (p) {
+            if (p != nullptr) {
                 QTC::TC(
                     "libtests",
                     "InputSource read next block",

--- a/libqpdf/JSONHandler.cc
+++ b/libqpdf/JSONHandler.cc
@@ -112,7 +112,7 @@ JSONHandler::handle(std::string const& path, JSON j)
                               std::string const& k, JSON v) {
             auto i = this->m->h.dict_handlers.find(k);
             if (i == this->m->h.dict_handlers.end()) {
-                if (this->m->h.fallback_dict_handler.get()) {
+                if (this->m->h.fallback_dict_handler.get() != nullptr) {
                     this->m->h.fallback_dict_handler->handle(path_base + k, v);
                 } else {
                     QTC::TC("libtests", "JSONHandler unexpected key");

--- a/libqpdf/MD5.cc
+++ b/libqpdf/MD5.cc
@@ -81,7 +81,7 @@ MD5::encodeFile(char const* filename, qpdf_offset_t up_to_offset)
             }
         }
     } while (len > 0);
-    if (ferror(file)) {
+    if (ferror(file) != 0) {
         // Assume, perhaps incorrectly, that errno was set by the
         // underlying call to read....
         (void)fclose(file);

--- a/libqpdf/NNTree.cc
+++ b/libqpdf/NNTree.cc
@@ -647,7 +647,7 @@ NNTreeIterator::deepen(QPDFObjectHandle node, bool first, bool allow_empty)
     while (!failed) {
         if (node.isIndirect()) {
             auto og = node.getObjGen();
-            if (seen.count(og)) {
+            if (seen.count(og) != 0u) {
                 QTC::TC("qpdf", "NNTree deepen: loop");
                 warn(
                     impl.qpdf,
@@ -938,7 +938,7 @@ NNTreeImpl::findInternal(QPDFObjectHandle key, bool return_prev_if_not_found)
 
     while (true) {
         auto og = node.getObjGen();
-        if (seen.count(og)) {
+        if (seen.count(og) != 0u) {
             QTC::TC("qpdf", "NNTree loop in find");
             error(qpdf, node, "loop detected in find");
         }
@@ -1028,7 +1028,7 @@ NNTreeImpl::remove(QPDFObjectHandle key, QPDFObjectHandle* value)
         QTC::TC("qpdf", "NNTree remove not found");
         return false;
     }
-    if (value) {
+    if (value != nullptr) {
         *value = iter->second;
     }
     iter.remove();

--- a/libqpdf/Pl_Buffer.cc
+++ b/libqpdf/Pl_Buffer.cc
@@ -37,13 +37,13 @@ Pl_Buffer::write(unsigned char const* buf, size_t len)
         memcpy(b->getBuffer(), this->m->data->getBuffer(), this->m->total_size);
         this->m->data = b;
     }
-    if (len) {
+    if (len != 0u) {
         memcpy(this->m->data->getBuffer() + this->m->total_size, buf, len);
         this->m->total_size += len;
     }
     this->m->ready = false;
 
-    if (getNext(true)) {
+    if (getNext(true) != nullptr) {
         getNext()->write(buf, len);
     }
 }
@@ -52,7 +52,7 @@ void
 Pl_Buffer::finish()
 {
     this->m->ready = true;
-    if (getNext(true)) {
+    if (getNext(true) != nullptr) {
         getNext()->finish();
     }
 }

--- a/libqpdf/Pl_Count.cc
+++ b/libqpdf/Pl_Count.cc
@@ -23,7 +23,7 @@ Pl_Count::~Pl_Count()
 void
 Pl_Count::write(unsigned char const* buf, size_t len)
 {
-    if (len) {
+    if (len != 0u) {
         this->m->count += QIntC::to_offset(len);
         this->m->last_char = buf[len - 1];
         getNext()->write(buf, len);

--- a/libqpdf/Pl_DCT.cc
+++ b/libqpdf/Pl_DCT.cc
@@ -289,7 +289,7 @@ Pl_DCT::compress(void* cinfo_p, Buffer* b)
     cinfo->input_components = this->m->components;
     cinfo->in_color_space = this->m->color_space;
     jpeg_set_defaults(cinfo);
-    if (this->m->config_callback) {
+    if (this->m->config_callback != nullptr) {
         this->m->config_callback->apply(cinfo);
     }
 

--- a/libqpdf/Pl_Flate.cc
+++ b/libqpdf/Pl_Flate.cc
@@ -156,7 +156,8 @@ Pl_Flate::handleData(unsigned char const* data, size_t len, int flush)
         } else {
             err = inflate(&zstream, flush);
         }
-        if ((this->m->action == a_inflate) && (err != Z_OK) && zstream.msg &&
+        if ((this->m->action == a_inflate) && (err != Z_OK) &&
+            (zstream.msg != nullptr) &&
             (strcmp(zstream.msg, "incorrect data check") == 0)) {
             // Other PDF readers ignore this specific error. Combining
             // this with Z_SYNC_FLUSH enables qpdf to handle some
@@ -211,7 +212,7 @@ void
 Pl_Flate::finish()
 {
     try {
-        if (this->m->outbuf.get()) {
+        if (this->m->outbuf.get() != nullptr) {
             if (this->m->initialized) {
                 z_stream& zstream = *(static_cast<z_stream*>(this->m->zdata));
                 unsigned char buf[1];
@@ -256,7 +257,7 @@ Pl_Flate::checkError(char const* prefix, int error_code)
         std::string msg =
             this->identifier + ": " + action_str + ": " + prefix + ": ";
 
-        if (zstream.msg) {
+        if (zstream.msg != nullptr) {
             msg += zstream.msg;
         } else {
             switch (error_code) {

--- a/libqpdf/Pl_Function.cc
+++ b/libqpdf/Pl_Function.cc
@@ -25,7 +25,7 @@ void
 Pl_Function::write(unsigned char const* buf, size_t len)
 {
     this->m->fn(buf, len);
-    if (getNext(true)) {
+    if (getNext(true) != nullptr) {
         getNext()->write(buf, len);
     }
 }
@@ -33,7 +33,7 @@ Pl_Function::write(unsigned char const* buf, size_t len)
 void
 Pl_Function::finish()
 {
-    if (getNext(true)) {
+    if (getNext(true) != nullptr) {
         getNext()->finish();
     }
 }

--- a/libqpdf/Pl_LZWDecoder.cc
+++ b/libqpdf/Pl_LZWDecoder.cc
@@ -62,7 +62,7 @@ Pl_LZWDecoder::sendNextCode()
     unsigned int code = 0;
     code += (this->buf[high] & high_mask) << bits_from_med;
     code += ((this->buf[med] & med_mask) >> (8 - bits_from_med));
-    if (bits_from_low) {
+    if (bits_from_low != 0u) {
         code <<= bits_from_low;
         code += ((this->buf[low] & low_mask) >> (8 - bits_from_low));
         this->byte_pos = low;
@@ -181,7 +181,8 @@ Pl_LZWDecoder::handleCode(unsigned int code)
                 throw std::runtime_error("LZWDecoder: table full");
             }
             addToTable(next);
-            unsigned int change_idx = new_idx + code_change_delta;
+            unsigned int change_idx =
+                new_idx + static_cast<unsigned int>(code_change_delta);
             if ((change_idx == 511) || (change_idx == 1023) ||
                 (change_idx == 2047)) {
                 ++this->code_size;

--- a/libqpdf/Pl_PNGFilter.cc
+++ b/libqpdf/Pl_PNGFilter.cc
@@ -77,12 +77,12 @@ Pl_PNGFilter::write(unsigned char const* data, size_t len)
         // Swap rows
         unsigned char* t = this->prev_row;
         this->prev_row = this->cur_row;
-        this->cur_row = t ? t : this->buf2.get();
+        this->cur_row = t != nullptr ? t : this->buf2.get();
         memset(this->cur_row, 0, this->bytes_per_row + 1);
         left = this->incoming;
         this->pos = 0;
     }
-    if (len) {
+    if (len != 0u) {
         memcpy(this->cur_row + this->pos, data + offset, len);
     }
     this->pos += len;
@@ -102,7 +102,7 @@ void
 Pl_PNGFilter::decodeRow()
 {
     int filter = this->cur_row[0];
-    if (this->prev_row) {
+    if (this->prev_row != nullptr) {
         switch (filter) {
         case 0:
             break;
@@ -225,7 +225,7 @@ Pl_PNGFilter::encodeRow()
     // For now, hard-code to using UP filter.
     unsigned char ch = 2;
     getNext()->write(&ch, 1);
-    if (this->prev_row) {
+    if (this->prev_row != nullptr) {
         for (unsigned int i = 0; i < this->bytes_per_row; ++i) {
             ch = static_cast<unsigned char>(
                 this->cur_row[i] - this->prev_row[i]);
@@ -239,7 +239,7 @@ Pl_PNGFilter::encodeRow()
 void
 Pl_PNGFilter::finish()
 {
-    if (this->pos) {
+    if (this->pos != 0u) {
         // write partial row
         processRow();
     }

--- a/libqpdf/Pl_QPDFTokenizer.cc
+++ b/libqpdf/Pl_QPDFTokenizer.cc
@@ -71,7 +71,7 @@ Pl_QPDFTokenizer::finish()
     QPDFObjectHandle::TokenFilter::PipelineAccessor::setPipeline(
         m->filter, nullptr);
     Pipeline* next = this->getNext(true);
-    if (next) {
+    if (next != nullptr) {
         next->finish();
     }
 }

--- a/libqpdf/Pl_SHA2.cc
+++ b/libqpdf/Pl_SHA2.cc
@@ -9,7 +9,7 @@ Pl_SHA2::Pl_SHA2(int bits, Pipeline* next) :
     Pipeline("sha2", next),
     in_progress(false)
 {
-    if (bits) {
+    if (bits != 0) {
         resetBits(bits);
     }
 }
@@ -33,7 +33,7 @@ Pl_SHA2::write(unsigned char const* buf, size_t len)
         data += bytes;
     }
 
-    if (this->getNext(true)) {
+    if (this->getNext(true) != nullptr) {
         this->getNext()->write(buf, len);
     }
 }
@@ -41,7 +41,7 @@ Pl_SHA2::write(unsigned char const* buf, size_t len)
 void
 Pl_SHA2::finish()
 {
-    if (this->getNext(true)) {
+    if (this->getNext(true) != nullptr) {
         this->getNext()->finish();
     }
     this->crypto->SHA2_finalize();

--- a/libqpdf/Pl_String.cc
+++ b/libqpdf/Pl_String.cc
@@ -25,7 +25,7 @@ void
 Pl_String::write(unsigned char const* buf, size_t len)
 {
     this->m->s.append(reinterpret_cast<char const*>(buf), len);
-    if (getNext(true)) {
+    if (getNext(true) != nullptr) {
         getNext()->write(buf, len);
     }
 }
@@ -33,7 +33,7 @@ Pl_String::write(unsigned char const* buf, size_t len)
 void
 Pl_String::finish()
 {
-    if (getNext(true)) {
+    if (getNext(true) != nullptr) {
         getNext()->finish();
     }
 }

--- a/libqpdf/Pl_TIFFPredictor.cc
+++ b/libqpdf/Pl_TIFFPredictor.cc
@@ -63,7 +63,7 @@ Pl_TIFFPredictor::write(unsigned char const* data, size_t len)
         left = this->bytes_per_row;
         this->pos = 0;
     }
-    if (len) {
+    if (len != 0u) {
         memcpy(this->cur_row.get() + this->pos, data + offset, len);
     }
     this->pos += len;
@@ -104,7 +104,7 @@ Pl_TIFFPredictor::processRow()
 void
 Pl_TIFFPredictor::finish()
 {
-    if (this->pos) {
+    if (this->pos != 0u) {
         // write partial row
         processRow();
     }

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -75,7 +75,7 @@ QPDFAcroFormDocumentHelper::addAndRenameFormFields(
         QPDFObjectHandle obj = queue.front();
         queue.pop_front();
         auto og = obj.getObjGen();
-        if (seen.count(og)) {
+        if (seen.count(og) != 0u) {
             // loop
             continue;
         }
@@ -159,7 +159,7 @@ QPDFAcroFormDocumentHelper::removeFormFields(
     int i = 0;
     while (i < fields.getArrayNItems()) {
         auto field = fields.getArrayItem(i);
-        if (to_remove.count(field.getObjGen())) {
+        if (to_remove.count(field.getObjGen()) != 0u) {
             fields.eraseItem(i);
         } else {
             ++i;
@@ -207,7 +207,7 @@ QPDFAcroFormDocumentHelper::getAnnotationsForField(QPDFFormFieldObjectHelper h)
     analyze();
     std::vector<QPDFAnnotationObjectHelper> result;
     QPDFObjGen og(h.getObjectHandle().getObjGen());
-    if (this->m->field_to_annotations.count(og)) {
+    if (this->m->field_to_annotations.count(og) != 0u) {
         result = this->m->field_to_annotations[og];
     }
     return result;
@@ -230,7 +230,7 @@ QPDFAcroFormDocumentHelper::getFormFieldsForPage(QPDFPageObjectHelper ph)
         auto field = getFieldForAnnotation(annot);
         field = field.getTopLevelField();
         auto og = field.getObjectHandle().getObjGen();
-        if (!added.count(og)) {
+        if (added.count(og) == 0u) {
             added.insert(og);
             if (field.getObjectHandle().isDictionary()) {
                 result.push_back(field);
@@ -250,7 +250,7 @@ QPDFAcroFormDocumentHelper::getFieldForAnnotation(QPDFAnnotationObjectHelper h)
     }
     analyze();
     QPDFObjGen og(oh.getObjGen());
-    if (this->m->annotation_to_field.count(og)) {
+    if (this->m->annotation_to_field.count(og) != 0u) {
         result = this->m->annotation_to_field[og];
     }
     return result;
@@ -581,7 +581,8 @@ ResourceReplacer::handleToken(QPDFTokenizer::Token const& token)
     if (token.getType() == QPDFTokenizer::tt_name) {
         std::string name =
             QPDFObjectHandle::newName(token.getValue()).getName();
-        if (to_replace.count(name) && to_replace[name].count(offset)) {
+        if ((to_replace.count(name) != 0u) &&
+            (to_replace[name].count(offset) != 0u)) {
             QTC::TC("qpdf", "QPDFAcroFormDocumentHelper replaced DA token");
             write(to_replace[name][offset]);
             wrote = true;
@@ -771,11 +772,11 @@ QPDFAcroFormDocumentHelper::transformAnnotations(
     QPDFAcroFormDocumentHelper* from_afdh)
 {
     std::shared_ptr<QPDFAcroFormDocumentHelper> afdhph;
-    if (!from_qpdf) {
+    if (from_qpdf == nullptr) {
         // Assume these are from the same QPDF.
         from_qpdf = &this->qpdf;
         from_afdh = this;
-    } else if ((from_qpdf != &this->qpdf) && (!from_afdh)) {
+    } else if ((from_qpdf != &this->qpdf) && (from_afdh == nullptr)) {
         afdhph = std::make_shared<QPDFAcroFormDocumentHelper>(*from_qpdf);
         from_afdh = afdhph.get();
     }
@@ -876,7 +877,7 @@ QPDFAcroFormDocumentHelper::transformAnnotations(
     std::map<QPDFObjGen, QPDFObjectHandle> orig_to_copy;
     auto maybe_copy_object = [&](QPDFObjectHandle& to_copy) {
         auto og = to_copy.getObjGen();
-        if (orig_to_copy.count(og)) {
+        if (orig_to_copy.count(og) != 0u) {
             to_copy = orig_to_copy[og];
             return false;
         } else {
@@ -978,7 +979,7 @@ QPDFAcroFormDocumentHelper::transformAnnotations(
                 QPDFObjectHandle obj = queue.front();
                 queue.pop_front();
                 auto orig_og = obj.getObjGen();
-                if (seen.count(orig_og)) {
+                if (seen.count(orig_og) != 0u) {
                     // loop
                     break;
                 }
@@ -986,7 +987,7 @@ QPDFAcroFormDocumentHelper::transformAnnotations(
                 auto parent = obj.getKey("/Parent");
                 if (parent.isIndirect()) {
                     auto parent_og = parent.getObjGen();
-                    if (orig_to_copy.count(parent_og)) {
+                    if (orig_to_copy.count(parent_og) != 0u) {
                         obj.replaceKey("/Parent", orig_to_copy[parent_og]);
                     } else {
                         parent.warnIfPossible(
@@ -1064,7 +1065,8 @@ QPDFAcroFormDocumentHelper::transformAnnotations(
         maybe_copy_object(annot);
 
         // Now we have copies, so we can safely mutate.
-        if (have_field && !added_new_fields.count(top_field.getObjGen())) {
+        if (have_field &&
+            (added_new_fields.count(top_field.getObjGen()) == 0u)) {
             new_fields.push_back(top_field);
             added_new_fields.insert(top_field.getObjGen());
         }
@@ -1149,7 +1151,7 @@ QPDFAcroFormDocumentHelper::fixCopiedAnnotations(
 
     to_page.replaceKey("/Annots", QPDFObjectHandle::newArray(new_annots));
     addAndRenameFormFields(new_fields);
-    if (added_fields) {
+    if (added_fields != nullptr) {
         for (auto f: new_fields) {
             added_fields->insert(f.getObjGen());
         }

--- a/libqpdf/QPDFAnnotationObjectHelper.cc
+++ b/libqpdf/QPDFAnnotationObjectHelper.cc
@@ -168,7 +168,7 @@ QPDFAnnotationObjectHelper::getPageContentForAppearance(
     QPDFObjectHandle matrix_obj = as.getKey("/Matrix");
 
     int flags = getFlags();
-    if (flags & forbidden_flags) {
+    if ((flags & forbidden_flags) != 0) {
         QTC::TC("qpdf", "QPDFAnnotationObjectHelper forbidden flags");
         return "";
     }
@@ -188,7 +188,7 @@ QPDFAnnotationObjectHelper::getPageContentForAppearance(
         QTC::TC("qpdf", "QPDFAnnotationObjectHelper default matrix");
     }
     QPDFObjectHandle::Rectangle rect = rect_obj.getArrayAsRectangle();
-    bool do_rotate = (rotate && (flags & an_no_rotate));
+    bool do_rotate = ((rotate != 0) && ((flags & an_no_rotate) != 0));
     if (do_rotate) {
         // If the the annotation flags include the NoRotate bit and
         // the page is rotated, we have to rotate the annotation about

--- a/libqpdf/QPDFArgParser.cc
+++ b/libqpdf/QPDFArgParser.cc
@@ -142,7 +142,7 @@ QPDFArgParser::addChoices(
     OptionEntry& oe = registerArg(arg);
     oe.parameter_needed = required;
     oe.param_arg_handler = handler;
-    for (char const** i = choices; *i; ++i) {
+    for (char const** i = choices; *i != nullptr; ++i) {
         oe.choices.insert(*i);
     }
 }
@@ -264,7 +264,7 @@ QPDFArgParser::handleArgFileArguments()
                 }
             }
         }
-        if (argfile) {
+        if (argfile != nullptr) {
             readArgsFromFile(1 + this->m->argv[i]);
         } else {
             this->m->new_argv.push_back(
@@ -515,7 +515,7 @@ QPDFArgParser::parseArgs()
 
             if ((!this->m->bash_completion) && (this->m->argc == 2) &&
                 (this->m->cur_arg == 1) &&
-                this->m->help_option_table.count(arg_s)) {
+                (this->m->help_option_table.count(arg_s) != 0u)) {
                 // Handle help option, which is only valid as the sole
                 // option.
                 QTC::TC("libtests", "QPDFArgParser help option");
@@ -741,7 +741,7 @@ QPDFArgParser::addHelpTopic(
         throw std::logic_error(
             "QPDFArgParser: help topics must not start with -");
     }
-    if (this->m->help_topics.count(topic)) {
+    if (this->m->help_topics.count(topic) != 0u) {
         QTC::TC("libtests", "QPDFArgParser add existing topic");
         throw std::logic_error(
             "QPDFArgParser: topic " + topic + " has already been added");
@@ -764,7 +764,7 @@ QPDFArgParser::addOptionHelp(
         throw std::logic_error(
             "QPDFArgParser: options for help must start with --");
     }
-    if (this->m->option_help.count(option_name)) {
+    if (this->m->option_help.count(option_name) != 0u) {
         QTC::TC("libtests", "QPDFArgParser duplicate option help");
         throw std::logic_error(
             "QPDFArgParser: option " + option_name + " already has help");
@@ -843,9 +843,9 @@ QPDFArgParser::getHelp(std::string const& arg)
     } else {
         if (arg == "all") {
             getAllHelp(msg);
-        } else if (this->m->option_help.count(arg)) {
+        } else if (this->m->option_help.count(arg) != 0u) {
             getTopicHelp(arg, this->m->option_help[arg], msg);
-        } else if (this->m->help_topics.count(arg)) {
+        } else if (this->m->help_topics.count(arg) != 0u) {
             getTopicHelp(arg, this->m->help_topics[arg], msg);
         } else {
             // should not be possible

--- a/libqpdf/QPDFCryptoProvider.cc
+++ b/libqpdf/QPDFCryptoProvider.cc
@@ -92,7 +92,7 @@ QPDFCryptoProvider::registerImpl_internal(std::string const& name)
 void
 QPDFCryptoProvider::setDefaultProvider_internal(std::string const& name)
 {
-    if (!this->m->providers.count(name)) {
+    if (this->m->providers.count(name) == 0u) {
         throw std::logic_error(
             "QPDFCryptoProvider: request to set default"
             " provider to unknown implementation \"" +

--- a/libqpdf/QPDFCrypto_native.cc
+++ b/libqpdf/QPDFCrypto_native.cc
@@ -20,9 +20,10 @@ getRandomProvider()
         SecureRandomDataProvider::getInstance();
 
     static RandomDataProvider* provider =
-        (secure_random_data_provider         ? secure_random_data_provider
-             : insecure_random_data_provider ? insecure_random_data_provider
-                                             : nullptr);
+        (secure_random_data_provider != nullptr ? secure_random_data_provider
+             : insecure_random_data_provider != nullptr
+             ? insecure_random_data_provider
+             : nullptr);
 
     if (provider == nullptr) {
         throw std::logic_error("QPDFCrypto_native has no random data provider");

--- a/libqpdf/QPDFCrypto_openssl.cc
+++ b/libqpdf/QPDFCrypto_openssl.cc
@@ -141,7 +141,7 @@ QPDFCrypto_openssl::MD5_finalize()
 #else
     auto md = EVP_MD_CTX_get0_md(md_ctx);
 #endif
-    if (md) {
+    if (md != nullptr) {
         check_openssl(EVP_DigestFinal(md_ctx, md_out + 0, nullptr));
     }
 }
@@ -154,7 +154,7 @@ QPDFCrypto_openssl::SHA2_finalize()
 #else
     auto md = EVP_MD_CTX_get0_md(md_ctx);
 #endif
-    if (md) {
+    if (md != nullptr) {
         check_openssl(EVP_DigestFinal(md_ctx, md_out + 0, nullptr));
     }
 }
@@ -211,7 +211,12 @@ QPDFCrypto_openssl::rijndael_init(
     check_openssl(
         // line-break
         EVP_CipherInit_ex(
-            cipher_ctx, cipher, nullptr, key_data, cbc_block, encrypt));
+            cipher_ctx,
+            cipher,
+            nullptr,
+            key_data,
+            cbc_block,
+            static_cast<int>(encrypt)));
     check_openssl(EVP_CIPHER_CTX_set_padding(cipher_ctx, 0));
 }
 
@@ -235,7 +240,7 @@ QPDFCrypto_openssl::rijndael_process(
 void
 QPDFCrypto_openssl::RC4_finalize()
 {
-    if (EVP_CIPHER_CTX_cipher(cipher_ctx)) {
+    if (EVP_CIPHER_CTX_cipher(cipher_ctx) != nullptr) {
         check_openssl(EVP_CIPHER_CTX_reset(cipher_ctx));
     }
 }
@@ -243,7 +248,7 @@ QPDFCrypto_openssl::RC4_finalize()
 void
 QPDFCrypto_openssl::rijndael_finalize()
 {
-    if (EVP_CIPHER_CTX_cipher(cipher_ctx)) {
+    if (EVP_CIPHER_CTX_cipher(cipher_ctx) != nullptr) {
         check_openssl(EVP_CIPHER_CTX_reset(cipher_ctx));
     }
 }

--- a/libqpdf/QPDFFormFieldObjectHelper.cc
+++ b/libqpdf/QPDFFormFieldObjectHelper.cc
@@ -40,11 +40,11 @@ QPDFFormFieldObjectHelper::getTopLevelField(bool* is_different)
     while (top_field.isDictionary() &&
            (!top_field.getKey("/Parent").isNull())) {
         top_field = top_field.getKey("/Parent");
-        if (is_different) {
+        if (is_different != nullptr) {
             *is_different = true;
         }
         auto og = top_field.getObjGen();
-        if (seen.count(og)) {
+        if (seen.count(og) != 0u) {
             break;
         }
         seen.insert(og);
@@ -58,7 +58,7 @@ QPDFFormFieldObjectHelper::getFieldFromAcroForm(std::string const& name)
     QPDFObjectHandle result = QPDFObjectHandle::newNull();
     // Fields are supposed to be indirect, so this should work.
     QPDF* q = this->oh.getOwningQPDF();
-    if (!q) {
+    if (q == nullptr) {
         return result;
     }
     auto acroform = q->getRoot().getKey("/AcroForm");
@@ -80,7 +80,7 @@ QPDFFormFieldObjectHelper::getInheritableFieldValue(std::string const& name)
     while (result.isNull() && node.hasKey("/Parent")) {
         seen.insert(node.getObjGen());
         node = node.getKey("/Parent");
-        if (seen.count(node.getObjGen())) {
+        if (seen.count(node.getObjGen()) != 0u) {
             break;
         }
         result = node.getKey(name);
@@ -363,7 +363,7 @@ QPDFFormFieldObjectHelper::setV(QPDFObjectHandle value, bool need_appearances)
     }
     if (need_appearances) {
         QPDF* qpdf = this->oh.getOwningQPDF();
-        if (!qpdf) {
+        if (qpdf == nullptr) {
             throw std::logic_error(
                 "QPDFFormFieldObjectHelper::setV called with"
                 " need_appearances = true on an object that is"

--- a/libqpdf/QPDFJob_argv.cc
+++ b/libqpdf/QPDFJob_argv.cc
@@ -290,7 +290,7 @@ ArgParser::argPagesPositional(std::string const& arg)
             range_p = nullptr;
         }
     }
-    std::string range(range_p ? range_p : "1-z");
+    std::string range(range_p != nullptr ? range_p : "1-z");
     this->c_pages->pageSpec(file, range, this->pages_password.get());
     this->accumulated_args.clear();
     this->pages_password = nullptr;
@@ -429,7 +429,7 @@ QPDFJob::initializeFromArgv(char const* const argv[], char const* progname_env)
         progname_env = "QPDF_EXECUTABLE";
     }
     int argc = 0;
-    for (auto k = argv; *k; ++k) {
+    for (auto k = argv; *k != nullptr; ++k) {
         ++argc;
     }
     QPDFArgParser qap(argc, argv, progname_env);

--- a/libqpdf/QPDFJob_json.cc
+++ b/libqpdf/QPDFJob_json.cc
@@ -157,7 +157,7 @@ Handlers::addChoices(char const** choices, bool required, param_handler_t fn)
                 matches = true;
             }
             if (!matches) {
-                for (char const** i = choices; *i; ++i) {
+                for (char const** i = choices; *i != nullptr; ++i) {
                     if (strcmp(*i, p) == 0) {
                         QTC::TC("qpdf", "QPDFJob json choice match");
                         matches = true;
@@ -170,7 +170,7 @@ Handlers::addChoices(char const** choices, bool required, param_handler_t fn)
                 std::ostringstream msg;
                 msg << path + ": unexpected value; expected one of ";
                 bool first = true;
-                for (char const** i = choices; *i; ++i) {
+                for (char const** i = choices; *i != nullptr; ++i) {
                     if (first) {
                         first = false;
                     } else {

--- a/libqpdf/QPDFOutlineDocumentHelper.cc
+++ b/libqpdf/QPDFOutlineDocumentHelper.cc
@@ -18,7 +18,7 @@ QPDFOutlineDocumentHelper::QPDFOutlineDocumentHelper(QPDF& qpdf) :
     std::set<QPDFObjGen> seen;
     while (!cur.isNull()) {
         auto og = cur.getObjGen();
-        if (seen.count(og)) {
+        if (seen.count(og) != 0u) {
             break;
         }
         seen.insert(og);
@@ -63,7 +63,7 @@ QPDFOutlineDocumentHelper::getOutlinesForPage(QPDFObjGen const& og)
         initializeByPage();
     }
     std::vector<QPDFOutlineObjectHelper> result;
-    if (this->m->by_page.count(og)) {
+    if (this->m->by_page.count(og) != 0u) {
         result = this->m->by_page[og];
     }
     return result;
@@ -93,7 +93,7 @@ QPDFOutlineDocumentHelper::resolveNamedDest(QPDFObjectHandle name)
                 }
             }
         }
-        if (this->m->names_dest.get()) {
+        if (this->m->names_dest.get() != nullptr) {
             if (this->m->names_dest->findObject(name.getUTF8Value(), result)) {
                 QTC::TC("qpdf", "QPDFOutlineDocumentHelper string named dest");
             }

--- a/libqpdf/QPDFPageDocumentHelper.cc
+++ b/libqpdf/QPDFPageDocumentHelper.cc
@@ -93,7 +93,7 @@ QPDFPageDocumentHelper::flattenAnnotationsForPage(
     std::string new_content;
     int rotate = 0;
     QPDFObjectHandle rotate_obj = page.getObjectHandle().getKey("/Rotate");
-    if (rotate_obj.isInteger() && rotate_obj.getIntValue()) {
+    if (rotate_obj.isInteger() && (rotate_obj.getIntValue() != 0)) {
         rotate = rotate_obj.getIntValueAsInt();
     }
     int next_fx = 1;

--- a/libqpdf/QPDFPageObjectHelper.cc
+++ b/libqpdf/QPDFPageObjectHelper.cc
@@ -257,7 +257,7 @@ QPDFPageObjectHelper::getAttribute(std::string const& name, bool copy_if_shared)
         while (inheritable && result.isNull() && node.hasKey("/Parent")) {
             seen.insert(node.getObjGen());
             node = node.getKey("/Parent");
-            if (seen.count(node.getObjGen())) {
+            if (seen.count(node.getObjGen()) != 0u) {
                 break;
             }
             result = node.getKey(name);
@@ -325,7 +325,7 @@ QPDFPageObjectHelper::forEachXObject(
         QPDFPageObjectHelper ph = queue.front();
         queue.pop_front();
         QPDFObjGen og = ph.oh.getObjGen();
-        if (seen.count(og)) {
+        if (seen.count(og) != 0u) {
             continue;
         }
         seen.insert(og);
@@ -563,9 +563,9 @@ QPDFPageObjectHelper::removeUnreferencedResourcesHelper(
     ResourceFinder rf;
     try {
         auto q = ph.oh.getOwningQPDF();
-        size_t before_nw = (q ? q->numWarnings() : 0);
+        size_t before_nw = (q != nullptr ? q->numWarnings() : 0);
         ph.parseContents(&rf);
-        size_t after_nw = (q ? q->numWarnings() : 0);
+        size_t after_nw = (q != nullptr ? q->numWarnings() : 0);
         if (after_nw > before_nw) {
             ph.oh.warnIfPossible(
                 "Bad token found while scanning content stream; "
@@ -608,7 +608,7 @@ QPDFPageObjectHelper::removeUnreferencedResourcesHelper(
     for (auto const& i1: to_filter) {
         for (auto const& n_iter: names_by_rtype[i1]) {
             std::string const& name = n_iter.first;
-            if (!known_names.count(name)) {
+            if (known_names.count(name) == 0u) {
                 unresolved.insert(name);
                 local_unresolved.insert(name);
             }
@@ -647,11 +647,11 @@ QPDFPageObjectHelper::removeUnreferencedResourcesHelper(
 
     for (auto& dict: rdicts) {
         for (auto const& key: dict.getKeys()) {
-            if (is_page && unresolved.count(key)) {
+            if (is_page && (unresolved.count(key) != 0u)) {
                 // This name is referenced by some nested form
                 // xobject, so don't remove it.
                 QTC::TC("qpdf", "QPDFPageObjectHelper resolving unresolved");
-            } else if (!rf.getNames().count(key)) {
+            } else if (rf.getNames().count(key) == 0u) {
                 dict.removeKey(key);
             }
         }
@@ -684,7 +684,7 @@ QPDFPageObjectHelper
 QPDFPageObjectHelper::shallowCopyPage()
 {
     QPDF* qpdf = this->oh.getOwningQPDF();
-    if (!qpdf) {
+    if (qpdf == nullptr) {
         throw std::runtime_error("QPDFPageObjectHelper::shallowCopyPage"
                                  " called with a direct object");
     }
@@ -744,7 +744,7 @@ QPDFObjectHandle
 QPDFPageObjectHelper::getFormXObjectForPage(bool handle_transformations)
 {
     QPDF* qpdf = this->oh.getOwningQPDF();
-    if (!qpdf) {
+    if (qpdf == nullptr) {
         throw std::runtime_error("QPDFPageObjectHelper::getFormXObjectForPage"
                                  " called with a direct object");
     }
@@ -918,7 +918,7 @@ void
 QPDFPageObjectHelper::flattenRotation(QPDFAcroFormDocumentHelper* afdh)
 {
     QPDF* qpdf = this->oh.getOwningQPDF();
-    if (!qpdf) {
+    if (qpdf == nullptr) {
         throw std::runtime_error("QPDFPageObjectHelper::flattenRotation"
                                  " called with a direct object");
     }
@@ -1040,7 +1040,7 @@ QPDFPageObjectHelper::flattenRotation(QPDFAcroFormDocumentHelper* afdh)
         std::vector<QPDFObjectHandle> new_fields;
         std::set<QPDFObjGen> old_fields;
         std::shared_ptr<QPDFAcroFormDocumentHelper> afdhph;
-        if (!afdh) {
+        if (afdh == nullptr) {
             afdhph = std::make_shared<QPDFAcroFormDocumentHelper>(*qpdf);
             afdh = afdhph.get();
         }
@@ -1067,12 +1067,12 @@ QPDFPageObjectHelper::copyAnnotations(
     }
 
     QPDF* from_qpdf = from_page.getObjectHandle().getOwningQPDF();
-    if (!from_qpdf) {
+    if (from_qpdf == nullptr) {
         throw std::runtime_error("QPDFPageObjectHelper::copyAnnotations:"
                                  " from page is a direct object");
     }
     QPDF* this_qpdf = this->oh.getOwningQPDF();
-    if (!this_qpdf) {
+    if (this_qpdf == nullptr) {
         throw std::runtime_error("QPDFPageObjectHelper::copyAnnotations:"
                                  " this page is a direct object");
     }
@@ -1082,13 +1082,13 @@ QPDFPageObjectHelper::copyAnnotations(
     std::set<QPDFObjGen> old_fields;
     std::shared_ptr<QPDFAcroFormDocumentHelper> afdhph;
     std::shared_ptr<QPDFAcroFormDocumentHelper> from_afdhph;
-    if (!afdh) {
+    if (afdh == nullptr) {
         afdhph = std::make_shared<QPDFAcroFormDocumentHelper>(*this_qpdf);
         afdh = afdhph.get();
     }
     if (this_qpdf == from_qpdf) {
         from_afdh = afdh;
-    } else if (from_afdh) {
+    } else if (from_afdh != nullptr) {
         if (from_afdh->getQPDF().getUniqueId() != from_qpdf->getUniqueId()) {
             throw std::logic_error(
                 "QPDFAcroFormDocumentHelper::copyAnnotations: from_afdh"

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -373,7 +373,7 @@ QPDFTokenizer::presentCharacter(char ch)
             }
         } else if (ch == '\\') {
             // last_char_was_bs is set/cleared below as appropriate
-            if (bs_num_count) {
+            if (bs_num_count != 0u) {
                 throw std::logic_error(
                     "INTERNAL ERROR: QPDFTokenizer: bs_num_count != 0 "
                     "when ch == '\\'");
@@ -436,7 +436,7 @@ QPDFTokenizer::presentCharacter(char ch)
         if (ch == '>') {
             this->m->type = tt_string;
             this->m->state = st_token_ready;
-            if (this->m->val.length() % 2) {
+            if ((this->m->val.length() % 2) != 0u) {
                 // PDF spec says odd hexstrings have implicit
                 // trailing 0.
                 this->m->val += '0';
@@ -514,7 +514,7 @@ QPDFTokenizer::expectInlineImage(std::shared_ptr<InputSource> input)
 void
 QPDFTokenizer::findEI(std::shared_ptr<InputSource> input)
 {
-    if (!input.get()) {
+    if (input.get() == nullptr) {
         return;
     }
 
@@ -672,7 +672,7 @@ QPDFTokenizer::readToken(
             if (betweenTokens() && (input->getLastOffset() == offset)) {
                 ++offset;
             }
-            if (max_len && (this->m->raw_val.length() >= max_len) &&
+            if ((max_len != 0u) && (this->m->raw_val.length() >= max_len) &&
                 (this->m->state != st_token_ready)) {
                 // terminate this token now
                 QTC::TC("qpdf", "QPDFTokenizer block long token");

--- a/libqpdf/QPDF_Name.cc
+++ b/libqpdf/QPDF_Name.cc
@@ -36,7 +36,8 @@ QPDF_Name::normalizeName(std::string const& name)
             // QPDFTokenizer embeds a null character to encode an
             // invalid #.
             result += "#";
-        } else if (strchr("#()<>[]{}/%", ch) || (ch < 33) || (ch > 126)) {
+        } else if (
+            (strchr("#()<>[]{}/%", ch) != nullptr) || (ch < 33) || (ch > 126)) {
             result += "#" + QUtil::hex_encode(std::string(&ch, 1));
         } else {
             result += ch;

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -257,7 +257,7 @@ QPDF_Stream::getStreamJSON(
                 filter = false;
                 decode_level = qpdf_dl_none;
             } else {
-                if (buf_pl.get()) {
+                if (buf_pl.get() != nullptr) {
                     buf = buf_pl->getBufferSharedPointer();
                 }
                 break;
@@ -274,7 +274,7 @@ QPDF_Stream::getStreamJSON(
         if (json_data == qpdf_sj_file) {
             result.addDictionaryMember(
                 "datafile", JSON::makeString(data_filename));
-            if (!buf.get()) {
+            if (buf.get() == nullptr) {
                 throw std::logic_error(
                     "QPDF_Stream: failed to get stream data in json file mode");
             }
@@ -437,7 +437,7 @@ QPDF_Stream::filterable(
     bool filterable = true;
 
     for (auto& filter_name: filter_names) {
-        if (filter_abbreviations.count(filter_name)) {
+        if (filter_abbreviations.count(filter_name) != 0u) {
             QTC::TC("qpdf", "QPDF_Stream expand filter abbreviation");
             filter_name = filter_abbreviations[filter_name];
         }
@@ -562,14 +562,14 @@ QPDF_Stream::pipeStreamData(
     std::shared_ptr<ContentNormalizer> normalizer;
     std::shared_ptr<Pipeline> new_pipeline;
     if (filter) {
-        if (encode_flags & qpdf_ef_compress) {
+        if ((encode_flags & qpdf_ef_compress) != 0) {
             new_pipeline = std::make_shared<Pl_Flate>(
                 "compress stream", pipeline, Pl_Flate::a_deflate);
             to_delete.push_back(new_pipeline);
             pipeline = new_pipeline.get();
         }
 
-        if (encode_flags & qpdf_ef_normalize) {
+        if ((encode_flags & qpdf_ef_normalize) != 0) {
             normalizer = std::make_shared<ContentNormalizer>();
             new_pipeline = std::make_shared<Pl_QPDFTokenizer>(
                 "normalizer", normalizer.get(), pipeline);
@@ -589,7 +589,7 @@ QPDF_Stream::pipeStreamData(
         for (auto f_iter = filters.rbegin(); f_iter != filters.rend();
              ++f_iter) {
             auto decode_pipeline = (*f_iter)->getDecodePipeline(pipeline);
-            if (decode_pipeline) {
+            if (decode_pipeline != nullptr) {
                 pipeline = decode_pipeline;
             }
             Pl_Flate* flate = dynamic_cast<Pl_Flate*>(pipeline);
@@ -601,12 +601,12 @@ QPDF_Stream::pipeStreamData(
         }
     }
 
-    if (this->stream_data.get()) {
+    if (this->stream_data.get() != nullptr) {
         QTC::TC("qpdf", "QPDF_Stream pipe replaced stream data");
         pipeline->write(
             this->stream_data->getBuffer(), this->stream_data->getSize());
         pipeline->finish();
-    } else if (this->stream_provider.get()) {
+    } else if (this->stream_provider.get() != nullptr) {
         Pl_Count count("stream provider count", pipeline);
         if (this->stream_provider->supportsRetry()) {
             if (!this->stream_provider->provideStreamData(
@@ -657,7 +657,7 @@ QPDF_Stream::pipeStreamData(
         }
     }
 
-    if (filter && (!suppress_warnings) && normalizer.get() &&
+    if (filter && (!suppress_warnings) && (normalizer.get() != nullptr) &&
         normalizer->anyBadTokens()) {
         warn(
             qpdf_e_damaged_pdf,

--- a/libqpdf/QPDF_String.cc
+++ b/libqpdf/QPDF_String.cc
@@ -108,7 +108,8 @@ QPDF_String::useHexString() const
     for (unsigned int i = 0; i < this->val.length(); ++i) {
         char ch = this->val.at(i);
         if ((ch == 0) ||
-            (!(is_ascii_printable(ch) || strchr("\n\r\t\b\f", ch)))) {
+            (!(is_ascii_printable(ch) ||
+               (strchr("\n\r\t\b\f", ch) != nullptr)))) {
             if ((ch >= 0) && (ch < 24)) {
                 nonprintable = true;
             }

--- a/libqpdf/QPDF_encryption.cc
+++ b/libqpdf/QPDF_encryption.cc
@@ -228,7 +228,7 @@ process_with_aes(
         encrypt,
         QUtil::unsigned_char_pointer(key),
         QIntC::to_uint(key.length()));
-    if (iv) {
+    if (iv != nullptr) {
         aes.setIV(iv, iv_length);
     } else {
         aes.useZeroIV();
@@ -928,7 +928,7 @@ QPDF::initializeEncryption()
     } else {
         if (encryption_dict.getKey("/Length").isInteger()) {
             Length = encryption_dict.getKey("/Length").getIntValueAsInt();
-            if ((Length % 8) || (Length < 40) || (Length > 128)) {
+            if (((Length % 8) != 0) || (Length < 40) || (Length > 128)) {
                 Length = 0;
             }
         }

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -89,7 +89,7 @@ is_indirect_object(std::string const& v, int& obj, int& gen)
     if (*p++ != 'R') {
         return false;
     }
-    if (*p) {
+    if (*p != 0) {
         return false;
     }
     obj = QUtil::string_to_int(o_str.c_str());
@@ -799,7 +799,7 @@ QPDF::writeJSONStream(
             version, json_stream_data, decode_level, stream_p, filename));
 
     JSON::writeDictionaryItem(p, first, key, j, 3);
-    if (f) {
+    if (f != nullptr) {
         f_pl->finish();
         f_pl = nullptr;
         fclose(f);
@@ -908,7 +908,7 @@ QPDF::writeJSON(
     bool all_objects = wanted_objects.empty();
     for (auto& obj: getAllObjects()) {
         std::string key = "obj:" + obj.unparse();
-        if (all_objects || wanted_objects.count(key)) {
+        if (all_objects || (wanted_objects.count(key) != 0u)) {
             if (obj.isStream()) {
                 writeJSONStream(
                     version,
@@ -924,7 +924,7 @@ QPDF::writeJSON(
             }
         }
     }
-    if (all_objects || wanted_objects.count("trailer")) {
+    if (all_objects || (wanted_objects.count("trailer") != 0u)) {
         auto trailer = getTrailer();
         writeJSONObject(version, p, first_qpdf_inner, "trailer", trailer);
     }

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -271,7 +271,7 @@ QPDF::readLinearizationData()
 
     Pl_Buffer pb("hint buffer");
     QPDFObjectHandle H0 = readHintStream(pb, H0_offset, toS(H0_length));
-    if (H1_offset) {
+    if (H1_offset != 0) {
         (void)readHintStream(pb, H1_offset, toS(H1_length));
     }
 
@@ -475,7 +475,7 @@ QPDF::readHSharedObject(BitStream h)
     load_vector_int(
         h, nitems, entries, 1, &HSharedObjectEntry::signature_present);
     for (size_t i = 0; i < toS(nitems); ++i) {
-        if (entries.at(i).signature_present) {
+        if (entries.at(i).signature_present != 0) {
             // Skip 128-bit MD5 hash.  These are not supported by
             // acrobat, so they should probably never be there.  We
             // have no test case for this.
@@ -839,7 +839,7 @@ QPDF::checkHPageOffset(
         }
 
         for (int iter: hint_shared) {
-            if (!computed_shared.count(iter)) {
+            if (computed_shared.count(iter) == 0u) {
                 // pdlin puts thumbnails here even though it shouldn't
                 warnings.push_back(
                     "page " + QUtil::int_to_string(pageno) +
@@ -849,7 +849,7 @@ QPDF::checkHPageOffset(
         }
 
         for (int iter: computed_shared) {
-            if (!hint_shared.count(iter)) {
+            if (hint_shared.count(iter) == 0u) {
                 // Acrobat does not put some things including at least
                 // built-in fonts and procsets here, at least in some
                 // cases.
@@ -1122,7 +1122,7 @@ QPDF::dumpHSharedObject()
             << "\n";
         // PDF spec says signature present nobjects_minus_one are
         // always 0, so print them only if they have a non-zero value.
-        if (se.signature_present) {
+        if (se.signature_present != 0) {
             *this->m->log->getInfo() << "  signature present\n";
         }
         if (se.nobjects_minus_one != 0) {
@@ -1397,7 +1397,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
         stopOnError("no pages found while calculating linearization data");
     }
     QPDFObjGen first_page_og(pages.at(0).getObjGen());
-    if (!lc_first_page_private.count(first_page_og)) {
+    if (lc_first_page_private.count(first_page_og) == 0u) {
         stopOnError(
             "INTERNAL ERROR: QPDF::calculateLinearizationData: first page "
             "object not in lc_first_page_private");
@@ -1440,7 +1440,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
         // Place this page's page object
 
         QPDFObjGen page_og(pages.at(i).getObjGen());
-        if (!lc_other_page_private.count(page_og)) {
+        if (lc_other_page_private.count(page_og) == 0u) {
             stopOnError(
                 "INTERNAL ERROR: "
                 "QPDF::calculateLinearizationData: page object for page " +
@@ -1460,7 +1460,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
                         " calculating linearization data");
         }
         for (auto const& og: this->m->obj_user_to_objects[ou]) {
-            if (lc_other_page_private.count(og)) {
+            if (lc_other_page_private.count(og) != 0u) {
                 lc_other_page_private.erase(og);
                 this->m->part7.push_back(getObjectByObjGen(og));
                 ++this->m->c_page_offset_data.entries.at(i).nobjects;
@@ -1499,7 +1499,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
                     " calculating linearization data");
     }
     for (auto const& og: pages_ogs) {
-        if (lc_other.count(og)) {
+        if (lc_other.count(og) != 0u) {
             lc_other.erase(og);
             this->m->part9.push_back(getObjectByObjGen(og));
         }
@@ -1514,7 +1514,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
         if (!thumb.isNull()) {
             // Output the thumbnail itself
             QPDFObjGen thumb_og(thumb.getObjGen());
-            if (lc_thumbnail_private.count(thumb_og)) {
+            if (lc_thumbnail_private.count(thumb_og) != 0u) {
                 lc_thumbnail_private.erase(thumb_og);
                 this->m->part9.push_back(thumb);
             } else {
@@ -1529,7 +1529,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
                 this->m
                     ->obj_user_to_objects[ObjUser(ObjUser::ou_thumb, toI(i))];
             for (auto const& og: ogs) {
-                if (lc_thumbnail_private.count(og)) {
+                if (lc_thumbnail_private.count(og) != 0u) {
                     lc_thumbnail_private.erase(og);
                     this->m->part9.push_back(getObjectByObjGen(og));
                 }

--- a/libqpdf/QPDF_optimization.cc
+++ b/libqpdf/QPDF_optimization.cc
@@ -352,7 +352,7 @@ QPDF::updateObjectMapsInternal(
 
     if (oh.isIndirect()) {
         QPDFObjGen og(oh.getObjGen());
-        if (visited.count(og)) {
+        if (visited.count(og) != 0u) {
             QTC::TC("qpdf", "QPDF opt loop detected");
             return;
         }

--- a/libqpdf/QPDF_pages.cc
+++ b/libqpdf/QPDF_pages.cc
@@ -61,7 +61,7 @@ QPDF::getAllPages()
         bool warned = false;
         bool changed_pages = false;
         while (pages.isDictionary() && pages.hasKey("/Parent")) {
-            if (seen.count(pages.getObjGen())) {
+            if (seen.count(pages.getObjGen()) != 0u) {
                 // loop -- will be detected again and reported later
                 break;
             }
@@ -118,7 +118,7 @@ QPDF::getAllPagesInternal(
                     " (from 0) is direct; converting to indirect");
                 kid = makeIndirectObject(kid);
                 kids.setArrayItem(i, kid);
-            } else if (seen.count(kid.getObjGen())) {
+            } else if (seen.count(kid.getObjGen()) != 0u) {
                 // Make a copy of the page. This does the same as
                 // shallowCopyPage in QPDFPageObjectHelper.
                 QTC::TC("qpdf", "QPDF resolve duplicated page object");
@@ -254,7 +254,7 @@ QPDF::insertPage(QPDFObjectHandle newpage, int pos)
             2); // insert in middle
 
     auto og = newpage.getObjGen();
-    if (this->m->pageobj_to_pages_pos.count(og)) {
+    if (this->m->pageobj_to_pages_pos.count(og) != 0u) {
         QTC::TC("qpdf", "QPDF resolve duplicated page in insert");
         newpage = makeIndirectObject(QPDFObjectHandle(newpage).shallowCopy());
     }

--- a/libqpdf/QTC.cc
+++ b/libqpdf/QTC.cc
@@ -31,7 +31,7 @@ QTC::TC(char const* const scope, char const* const ccase, int n)
     }
 #undef TC_ENV
 
-    if (cache.count(std::make_pair(ccase, n))) {
+    if (cache.count(std::make_pair(ccase, n)) != 0u) {
         return;
     }
     cache.insert(std::make_pair(ccase, n));

--- a/libqpdf/QUtil.cc
+++ b/libqpdf/QUtil.cc
@@ -417,7 +417,7 @@ unsigned long long
 QUtil::string_to_ull(char const* str)
 {
     char const* p = str;
-    while (*p && is_space(*p)) {
+    while ((*p != 0) && is_space(*p)) {
         ++p;
     }
     if (*p == '-') {
@@ -696,7 +696,7 @@ QUtil::pipe_file(char const* filename, Pipeline* p)
         p->write(buf, len);
     }
     p->finish();
-    if (ferror(f)) {
+    if (ferror(f) != 0) {
         throw std::runtime_error(
             std::string("failure reading file ") + filename);
     }
@@ -878,7 +878,7 @@ QUtil::get_env(std::string const& var, std::string* value)
     if (p == nullptr) {
         return false;
     }
-    if (value) {
+    if (value != nullptr) {
         *value = p;
     }
 
@@ -1031,7 +1031,7 @@ QUtil::pdf_time_to_qpdf_time(std::string const& str, QPDFTime* qtm)
             tz_delta = -tz_delta;
         }
     }
-    if (qtm) {
+    if (qtm != nullptr) {
         *qtm = QPDFTime(
             to_i(m[1]),
             to_i(m[2]),
@@ -1169,7 +1169,7 @@ RandomDataProviderProvider::getProvider()
 void
 RandomDataProviderProvider::setProvider(RandomDataProvider* p)
 {
-    this->current_provider = p ? p : this->default_provider;
+    this->current_provider = p != nullptr ? p : this->default_provider;
 }
 
 static RandomDataProviderProvider*
@@ -1210,13 +1210,13 @@ QUtil::random()
 bool
 QUtil::is_hex_digit(char ch)
 {
-    return (ch && (strchr("0123456789abcdefABCDEF", ch) != nullptr));
+    return ((ch != 0) && (strchr("0123456789abcdefABCDEF", ch) != nullptr));
 }
 
 bool
 QUtil::is_space(char ch)
 {
-    return (ch && (strchr(" \f\n\r\t\v", ch) != nullptr));
+    return ((ch != 0) && (strchr(" \f\n\r\t\v", ch) != nullptr));
 }
 
 bool
@@ -1229,7 +1229,7 @@ bool
 QUtil::is_number(char const* p)
 {
     // ^[\+\-]?(\.\d*|\d+(\.\d*)?)$
-    if (!*p) {
+    if (*p == 0) {
         return false;
     }
     if ((*p == '-') || (*p == '+')) {
@@ -1237,7 +1237,7 @@ QUtil::is_number(char const* p)
     }
     bool found_dot = false;
     bool found_digit = false;
-    for (; *p; ++p) {
+    for (; *p != 0; ++p) {
         if (*p == '.') {
             if (found_dot) {
                 // only one dot
@@ -1270,7 +1270,7 @@ QUtil::read_file_into_memory(
         bytes_read += len;
     }
     if (bytes_read != size) {
-        if (ferror(f)) {
+        if (ferror(f) != 0) {
             throw std::runtime_error(
                 std::string("failure reading file ") + filename +
                 " into memory: read " + uint_to_string(bytes_read) +
@@ -1289,7 +1289,7 @@ read_char_from_FILE(char& ch, FILE* f)
 {
     auto len = fread(&ch, 1, 1, f);
     if (len == 0) {
-        if (ferror(f)) {
+        if (ferror(f) != 0) {
             throw std::runtime_error("failure reading character from file");
         }
         return false;
@@ -1402,9 +1402,9 @@ QUtil::parse_numrange(char const* range, int max)
         bool last_separator_was_dash = false;
         int cur_number = 0;
         bool from_end = false;
-        while (*p) {
+        while (*p != 0) {
             char ch = *p;
-            if (isdigit(ch)) {
+            if (isdigit(ch) != 0) {
                 if (!((state == st_top) || (state == st_in_number))) {
                     throw std::runtime_error("digit not expected");
                 }
@@ -1512,7 +1512,7 @@ QUtil::parse_numrange(char const* range, int max)
         }
     } catch (std::runtime_error const& e) {
         std::string message;
-        if (p) {
+        if (p != nullptr) {
             message = "error at * in numeric range " +
                 std::string(range, QIntC::to_size(p - range)) + "*" + p + ": " +
                 e.what();
@@ -1571,7 +1571,7 @@ QUtil::get_next_utf8_codepoint(
     size_t bytes_needed = 0;
     unsigned bit_check = 0x40;
     unsigned char to_clear = 0x80;
-    while (ch & bit_check) {
+    while ((ch & bit_check) != 0u) {
         ++bytes_needed;
         to_clear = static_cast<unsigned char>(to_clear | bit_check);
         bit_check >>= 1;
@@ -1951,7 +1951,7 @@ QUtil::possible_repaired_encodings(std::string supplied)
     std::vector<std::string> t;
     std::set<std::string> seen;
     for (auto const& iter: result) {
-        if (!seen.count(iter)) {
+        if (seen.count(iter) == 0u) {
             seen.insert(iter);
             t.push_back(iter);
         }

--- a/libqpdf/qpdfjob-c.cc
+++ b/libqpdf/qpdfjob-c.cc
@@ -55,7 +55,7 @@ int
 qpdfjob_initialize_from_wide_argv(qpdfjob_handle j, wchar_t const* const argv[])
 {
     int argc = 0;
-    for (auto k = argv; *k; ++k) {
+    for (auto k = argv; *k != nullptr; ++k) {
         ++argc;
     }
     return QUtil::call_main_from_wmain(

--- a/qpdf/fix-qdf.cc
+++ b/qpdf/fix-qdf.cc
@@ -143,7 +143,7 @@ QdfFixer::processLines(std::list<std::string>& lines)
                 xref_offset = xref.back().getOffset();
                 xref_f1_nbytes = 0;
                 auto t = xref_offset;
-                while (t) {
+                while (t != 0) {
                     t >>= 8;
                     ++xref_f1_nbytes;
                 }
@@ -157,7 +157,7 @@ QdfFixer::processLines(std::list<std::string>& lines)
                         max_objects = e.getObjStreamIndex();
                     }
                 }
-                while (max_objects) {
+                while (max_objects != 0) {
                     max_objects >>= 8;
                     ++xref_f2_nbytes;
                 }

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -3319,7 +3319,7 @@ runtest(int n, char const* filename1, char const* arg2)
         }
         pdf.processMemoryFile(
             (std::string(filename1) + ".pdf").c_str(), p, size);
-    } else if (ignore_filename.count(n)) {
+    } else if (ignore_filename.count(n) != 0u) {
         // Ignore filename argument entirely
     } else if (n == 89) {
         pdf.createFromJSON(filename1);
@@ -3371,7 +3371,7 @@ runtest(int n, char const* filename1, char const* arg2)
     }
     (fn->second)(pdf, arg2);
 
-    if (filep) {
+    if (filep != nullptr) {
         fclose(filep);
     }
     std::cout << "test " << n << " done" << std::endl;

--- a/qpdf/test_large_file.cc
+++ b/qpdf/test_large_file.cc
@@ -53,7 +53,7 @@ static inline unsigned char
 get_pixel_color(size_t n, size_t row)
 {
     return (
-        (n & (1LLU << (nstripes - 1LLU - row)))
+        (n & (1LLU << (nstripes - 1LLU - row))) != 0u
             ? static_cast<unsigned char>('\xc0')
             : static_cast<unsigned char>('\x40'));
 }

--- a/qpdf/test_renumber.cc
+++ b/qpdf/test_renumber.cc
@@ -28,7 +28,7 @@ compare(QPDFObjectHandle a, QPDFObjectHandle b)
 {
     static std::set<QPDFObjGen> visited;
     if (a.isIndirect()) {
-        if (visited.count(a.getObjGen())) {
+        if (visited.count(a.getObjGen()) != 0u) {
             return true;
         }
         visited.insert(a.getObjGen());

--- a/qpdf/test_tokenizer.cc
+++ b/qpdf/test_tokenizer.cc
@@ -147,8 +147,9 @@ dump_tokens(
     qpdf_offset_t inline_image_offset = 0;
     while (!done) {
         QPDFTokenizer::Token token = tokenizer.readToken(
-            is, "test", true, inline_image_offset ? 0 : max_len);
-        if (inline_image_offset && (token.getType() == QPDFTokenizer::tt_bad)) {
+            is, "test", true, inline_image_offset != 0 ? 0 : max_len);
+        if ((inline_image_offset != 0) &&
+            (token.getType() == QPDFTokenizer::tt_bad)) {
             std::cout << "EI not found; resuming normal scanning" << std::endl;
             is->seek(inline_image_offset, SEEK_SET);
             inline_image_offset = 0;
@@ -260,7 +261,7 @@ main(int argc, char* argv[])
             } else {
                 usage();
             }
-        } else if (filename) {
+        } else if (filename != nullptr) {
             usage();
         } else {
             filename = argv[i];


### PR DESCRIPTION
Remove redundant '==' from conditions as suggested by C++ core guideline ES.87.