### PR TITLE
Refactor QPDF::fixDanglingReferences

### DIFF
--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -190,6 +190,11 @@ QPDFParser::parse(bool& empty, bool content_stream)
                         olist.at(size - 2).getIntValueAsInt(),
                         olist.back().getIntValueAsInt());
                     if (ref_og.isIndirect()) {
+                        // This action has the desirable side effect
+                        // of causing dangling references (references
+                        // to indirect objects that don't appear in
+                        // the PDF) in any parsed object to appear in
+                        // the object cache.
                         object = context->getObject(ref_og);
                         indirect_ref = true;
                     } else {

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -381,7 +381,6 @@ QPDFFormFieldObjectHelper list not found 0
 QPDFFormFieldObjectHelper list found 0
 QPDFFormFieldObjectHelper list first too low 0
 QPDFFormFieldObjectHelper list last too high 0
-QPDF detected dangling ref 0
 QPDFJob image optimize no pipeline 0
 QPDFJob image optimize no shrink 0
 QPDFJob image optimize too small 0


### PR DESCRIPTION
This feels too simple, but unless I am missing something, the rest has been taken care of by #726.

I see approx 10% performance improvement.