### PR TITLE
Correct syntax of example shell test

### DIFF
--- a/manual/cli.rst
+++ b/manual/cli.rst
@@ -2917,7 +2917,7 @@ Related Options
 
    .. code-block:: bash
 
-      if [ qpdf --requires-password file.pdf ]; then
+      if qpdf --requires-password file.pdf; then
           # prompt for password
       fi
 


### PR DESCRIPTION
Here is the output showing that the current example code produces an error, and the corrected syntax doees not:
```
#  if [ qpdf --requires-password file.pdf ]; then
>     echo "testing"
>  fi
-bash: [: --requires-password: binary operator expected
#  if qpdf --requires-password file.pdf; then
>  echo "testing"
> else
>  echo "testing2"
> fi
testing2
```