### PR TITLE
Remove obsolete LL_FMT check from build (fixes #768)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-09-12  Jay Berkenbilt  <ejb@ql.org>
+
+        * Remove compile-time test for LL_FMT. It's unlikely that any
+        compiler new enough to build qpdf still doesn't support %lld.
+
 2022-09-10  Jay Berkenbilt  <ejb@ql.org>
 
         * 11.0.0: release

--- a/libqpdf/CMakeLists.txt
+++ b/libqpdf/CMakeLists.txt
@@ -361,24 +361,6 @@ if(LFS_WITH_MACROS AND NOT LFS_WITHOUT_MACROS)
   set(_FILE_OFFSET_BITS 64)
 endif()
 
-function(qpdf_check_ll_fmt fmt var)
-  if(NOT DEFINED LL_FMT)
-    check_c_source_runs(
-      "#define _CRT_SECURE_NO_WARNINGS
-#include <stdio.h>
-#include <string.h>
-int main(int argc, char* argv[]) {
-    long long int a = 123456789012345ll;
-    char s[30];
-    sprintf(s, \"${fmt}\", a);
-    return (strcmp(s, \"123456789012345\") == 0) ? 0 : 1;
-}" ${var})
-    if(${var})
-      set(LL_FMT "${fmt}" PARENT_SCOPE)
-    endif()
-  endif()
-endfunction()
-
 check_c_source_compiles(
 "#include <malloc.h>
 #include <stdio.h>
@@ -401,10 +383,6 @@ int main(int argc, char* argv[]) {
     return 0;
 }"
     HAVE_OPEN_MEMSTREAM)
-
-qpdf_check_ll_fmt("%lld" fmt_lld)
-qpdf_check_ll_fmt("%I64d" fmt_i64d)
-qpdf_check_ll_fmt("%I64lld" fmt_i64lld)
 
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/qpdf/qpdf-config.h.in"

--- a/libqpdf/qpdf/qpdf-config.h.in
+++ b/libqpdf/qpdf/qpdf-config.h.in
@@ -24,9 +24,6 @@
 #cmakedefine HAVE_MALLOC_INFO 1
 #cmakedefine HAVE_OPEN_MEMSTREAM 1
 
-/* printf format for long long */
-#cmakedefine LL_FMT "${LL_FMT}"
-
 /* system random device (e.g. /dev/random) if any */
 #cmakedefine RANDOM_DEVICE "${RANDOM_DEVICE}"
 

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -8,6 +8,12 @@ For a detailed list of changes, please see the file
 
 .. x.y.z: not yet released
 
+11.0.1: not yet released
+  - Build fixes
+
+    - Remove ``LL_FMT`` tests, which were broken for cross
+      compilation. The code just uses ``%lld`` now.
+
 11.0.0: September 10, 2022
   - Replacement of ``PointerHolder`` with ``std::shared_ptr``
 

--- a/qpdf/CMakeLists.txt
+++ b/qpdf/CMakeLists.txt
@@ -27,7 +27,6 @@ foreach(PROG ${MAIN_C_PROGRAMS})
   target_link_libraries(${PROG} libqpdf)
   set_property(TARGET ${PROG} PROPERTY LINKER_LANGUAGE CXX)
 endforeach()
-target_include_directories(qpdf-ctest PRIVATE ${CMAKE_BINARY_DIR}/libqpdf)
 target_include_directories(sizes PRIVATE ${JPEG_INCLUDE})
 
 set(needs_private_headers

--- a/qpdf/qpdf-ctest.c
+++ b/qpdf/qpdf-ctest.c
@@ -6,8 +6,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <qpdf/qpdf-config.h> // for LL_FMT -- special case in build
-
 static char* whoami = 0;
 static qpdf_data qpdf = 0;
 
@@ -42,11 +40,10 @@ safe_fopen(char const* filename, char const* mode)
 static void
 print_error(char const* label, qpdf_data q, qpdf_error e)
 {
-#define POS_FMT "  pos : " LL_FMT "\n"
     printf("%s: %s\n", label, qpdf_get_error_full_text(q, e));
     printf("  code: %d\n", qpdf_get_error_code(q, e));
     printf("  file: %s\n", qpdf_get_error_filename(q, e));
-    printf(POS_FMT, qpdf_get_error_file_position(q, e));
+    printf("  pos: %lld\n", qpdf_get_error_file_position(q, e));
     printf("  text: %s\n", qpdf_get_error_message_detail(q, e));
 }
 

--- a/qpdf/qtest/qpdf/append-page-content-damaged-c-check.out
+++ b/qpdf/qtest/qpdf/append-page-content-damaged-c-check.out
@@ -7,16 +7,16 @@ encrypted: 0
 warning: append-page-content-damaged.pdf: file is damaged
   code: 5
   file: append-page-content-damaged.pdf
-  pos : 0
+  pos: 0
   text: file is damaged
 warning: append-page-content-damaged.pdf: can't find startxref
   code: 5
   file: append-page-content-damaged.pdf
-  pos : 0
+  pos: 0
   text: can't find startxref
 warning: append-page-content-damaged.pdf: Attempting to reconstruct cross-reference table
   code: 5
   file: append-page-content-damaged.pdf
-  pos : 0
+  pos: 0
   text: Attempting to reconstruct cross-reference table
 C test 1 done

--- a/qpdf/qtest/qpdf/c-check-warn.out
+++ b/qpdf/qtest/qpdf/c-check-warn.out
@@ -5,16 +5,16 @@ status: 1
 warning: c-check-warn-in.pdf: file is damaged
   code: 5
   file: c-check-warn-in.pdf
-  pos : 0
+  pos: 0
   text: file is damaged
 warning: c-check-warn-in.pdf (offset 1556): xref not found
   code: 5
   file: c-check-warn-in.pdf
-  pos : 1556
+  pos: 1556
   text: xref not found
 warning: c-check-warn-in.pdf: Attempting to reconstruct cross-reference table
   code: 5
   file: c-check-warn-in.pdf
-  pos : 0
+  pos: 0
   text: Attempting to reconstruct cross-reference table
 C test 23 done

--- a/qpdf/qtest/qpdf/c-get-stream.out
+++ b/qpdf/qtest/qpdf/c-get-stream.out
@@ -2,12 +2,12 @@ page content on broken page
 error: page object 5 0:  object is supposed to be a stream or an array of streams but is neither
   code: 5
   file: 
-  pos : 0
+  pos: 0
   text:  object is supposed to be a stream or an array of streams but is neither
 stream data for non stream
 error: operation for stream attempted on object of type dictionary
   code: 2
   file: 
-  pos : 0
+  pos: 0
   text: operation for stream attempted on object of type dictionary
 C test 38 done

--- a/qpdf/qtest/qpdf/c-invalid-password.out
+++ b/qpdf/qtest/qpdf/c-invalid-password.out
@@ -1,6 +1,6 @@
 error: enc-R2,V1,U=view,O=view.pdf: invalid password
   code: 4
   file: enc-R2,V1,U=view,O=view.pdf
-  pos : 0
+  pos: 0
   text: invalid password
 C test 2 done

--- a/qpdf/qtest/qpdf/c-no-recovery.out
+++ b/qpdf/qtest/qpdf/c-no-recovery.out
@@ -1,6 +1,6 @@
 error: bad33.pdf (offset 1771): xref not found
   code: 5
   file: bad33.pdf
-  pos : 1771
+  pos: 1771
   text: xref not found
 C test 10 done

--- a/qpdf/qtest/qpdf/c-object-handles.out
+++ b/qpdf/qtest/qpdf/c-object-handles.out
@@ -13,11 +13,11 @@ minimal.pdf (C API object handle 9): attempted access to unknown object handle
 warning: minimal.pdf: C API function caught an exception that it isn't returning; please point the application developer to ERROR HANDLING in qpdf-c.h
   code: 1
   file: minimal.pdf
-  pos : 0
+  pos: 0
   text: C API function caught an exception that it isn't returning; please point the application developer to ERROR HANDLING in qpdf-c.h
 error: minimal.pdf (C API object handle 9): attempted access to unknown object handle
   code: 1
   file: minimal.pdf
-  pos : 0
+  pos: 0
   text: attempted access to unknown object handle
 C test 24 done

--- a/qpdf/qtest/qpdf/c-oh-errors.out
+++ b/qpdf/qtest/qpdf/c-oh-errors.out
@@ -1,56 +1,56 @@
 get root: attempted to dereference an uninitialized QPDFObjectHandle
   code: 1
   file: 
-  pos : 0
+  pos: 0
   text: attempted to dereference an uninitialized QPDFObjectHandle
 bad parse: parsed object (offset 1): unknown token while reading object; treating as string
   code: 5
   file: parsed object
-  pos : 1
+  pos: 1
   text: unknown token while reading object; treating as string
 type mismatch (int operation on string): operation for integer attempted on object of type string: returning 0
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for integer attempted on object of type string: returning 0
 type mismatch (string operation on int): operation for string attempted on object of type integer: returning empty string
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for string attempted on object of type integer: returning empty string
 array type mismatch - n_items: operation for array attempted on object of type integer: treating as empty
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for array attempted on object of type integer: treating as empty
 array type mismatch - item: operation for array attempted on object of type integer: returning null
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for array attempted on object of type integer: returning null
 append to non-array: operation for array attempted on object of type integer: ignoring attempt to append item
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for array attempted on object of type integer: ignoring attempt to append item
 array bounds: returning null for out of bounds array access
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: returning null for out of bounds array access
 dictionary iter type mismatch: operation for dictionary attempted on object of type integer: treating as empty
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for dictionary attempted on object of type integer: treating as empty
 dictionary type mismatch: operation for dictionary attempted on object of type integer: returning null for attempted key retrieval
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for dictionary attempted on object of type integer: returning null for attempted key retrieval
 dictionary type mismatch: operation for dictionary attempted on object of type integer: returning false for a key containment request
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for dictionary attempted on object of type integer: returning false for a key containment request
 C test 29 done

--- a/qpdf/qtest/qpdf/c-page-errors.out
+++ b/qpdf/qtest/qpdf/c-page-errors.out
@@ -4,11 +4,11 @@ WARNING: object 27 0: operation for dictionary attempted on object of type null:
 warning: object 27 0: operation for dictionary attempted on object of type null: ignoring key replacement request
   code: 7
   file: 
-  pos : 0
+  pos: 0
   text: operation for dictionary attempted on object of type null: ignoring key replacement request
 error: 11-pages.pdf (C API object handle 1000): attempted access to unknown object handle
   code: 1
   file: 11-pages.pdf
-  pos : 0
+  pos: 0
   text: attempted access to unknown object handle
 C test 35 done

--- a/qpdf/qtest/qpdf/c-read-errors.out
+++ b/qpdf/qtest/qpdf/c-read-errors.out
@@ -1,26 +1,26 @@
 warning: bad1.pdf: can't find PDF header
   code: 5
   file: bad1.pdf
-  pos : 0
+  pos: 0
   text: can't find PDF header
 warning: bad1.pdf: file is damaged
   code: 5
   file: bad1.pdf
-  pos : 0
+  pos: 0
   text: file is damaged
 warning: bad1.pdf: can't find startxref
   code: 5
   file: bad1.pdf
-  pos : 0
+  pos: 0
   text: can't find startxref
 warning: bad1.pdf: Attempting to reconstruct cross-reference table
   code: 5
   file: bad1.pdf
-  pos : 0
+  pos: 0
   text: Attempting to reconstruct cross-reference table
 error: bad1.pdf: unable to find trailer dictionary while recovering damaged file
   code: 5
   file: bad1.pdf
-  pos : 0
+  pos: 0
   text: unable to find trailer dictionary while recovering damaged file
 C test 2 done

--- a/qpdf/qtest/qpdf/c-write-damaged.out
+++ b/qpdf/qtest/qpdf/c-write-damaged.out
@@ -1,16 +1,16 @@
 warning: append-page-content-damaged.pdf: file is damaged
   code: 5
   file: append-page-content-damaged.pdf
-  pos : 0
+  pos: 0
   text: file is damaged
 warning: append-page-content-damaged.pdf: can't find startxref
   code: 5
   file: append-page-content-damaged.pdf
-  pos : 0
+  pos: 0
   text: can't find startxref
 warning: append-page-content-damaged.pdf: Attempting to reconstruct cross-reference table
   code: 5
   file: append-page-content-damaged.pdf
-  pos : 0
+  pos: 0
   text: Attempting to reconstruct cross-reference table
 C test 2 done

--- a/qpdf/qtest/qpdf/c-write-warnings.out
+++ b/qpdf/qtest/qpdf/c-write-warnings.out
@@ -1,21 +1,21 @@
 warning: bad33.pdf: file is damaged
   code: 5
   file: bad33.pdf
-  pos : 0
+  pos: 0
   text: file is damaged
 warning: bad33.pdf (offset 1771): xref not found
   code: 5
   file: bad33.pdf
-  pos : 1771
+  pos: 1771
   text: xref not found
 warning: bad33.pdf: Attempting to reconstruct cross-reference table
   code: 5
   file: bad33.pdf
-  pos : 0
+  pos: 0
   text: Attempting to reconstruct cross-reference table
 warning: bad33.pdf (offset 629): stream filter type is not name or array
   code: 5
   file: bad33.pdf
-  pos : 629
+  pos: 629
   text: stream filter type is not name or array
 C test 2 done

--- a/qpdf/qtest/qpdf/damaged-stream-c-check.out
+++ b/qpdf/qtest/qpdf/damaged-stream-c-check.out
@@ -1,11 +1,11 @@
 warning: damaged-stream.pdf (offset 426): error decoding stream data for object 5 0: LZWDecoder: bad code received
   code: 5
   file: damaged-stream.pdf
-  pos : 426
+  pos: 426
   text: error decoding stream data for object 5 0: LZWDecoder: bad code received
 warning: damaged-stream.pdf (offset 426): stream will be re-processed without filtering to avoid data loss
   code: 5
   file: damaged-stream.pdf
-  pos : 426
+  pos: 426
   text: stream will be re-processed without filtering to avoid data loss
 C test 2 done


### PR DESCRIPTION
This was broken for cross-compilation and has probably been unnecessary for several years now.