### PR TITLE
Fix tests with GNU grep 3.8

### DIFF
--- a/abi-perf-test
+++ b/abi-perf-test
@@ -3,7 +3,7 @@ set -eo pipefail
 cd $(dirname $0)
 whoami=$(basename $0)
 
-if [[ $(git status -s | egrep -v abi-perf-test | wc -l) != 0 ]]; then
+if [[ $(git status -s | grep -E -v abi-perf-test | wc -l) != 0 ]]; then
     echo 1>&2 "${whoami}: git is not clean. (abi-perf-test changes ignored)"
     git status -s
     exit 2

--- a/build-scripts/build-doc
+++ b/build-scripts/build-doc
@@ -10,7 +10,7 @@ pip3 install sphinx sphinx_rtd_theme
 cmake -S . -B build -DBUILD_DOC=1
 cmake --build build --target doc_dist
 zip -r doc.zip build/manual/doc-dist
-version=$(egrep '^release' manual/conf.py | cut -d"'" -f 2)
+version=$(grep -E '^release' manual/conf.py | cut -d"'" -f 2)
 mv build/manual/doc-dist qpdf-${version}-doc
 mkdir distribution
 zip -r distribution/qpdf-${version}-doc-ci.zip qpdf-${version}-doc

--- a/build-scripts/build-fuzzer
+++ b/build-scripts/build-fuzzer
@@ -8,7 +8,7 @@ sudo apt-get -y install build-essential cmake zlib1g-dev libjpeg-dev
 ./fuzz/oss-fuzz-build
 ls -l out/qpdf_fuzzer
 ls -l out/
-if ldd out/qpdf_fuzzer | egrep 'libjpeg|libz|libqpdf'; then
+if ldd out/qpdf_fuzzer | grep -E 'libjpeg|libz|libqpdf'; then
     echo 1>&2 "*** Fuzzers linked dynamically with some dependent libraries."
     ldd out/qpdf_fuzzer
     exit 2

--- a/qpdf/qtest/qpdf/diff-encrypted
+++ b/qpdf/qtest/qpdf/diff-encrypted
@@ -1,5 +1,5 @@
 #!/bin/sh
-lines=$(expr 0 + $(diff "$1" "$2" | egrep '^[<>]' | egrep -v '(Date|InstanceID)' | wc -l))
+lines=$(expr 0 + $(diff "$1" "$2" | grep -E '^[<>]' | grep -E -v '(Date|InstanceID)' | wc -l))
 if [ "$lines" = "0" ]; then
    echo okay
 else

--- a/qpdf/qtest/qpdf/diff-ignore-ID-version
+++ b/qpdf/qtest/qpdf/diff-ignore-ID-version
@@ -1,6 +1,6 @@
 #!/bin/sh
-lines=$(expr 0 + $(diff "$1" "$2" | egrep '^[<>]' | \
-        egrep -v '/ID' | egrep -v '%PDF-' | wc -l))
+lines=$(expr 0 + $(diff "$1" "$2" | grep -E '^[<>]' | \
+        grep -E -v '/ID' | grep -E -v '%PDF-' | wc -l))
 if [ "$lines" = "0" ]; then
    echo okay
 else


### PR DESCRIPTION
GNU grep 3.8 started to emit warnings when invoking egrep. Convert all calls to grep -E.
As seen on https://bugzilla.opensuse.org/show_bug.cgi?id=1203231
````
[  266s] Running ../qtest/qpdf.test
[  266s] qpdf test 603 (check non-static ID version) FAILED
[  266s] cwd: /home/abuild/rpmbuild/BUILD/qpdf-10.6.3/qpdf/qtest/qpdf
[  266s] command: sh ./diff-ignore-ID-version a.pdf b.pdf
[  266s]  at qpdf.test line 1725.
[  266s] --> BEGIN EXPECTED OUTPUT <--
[  266s] okay
[  266s] --> END EXPECTED OUTPUT <--
[  266s] --> BEGIN ACTUAL OUTPUT <--
[  266s] egrep: warning: egrep is obsolescent; using grep -E
[  266s] egrep: warning: egrep is obsolescent; using grep -E
[  266s] egrep: warning: egrep is obsolescent; using grep -E
[  266s] okay
[  266s] --> END ACTUAL OUTPUT <--
[  266s] --> DIFF EXPECTED ACTUAL <--
[  266s] --- /tmp/testtemp.13811/expected	2022-09-08 02:09:09.120000000 +0000
[  266s] +++ /tmp/testtemp.13811/actual	2022-09-08 02:09:09.120000000 +0000
[  266s] @@ -1 +1,4 @@
[  266s] +egrep: warning: egrep is obsolescent; using grep -E
[  266s] +egrep: warning: egrep is obsolescent; using grep -E
[  266s] +egrep: warning: egrep is obsolescent; using grep -E
[  266s]  okay
[  266s] --> END DIFFERENCES <--
[  266s] qpdf test 1851 (check against base) FAILED
````