### PR TITLE
Fix commit  805c1ad : Reset QPDFValue::qpdf and QPDFValue::og when ...

### DIFF
--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1500,23 +1500,6 @@ class QPDFObjectHandle
     };
     friend class ObjAccessor;
 
-    // Provide access to specific classes for recursive
-    // releaseResolved().
-    class ReleaseResolver
-    {
-        friend class QPDF_Dictionary;
-        friend class QPDF_Stream;
-        friend class SparseOHArray;
-
-      private:
-        static void
-        releaseResolved(QPDFObjectHandle& o)
-        {
-            o.releaseResolved();
-        }
-    };
-    friend class ReleaseResolver;
-
     // Convenience routine: Throws if the assumption is violated. Your
     // code will be better if you call one of the isType methods and
     // handle the case of the type being wrong, but these can be
@@ -1614,8 +1597,6 @@ class QPDFObjectHandle
         bool first_level_only,
         bool stop_at_streams);
     void shallowCopyInternal(QPDFObjectHandle& oh, bool first_level_only);
-    void releaseResolved();
-
     void setParsedOffset(qpdf_offset_t offset);
     void parseContentStream_internal(
         std::string const& description, ParserCallbacks* callbacks);

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -249,17 +249,16 @@ QPDF::~QPDF()
     // std::shared_ptr objects will prevent the objects from being
     // deleted.  Walk through all objects in the object cache, which
     // is those objects that we read from the file, and break all
-    // resolved references.  At this point, obviously no one is still
+    // resolved indirect references by replacing them with direct
+    // null objects.  At this point, obviously no one is still
     // using the QPDF object, but we'll explicitly clear the xref
     // table anyway just to prevent any possibility of resolve()
     // succeeding.  Note that we can't break references like this at
-    // any time when the QPDF object is active.  If we do, the next
-    // reference will reread the object from the file, which would
-    // have the effect of undoing any modifications that may have been
-    // made to any of the objects.
+    // any time when the QPDF object is active.
     this->m->xref_table.clear();
+    auto null_obj = QPDF_Null::create();
     for (auto const& iter: this->m->obj_cache) {
-        iter.second.object->releaseResolved();
+        iter.second.object->assign(null_obj);
         iter.second.object->resetObjGen();
     }
 }

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -236,22 +236,6 @@ LastChar::getLastChar()
     return this->last_char;
 }
 
-void
-QPDFObjectHandle::releaseResolved()
-{
-    // Recursively break any resolved references to indirect objects.
-    // Do not cross over indirect object boundaries to avoid an
-    // infinite loop.  This method may only be called during final
-    // destruction.  See comments in QPDF::~QPDF().
-    if (this->obj.get()) {
-        if (isIndirect()) {
-            this->obj = nullptr;
-        } else {
-            this->obj->releaseResolved();
-        }
-    }
-}
-
 qpdf_object_type_e
 QPDFObjectHandle::getTypeCode()
 {

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -34,12 +34,6 @@ QPDF_Array::shallowCopy()
     return create(elements);
 }
 
-void
-QPDF_Array::releaseResolved()
-{
-    this->elements.releaseResolved();
-}
-
 std::string
 QPDF_Array::unparse()
 {

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -21,14 +21,6 @@ QPDF_Dictionary::shallowCopy()
     return create(items);
 }
 
-void
-QPDF_Dictionary::releaseResolved()
-{
-    for (auto& iter: this->items) {
-        QPDFObjectHandle::ReleaseResolver::releaseResolved(iter.second);
-    }
-}
-
 std::string
 QPDF_Dictionary::unparse()
 {

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -168,13 +168,6 @@ QPDF_Stream::getFilterOnWrite() const
 }
 
 void
-QPDF_Stream::releaseResolved()
-{
-    this->stream_provider = nullptr;
-    QPDFObjectHandle::ReleaseResolver::releaseResolved(this->stream_dict);
-}
-
-void
 QPDF_Stream::setObjGen(QPDFObjGen const& og)
 {
     if (this->og.isIndirect()) {

--- a/libqpdf/SparseOHArray.cc
+++ b/libqpdf/SparseOHArray.cc
@@ -49,14 +49,6 @@ SparseOHArray::remove_last()
 }
 
 void
-SparseOHArray::releaseResolved()
-{
-    for (auto& iter: this->elements) {
-        QPDFObjectHandle::ReleaseResolver::releaseResolved(iter.second);
-    }
-}
-
-void
 SparseOHArray::setAt(size_t idx, QPDFObjectHandle oh)
 {
     if (idx >= this->n_elements) {

--- a/libqpdf/qpdf/QPDFObject.hh
+++ b/libqpdf/qpdf/QPDFObject.hh
@@ -137,12 +137,6 @@ class QPDFObject
         return dynamic_cast<T*>(value.get());
     }
 
-    void
-    releaseResolved()
-    {
-        value->releaseResolved();
-    }
-
   private:
     QPDFObject(QPDFObject const&) = delete;
     QPDFObject& operator=(QPDFObject const&) = delete;

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -86,10 +86,7 @@ class QPDFValue
         og(og)
     {
     }
-    virtual void
-    releaseResolved()
-    {
-    }
+
     static std::shared_ptr<QPDFObject> do_create(QPDFValue*);
 
   private:

--- a/libqpdf/qpdf/QPDF_Array.hh
+++ b/libqpdf/qpdf/QPDF_Array.hh
@@ -33,9 +33,6 @@ class QPDF_Array: public QPDFValue
     // API. Otherwise, these would be wrapped in accessor classes.
     void addExplicitElementsToList(std::list<QPDFObjectHandle>&) const;
 
-  protected:
-    virtual void releaseResolved();
-
   private:
     QPDF_Array(std::vector<QPDFObjectHandle> const& items);
     QPDF_Array(SparseOHArray const& items);

--- a/libqpdf/qpdf/QPDF_Dictionary.hh
+++ b/libqpdf/qpdf/QPDF_Dictionary.hh
@@ -32,9 +32,6 @@ class QPDF_Dictionary: public QPDFValue
     // Remove key, doing nothing if key does not exist
     void removeKey(std::string const& key);
 
-  protected:
-    virtual void releaseResolved();
-
   private:
     QPDF_Dictionary(std::map<std::string, QPDFObjectHandle> const& items);
     std::map<std::string, QPDFObjectHandle> items;

--- a/libqpdf/qpdf/QPDF_Stream.hh
+++ b/libqpdf/qpdf/QPDF_Stream.hh
@@ -77,9 +77,6 @@ class QPDF_Stream: public QPDFValue
     // when adding streams to files.
     void setObjGen(QPDFObjGen const& og);
 
-  protected:
-    virtual void releaseResolved();
-
   private:
     QPDF_Stream(
         QPDF*,

--- a/libqpdf/qpdf/SparseOHArray.hh
+++ b/libqpdf/qpdf/SparseOHArray.hh
@@ -12,7 +12,6 @@ class SparseOHArray
     void append(QPDFObjectHandle oh);
     QPDFObjectHandle at(size_t idx) const;
     void remove_last();
-    void releaseResolved();
     void setAt(size_t idx, QPDFObjectHandle oh);
     void erase(size_t idx);
     void insert(size_t idx, QPDFObjectHandle oh);


### PR DESCRIPTION
On destruction of the QPDF object replace all indirect object references
with direct nulls.

Remove all existing code to release resolved references.

Fixes performance issue due to interaction of resetting QPDFValue::qpdf and
og members and prior code.