### PR TITLE
Pass exp_og by value in QPDF::readObjectAtOffset

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1208,7 +1208,7 @@ class QPDF
         bool attempt_recovery,
         qpdf_offset_t offset,
         std::string const& description,
-        QPDFObjGen const& exp_og,
+        QPDFObjGen exp_og,
         QPDFObjGen& og,
         bool skip_cache_if_in_xref);
     void resolve(QPDFObjGen const& og);

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1211,7 +1211,7 @@ class QPDF
         QPDFObjGen exp_og,
         QPDFObjGen& og,
         bool skip_cache_if_in_xref);
-    void resolve(QPDFObjGen const& og);
+    void resolve(QPDFObjGen og);
     void resolveObjectsInStream(int obj_stream_number);
     void stopOnError(std::string const& message);
     QPDFObjectHandle reserveObjectIfNotExists(QPDFObjGen const& og);

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1616,7 +1616,7 @@ QPDF::readObjectAtOffset(
     bool try_recovery,
     qpdf_offset_t offset,
     std::string const& description,
-    QPDFObjGen const& exp_og,
+    QPDFObjGen exp_og,
     QPDFObjGen& og,
     bool skip_cache_if_in_xref)
 {

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1799,7 +1799,7 @@ QPDF::readObjectAtOffset(
 }
 
 void
-QPDF::resolve(QPDFObjGen const& og)
+QPDF::resolve(QPDFObjGen og)
 {
     if (!isUnresolved(og)) {
         return;


### PR DESCRIPTION
Prevent calls to reconstruct_xref from accidentally changing an exp_og passed from the xref table.