### PR TITLE
Fix check for direct nulls in QPDFParser::parse

### DIFF
--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -284,7 +284,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
 
         case st_dictionary:
         case st_array:
-            if (!indirect_ref && !object.isDirectNull()) {
+            if (!indirect_ref && !is_null) {
                 // No need to set description for direct nulls - they will
                 // become implicit.
                 setDescriptionFromInput(object, input->getLastOffset());


### PR DESCRIPTION
I am seeing performance improvements of around 20% (up to 50%) for many-nulls tests, and over 0.5% for other tests. Ouch. Sorry. 

Fixes #729