### PR TITLE
Fix QPDFObjectHandle::isScalar

### DIFF
--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -469,9 +469,8 @@ QPDFObjectHandle::isReserved()
 bool
 QPDFObjectHandle::isScalar()
 {
-    return (
-        !(isArray() || isDictionary() || isStream() || isOperator() ||
-          isInlineImage()));
+    return isBool() || isInteger() || isName() || isNull() || isReal() ||
+        isString();
 }
 
 bool

--- a/qpdf/qtest/object-handle-api.test
+++ b/qpdf/qtest/object-handle-api.test
@@ -26,6 +26,10 @@ $td->runtest("equality",
              {$td->COMMAND => "test_driver 93 minimal.pdf -"},
              {$td->STRING => "test 93 done\n", $td->EXIT_STATUS => 0},
              $td->NORMALIZE_NEWLINES);
+$td->runtest("isScalar checks",
+             {$td->COMMAND => "test_driver 95 - -"},
+             {$td->STRING => "test 95 done\n", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
 
 cleanup();
-$td->report(3);
+$td->report(4);

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1559,6 +1559,7 @@ test_42(QPDF& pdf, char const* arg2)
     assert(!uninitialized.isInitialized());
     assert(!uninitialized.isInteger());
     assert(!uninitialized.isDictionary());
+    assert(!uninitialized.isScalar());
 }
 
 static void
@@ -3331,6 +3332,7 @@ test_92(QPDF& pdf, char const* arg2)
     assert(resources.isDictionary());
     assert(!resources.isIndirect());
     auto contents = page1.getKey("/Contents");
+    assert(!contents.isScalar());
     auto contents_dict = contents.getDict();
     qpdf = nullptr;
     auto check = [](QPDFObjectHandle& oh) {
@@ -3347,6 +3349,7 @@ test_92(QPDF& pdf, char const* arg2)
     // Otherwise, they should have retained their old values but just
     // lost their connection to the owning QPDF.
     assert(root.isDestroyed());
+    assert(!root.isScalar());
     assert(page1.isDestroyed());
     assert(contents.isDestroyed());
     assert(resources.isDictionary());
@@ -3488,6 +3491,32 @@ test_94(QPDF& pdf, char const* arg2)
     assert(p5_new_bleed.unparse() == root_media_unparse);
 }
 
+static void
+test_95(QPDF& pdf, char const* arg2)
+{
+    // Test QPDFObjectHandle::isScalar
+
+    auto oh_b = QPDFObjectHandle::newBool(false);
+    auto oh_i = QPDFObjectHandle::newInteger(1);
+    auto oh_r = QPDFObjectHandle::newReal("42.0");
+    auto oh_n = QPDFObjectHandle::newName("/Test");
+    auto oh_s = QPDFObjectHandle::newString("/Test");
+    auto oh_o = QPDFObjectHandle::newOperator("/Test");
+    auto oh_ii = QPDFObjectHandle::newInlineImage("/Test");
+    auto oh_a = QPDFObjectHandle::newArray();
+    auto oh_d = QPDFObjectHandle::newDictionary();
+
+    assert(oh_b.isScalar());
+    assert(oh_i.isScalar());
+    assert(oh_r.isScalar());
+    assert(oh_n.isScalar());
+    assert(oh_s.isScalar());
+    assert(!oh_o.isScalar());
+    assert(!oh_ii.isScalar());
+    assert(!oh_a.isScalar());
+    assert(!oh_d.isScalar());
+}
+
 void
 runtest(int n, char const* filename1, char const* arg2)
 {
@@ -3495,7 +3524,7 @@ runtest(int n, char const* filename1, char const* arg2)
     // the test suite to see how the test is invoked to find the file
     // that the test is supposed to operate on.
 
-    std::set<int> ignore_filename = {61, 81, 83, 84, 85, 86, 87, 92};
+    std::set<int> ignore_filename = {61, 81, 83, 84, 85, 86, 87, 92, 95};
 
     if (n == 0) {
         // Throw in some random test cases that don't fit anywhere
@@ -3597,7 +3626,7 @@ runtest(int n, char const* filename1, char const* arg2)
         {80, test_80}, {81, test_81}, {82, test_82}, {83, test_83},
         {84, test_84}, {85, test_85}, {86, test_86}, {87, test_87},
         {88, test_88}, {89, test_89}, {90, test_90}, {91, test_91},
-        {92, test_92}, {93, test_93}, {94, test_94}};
+        {92, test_92}, {93, test_93}, {94, test_94}, {95, test_95}};
 
     auto fn = test_functions.find(n);
     if (fn == test_functions.end()) {


### PR DESCRIPTION
Exclude uninitialized, destroyed and reserved objects.