### PR TITLE
Use unique_ptr and move constructor for Buffer::Members

### DIFF
--- a/include/qpdf/Buffer.hh
+++ b/include/qpdf/Buffer.hh
@@ -49,6 +49,10 @@ class Buffer
     QPDF_DLL
     Buffer& operator=(Buffer const&);
     QPDF_DLL
+    Buffer(Buffer &&) noexcept;
+    QPDF_DLL
+    Buffer& operator=(Buffer &&) noexcept;
+    QPDF_DLL
     size_t getSize() const;
     QPDF_DLL
     unsigned char const* getBuffer() const;
@@ -75,7 +79,7 @@ class Buffer
 
     void copy(Buffer const&);
 
-    std::shared_ptr<Members> m;
+    std::unique_ptr<Members> m;
 };
 
 #endif // BUFFER_HH

--- a/libqpdf/Buffer.cc
+++ b/libqpdf/Buffer.cc
@@ -48,12 +48,24 @@ Buffer::operator=(Buffer const& rhs)
     return *this;
 }
 
+Buffer::Buffer(Buffer&& rhs) noexcept :
+    m(std::move(rhs.m))
+{
+}
+
+Buffer&
+Buffer::operator=(Buffer&& rhs) noexcept
+{
+    std::swap(this->m, rhs.m);
+    return *this;
+}
+
 void
 Buffer::copy(Buffer const& rhs)
 {
     if (this != &rhs) {
         this->m =
-            std::shared_ptr<Members>(new Members(rhs.m->size, nullptr, true));
+            std::unique_ptr<Members>(new Members(rhs.m->size, nullptr, true));
         if (this->m->size) {
             memcpy(this->m->buf, rhs.m->buf, this->m->size);
         }

--- a/libtests/buffer.cc
+++ b/libtests/buffer.cc
@@ -37,6 +37,23 @@ main()
         assert(bc2p[1] == 'W');
     }
 
+    {
+        // Test that buffers can be moved.
+        Buffer bm1(2);
+        unsigned char* bm1p = bm1.getBuffer();
+        bm1p[0] = 'Q';
+        bm1p[1] = 'W';
+        Buffer bm2(std::move(bm1));
+        bm1p[0] = 'R';
+        unsigned char* bm2p = bm2.getBuffer();
+        assert(bm2p == bm1p);
+        assert(bm2p[0] == 'R');
+
+        Buffer bm3 = std::move(bm2);
+        unsigned char* bm3p = bm3.getBuffer();
+        assert(bm3p == bm2p);
+    }
+
     try {
         Pl_Discard discard;
         Pl_Count count("count", &discard);


### PR DESCRIPTION
With the recent commit to privatize the copy constructor in QPDF, it's not longer possible for a QPDF::Members object to be shared, so the member can turned into a unique_ptr. Seems more clear than shared_ptr which implies there are other owners.

For Buffer has always implemented deep copies, so again the Buffer::Members can be converted to a unique_ptr. At the same time I set up move constructors, which cannot be automatically generated in this case due to the custom copy constructors. When compiler decides the move constructor can be used, it will now be able to avoid buffer copies in cases where it would previously be forced to duplicate the buffer and then delete the original.

I don't believe any other classes' ::Members can be converted to unique_ptr at the moment since their implicit copy constructors rely on shared_ptr, but it's quite possible there are some instances.