### PR TITLE
Overload QPDFTokenizer::readToken to take an InputSource&

### DIFF
--- a/include/qpdf/QPDFTokenizer.hh
+++ b/include/qpdf/QPDFTokenizer.hh
@@ -177,7 +177,12 @@ class QPDFTokenizer
         std::string const& context,
         bool allow_bad = false,
         size_t max_len = 0);
-
+    QPDF_DLL
+    Token readToken(
+        InputSource& input,
+        std::string const& context,
+        bool allow_bad = false,
+        size_t max_len = 0);
     // Calling this method puts the tokenizer in a state for reading
     // inline images. You should call this method after reading the
     // character following the ID operator. In that state, it will

--- a/libqpdf/Pl_QPDFTokenizer.cc
+++ b/libqpdf/Pl_QPDFTokenizer.cc
@@ -49,7 +49,7 @@ Pl_QPDFTokenizer::finish()
 
     while (true) {
         QPDFTokenizer::Token token = this->m->tokenizer.readToken(
-            input, "offset " + std::to_string(input->tell()), true);
+            *input, "offset " + std::to_string(input->tell()), true);
         this->m->filter->handleToken(token);
         if (token.getType() == QPDFTokenizer::tt_eof) {
             break;

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1758,7 +1758,7 @@ QPDFTokenizer::Token
 QPDF::readToken(std::shared_ptr<InputSource> input, size_t max_len)
 {
     return this->m->tokenizer.readToken(
-        input, this->m->last_object_description, true, max_len);
+        *input, this->m->last_object_description, true, max_len);
 }
 
 QPDFObjectHandle

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1919,7 +1919,7 @@ QPDFObjectHandle::parseContentStream_data(
         // from this process is the beginning of the next
         // non-ignorable (space, comment) token. This way, the offset
         // and don't including ignorable content.
-        tokenizer.readToken(input, "content", true);
+        tokenizer.readToken(*input, "content", true);
         qpdf_offset_t offset = input->getLastOffset();
         input->seek(offset, SEEK_SET);
         auto obj = QPDFParser(input, "content", tokenizer, nullptr, context)
@@ -1938,7 +1938,7 @@ QPDFObjectHandle::parseContentStream_data(
             input->read(&ch, 1);
             tokenizer.expectInlineImage(input);
             QPDFTokenizer::Token t =
-                tokenizer.readToken(input, description, true);
+                tokenizer.readToken(*input, description, true);
             offset = input->getLastOffset();
             length = QIntC::to_size(input->tell() - offset);
             if (t.getType() == QPDFTokenizer::tt_bad) {

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -66,7 +66,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
         set_offset = false;
 
         QPDFTokenizer::Token token =
-            tokenizer.readToken(input, object_description, true);
+            tokenizer.readToken(*input, object_description, true);
         std::string const& token_error_message = token.getErrorMessage();
         if (!token_error_message.empty()) {
             // Tokens other than tt_bad can still generate warnings.

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -974,11 +974,21 @@ QPDFTokenizer::readToken(
     bool allow_bad,
     size_t max_len)
 {
-    qpdf_offset_t offset = input->fastTell();
+    return readToken(*input, context, allow_bad, max_len);
+}
+
+QPDFTokenizer::Token
+QPDFTokenizer::readToken(
+    InputSource& input,
+    std::string const& context,
+    bool allow_bad,
+    size_t max_len)
+{
+    qpdf_offset_t offset = input.fastTell();
 
     while (this->state != st_token_ready) {
         char ch;
-        if (!input->fastRead(ch)) {
+        if (!input.fastRead(ch)) {
             presentEOF();
 
             if ((this->type == tt_eof) && (!this->allow_eof)) {
@@ -987,7 +997,7 @@ QPDFTokenizer::readToken(
                 // exercised.
                 this->type = tt_bad;
                 this->error_message = "unexpected EOF";
-                offset = input->getLastOffset();
+                offset = input.getLastOffset();
             }
         } else {
             handleCharacter(ch);
@@ -1013,10 +1023,10 @@ QPDFTokenizer::readToken(
     bool unread_char;
     char char_to_unread;
     getToken(token, unread_char, char_to_unread);
-    input->fastUnread(unread_char);
+    input.fastUnread(unread_char);
 
     if (token.getType() != tt_eof) {
-        input->setLastOffset(offset);
+        input.setLastOffset(offset);
     }
 
     if (token.getType() == tt_bad) {
@@ -1025,7 +1035,7 @@ QPDFTokenizer::readToken(
         } else {
             throw QPDFExc(
                 qpdf_e_damaged_pdf,
-                input->getName(),
+                input.getName(),
                 context,
                 offset,
                 token.getErrorMessage());


### PR DESCRIPTION
shared_ptrs definitely do not come for free.