### PR TITLE
Refactor QPDFParser::parse

### DIFF
--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1608,12 +1608,12 @@ class QPDFObjectHandle
     QPDF_DLL
     bool isImage(bool exclude_imagemask = true);
 
-  private:
     QPDFObjectHandle(std::shared_ptr<QPDFObject> const& obj) :
         obj(obj)
     {
     }
 
+  private:
     QPDF_Array* asArray();
     QPDF_Bool* asBool();
     QPDF_Dictionary* asDictionary();

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -404,7 +404,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                         QPDFObjectHandle::newString(frame.contents_string);
                     dict["/Contents"].setParsedOffset(frame.contents_offset);
                 }
-                object = QPDF_Dictionary::create(dict);
+                object = QPDF_Dictionary::create(std::move(dict));
                 setDescription(object, offset - 2);
                 // The `offset` points to the next of "<<". Set the rewind
                 // offset to point to the beginning of "<<". This has been

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -441,14 +441,14 @@ QPDFParser::setDescription(
 }
 
 void
-QPDFParser::warn(QPDF* qpdf, QPDFExc const& e)
+QPDFParser::warn(QPDFExc const& e) const
 {
     // If parsing on behalf of a QPDF object and want to give a
     // warning, we can warn through the object. If parsing for some
     // other reason, such as an explicit creation of an object from a
     // string, then just throw the exception.
-    if (qpdf) {
-        qpdf->warn(e);
+    if (context) {
+        context->warn(e);
     } else {
         throw e;
     }
@@ -457,14 +457,8 @@ QPDFParser::warn(QPDF* qpdf, QPDFExc const& e)
 void
 QPDFParser::warn(qpdf_offset_t offset, std::string const& msg) const
 {
-    warn(
-        context,
-        QPDFExc(
-            qpdf_e_damaged_pdf,
-            input->getName(),
-            object_description,
-            offset,
-            msg));
+    warn(QPDFExc(
+        qpdf_e_damaged_pdf, input->getName(), object_description, offset, msg));
 }
 
 void

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -381,7 +381,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                             "dictionary ended prematurely; "
                             "using null as value for last key");
                         val = QPDFObjectHandle::newNull();
-                        setDescription(val, offset);
+                        setDescription(val.obj, offset);
                     } else {
                         val = olist.at(++i);
                     }
@@ -432,9 +432,10 @@ QPDFParser::parse(bool& empty, bool content_stream)
 }
 
 void
-QPDFParser::setDescription(QPDFObjectHandle oh, qpdf_offset_t parsed_offset)
+QPDFParser::setDescription(
+    std::shared_ptr<QPDFObject>& obj, qpdf_offset_t parsed_offset)
 {
-    if (auto& obj = oh.obj) {
+    if (obj) {
         obj->setDescription(context, description, parsed_offset);
     }
 }

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -4,8 +4,23 @@
 #include <qpdf/QPDFObjGen.hh>
 #include <qpdf/QPDFObjectHandle.hh>
 #include <qpdf/QPDFObject_private.hh>
+#include <qpdf/QPDF_Array.hh>
+#include <qpdf/QPDF_Bool.hh>
+#include <qpdf/QPDF_Dictionary.hh>
+#include <qpdf/QPDF_InlineImage.hh>
+#include <qpdf/QPDF_Integer.hh>
+#include <qpdf/QPDF_Name.hh>
+#include <qpdf/QPDF_Null.hh>
+#include <qpdf/QPDF_Operator.hh>
+#include <qpdf/QPDF_Real.hh>
+#include <qpdf/QPDF_Reserved.hh>
+#include <qpdf/QPDF_Stream.hh>
+#include <qpdf/QPDF_String.hh>
+#include <qpdf/QPDF_Unresolved.hh>
 #include <qpdf/QTC.hh>
 #include <qpdf/QUtil.hh>
+
+#include <memory>
 
 namespace
 {
@@ -39,7 +54,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
 
     empty = false;
 
-    QPDFObjectHandle object;
+    std::shared_ptr<QPDFObject> object;
     bool set_offset = false;
 
     std::vector<StackFrame> stack;
@@ -63,7 +78,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
         parser_state_e state = state_stack.back();
         offset = frame.offset;
 
-        object = QPDFObjectHandle();
+        object = nullptr;
         set_offset = false;
 
         QPDFTokenizer::Token token =
@@ -140,7 +155,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
             break;
 
         case QPDFTokenizer::tt_bool:
-            object = QPDFObjectHandle::newBool((token.getValue() == "true"));
+            object = QPDF_Bool::create((token.getValue() == "true"));
             break;
 
         case QPDFTokenizer::tt_null:
@@ -148,18 +163,18 @@ QPDFParser::parse(bool& empty, bool content_stream)
             break;
 
         case QPDFTokenizer::tt_integer:
-            object = QPDFObjectHandle::newInteger(
+            object = QPDF_Integer::create(
                 QUtil::string_to_ll(token.getValue().c_str()));
             break;
 
         case QPDFTokenizer::tt_real:
-            object = QPDFObjectHandle::newReal(token.getValue());
+            object = QPDF_Real::create(token.getValue());
             break;
 
         case QPDFTokenizer::tt_name:
             {
                 std::string name = token.getValue();
-                object = QPDFObjectHandle::newName(name);
+                object = QPDF_Name::create(name);
 
                 if (name == "/Contents") {
                     b_contents = true;
@@ -174,7 +189,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                 std::string const& value = token.getValue();
                 auto size = olist.size();
                 if (content_stream) {
-                    object = QPDFObjectHandle::newOperator(value);
+                    object = QPDF_Operator::create(value);
                 } else if (
                     (value == "R") && (state != st_top) && (size >= 2) &&
                     (!olist.back().isIndirect()) &&
@@ -196,7 +211,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                         // to indirect objects that don't appear in
                         // the PDF) in any parsed object to appear in
                         // the object cache.
-                        object = context->getObject(ref_og);
+                        object = context->getObject(ref_og).obj;
                         indirect_ref = true;
                     } else {
                         QTC::TC("qpdf", "QPDFParser indirect with 0 objid");
@@ -216,7 +231,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                     warn("unknown token while reading object;"
                          " treating as string");
                     bad = true;
-                    object = QPDFObjectHandle::newString(value);
+                    object = QPDF_String::create(value);
                 }
             }
             break;
@@ -232,7 +247,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                     }
                     decrypter->decryptString(val);
                 }
-                object = QPDFObjectHandle::newString(val);
+                object = QPDF_String::create(val);
             }
 
             break;
@@ -245,7 +260,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
             break;
         }
 
-        if (!object.isInitialized() && !is_null &&
+        if (object == nullptr && !is_null &&
             (!((state == st_start) || (state == st_stop) ||
                (state == st_eof)))) {
             throw std::logic_error("QPDFObjectHandle::parseInternal: "
@@ -291,7 +306,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                 setDescription(object, input->getLastOffset());
             }
             set_offset = true;
-            olist.push_back(is_null ? null_oh : object);
+            olist.push_back(is_null ? null_oh : QPDFObjectHandle(object));
             break;
 
         case st_top:
@@ -310,7 +325,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
             parser_state_e old_state = state_stack.back();
             state_stack.pop_back();
             if (old_state == st_array) {
-                object = QPDFObjectHandle::newArray(olist);
+                object = QPDF_Array::create(olist);
                 setDescription(object, offset - 1);
                 // The `offset` points to the next of "[".  Set the rewind
                 // offset to point to the beginning of "[". This has been
@@ -384,7 +399,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                         QPDFObjectHandle::newString(frame.contents_string);
                     dict["/Contents"].setParsedOffset(frame.contents_offset);
                 }
-                object = QPDFObjectHandle::newDictionary(dict);
+                object = QPDF_Dictionary::create(dict);
                 setDescription(object, offset - 2);
                 // The `offset` points to the next of "<<". Set the rewind
                 // offset to point to the beginning of "<<". This has been
@@ -397,13 +412,14 @@ QPDFParser::parse(bool& empty, bool content_stream)
             if (state_stack.back() == st_top) {
                 done = true;
             } else {
-                stack.back().olist.push_back(is_null ? null_oh : object);
+                stack.back().olist.push_back(
+                    is_null ? null_oh : QPDFObjectHandle(object));
             }
         }
     }
 
     if (is_null) {
-        object = QPDFObjectHandle::newNull();
+        object = QPDF_Null::create();
     }
     if (!set_offset) {
         setDescription(object, offset);

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -1,6 +1,7 @@
 #include <qpdf/QPDF_Array.hh>
 
 #include <qpdf/QIntC.hh>
+#include <qpdf/QPDFObject_private.hh>
 #include <qpdf/QUtil.hh>
 #include <stdexcept>
 
@@ -8,6 +9,12 @@ QPDF_Array::QPDF_Array(std::vector<QPDFObjectHandle> const& v) :
     QPDFValue(::ot_array, "array")
 {
     setFromVector(v);
+}
+
+QPDF_Array::QPDF_Array(std::vector<std::shared_ptr<QPDFObject>>&& v) :
+    QPDFValue(::ot_array, "array")
+{
+    setFromVector(std::move(v));
 }
 
 QPDF_Array::QPDF_Array(SparseOHArray const& items) :
@@ -20,6 +27,12 @@ std::shared_ptr<QPDFObject>
 QPDF_Array::create(std::vector<QPDFObjectHandle> const& items)
 {
     return do_create(new QPDF_Array(items));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Array::create(std::vector<std::shared_ptr<QPDFObject>>&& items)
+{
+    return do_create(new QPDF_Array(std::move(items)));
 }
 
 std::shared_ptr<QPDFObject>
@@ -102,6 +115,15 @@ QPDF_Array::setFromVector(std::vector<QPDFObjectHandle> const& v)
 {
     this->elements = SparseOHArray();
     for (auto const& iter: v) {
+        this->elements.append(iter);
+    }
+}
+
+void
+QPDF_Array::setFromVector(std::vector<std::shared_ptr<QPDFObject>>&& v)
+{
+    this->elements = SparseOHArray();
+    for (auto&& iter: v) {
         this->elements.append(iter);
     }
 }

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -123,8 +123,12 @@ void
 QPDF_Array::setFromVector(std::vector<std::shared_ptr<QPDFObject>>&& v)
 {
     this->elements = SparseOHArray();
-    for (auto&& iter: v) {
-        this->elements.append(iter);
+    for (auto&& item: v) {
+        if (item) {
+            this->elements.append(item);
+        } else {
+            ++this->elements.n_elements;
+        }
     }
 }
 

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -9,8 +9,21 @@ QPDF_Dictionary::QPDF_Dictionary(
 {
 }
 
+QPDF_Dictionary::QPDF_Dictionary(
+    std::map<std::string, QPDFObjectHandle>&& items) :
+    QPDFValue(::ot_dictionary, "dictionary"),
+    items(items)
+{
+}
+
 std::shared_ptr<QPDFObject>
 QPDF_Dictionary::create(std::map<std::string, QPDFObjectHandle> const& items)
+{
+    return do_create(new QPDF_Dictionary(items));
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Dictionary::create(std::map<std::string, QPDFObjectHandle>&& items)
 {
     return do_create(new QPDF_Dictionary(items));
 }

--- a/libqpdf/SparseOHArray.cc
+++ b/libqpdf/SparseOHArray.cc
@@ -1,5 +1,8 @@
 #include <qpdf/SparseOHArray.hh>
 
+#include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFObject_private.hh>
+
 #include <stdexcept>
 
 SparseOHArray::SparseOHArray() :
@@ -18,6 +21,15 @@ SparseOHArray::append(QPDFObjectHandle oh)
 {
     if (!oh.isDirectNull()) {
         this->elements[this->n_elements] = oh;
+    }
+    ++this->n_elements;
+}
+
+void
+SparseOHArray::append(std::shared_ptr<QPDFObject>&& obj)
+{
+    if (obj->getTypeCode() != ::ot_null || !obj->getObjGen().isIndirect()) {
+        this->elements[this->n_elements] = std::move(obj);
     }
     ++this->n_elements;
 }

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -41,7 +41,7 @@ class QPDFParser
 
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;
-    static void warn(QPDF*, QPDFExc const&);
+    void warn(QPDFExc const&) const;
     void setDescription(
         std::shared_ptr<QPDFObject>& obj, qpdf_offset_t parsed_offset);
     std::shared_ptr<InputSource> input;

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -42,7 +42,8 @@ class QPDFParser
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;
     static void warn(QPDF*, QPDFExc const&);
-    void setDescription(QPDFObjectHandle oh, qpdf_offset_t parsed_offset);
+    void setDescription(
+        std::shared_ptr<QPDFObject>& obj, qpdf_offset_t parsed_offset);
     std::shared_ptr<InputSource> input;
     std::string const& object_description;
     QPDFTokenizer& tokenizer;

--- a/libqpdf/qpdf/QPDF_Array.hh
+++ b/libqpdf/qpdf/QPDF_Array.hh
@@ -13,6 +13,8 @@ class QPDF_Array: public QPDFValue
     virtual ~QPDF_Array() = default;
     static std::shared_ptr<QPDFObject>
     create(std::vector<QPDFObjectHandle> const& items);
+    static std::shared_ptr<QPDFObject>
+    create(std::vector<std::shared_ptr<QPDFObject>>&& items);
     static std::shared_ptr<QPDFObject> create(SparseOHArray const& items);
     virtual std::shared_ptr<QPDFObject> copy(bool shallow = false);
     virtual std::string unparse();
@@ -25,6 +27,7 @@ class QPDF_Array: public QPDFValue
 
     void setItem(int, QPDFObjectHandle const&);
     void setFromVector(std::vector<QPDFObjectHandle> const& items);
+    void setFromVector(std::vector<std::shared_ptr<QPDFObject>>&& items);
     void insertItem(int at, QPDFObjectHandle const& item);
     void appendItem(QPDFObjectHandle const& item);
     void eraseItem(int at);
@@ -36,6 +39,7 @@ class QPDF_Array: public QPDFValue
 
   private:
     QPDF_Array(std::vector<QPDFObjectHandle> const& items);
+    QPDF_Array(std::vector<std::shared_ptr<QPDFObject>>&& items);
     QPDF_Array(SparseOHArray const& items);
     SparseOHArray elements;
 };

--- a/libqpdf/qpdf/QPDF_Dictionary.hh
+++ b/libqpdf/qpdf/QPDF_Dictionary.hh
@@ -14,6 +14,8 @@ class QPDF_Dictionary: public QPDFValue
     virtual ~QPDF_Dictionary() = default;
     static std::shared_ptr<QPDFObject>
     create(std::map<std::string, QPDFObjectHandle> const& items);
+    static std::shared_ptr<QPDFObject>
+    create(std::map<std::string, QPDFObjectHandle>&& items);
     virtual std::shared_ptr<QPDFObject> copy(bool shallow = false);
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
@@ -35,6 +37,7 @@ class QPDF_Dictionary: public QPDFValue
 
   private:
     QPDF_Dictionary(std::map<std::string, QPDFObjectHandle> const& items);
+    QPDF_Dictionary(std::map<std::string, QPDFObjectHandle>&& items);
     std::map<std::string, QPDFObjectHandle> items;
 };
 

--- a/libqpdf/qpdf/SparseOHArray.hh
+++ b/libqpdf/qpdf/SparseOHArray.hh
@@ -10,6 +10,7 @@ class SparseOHArray
     SparseOHArray();
     size_t size() const;
     void append(QPDFObjectHandle oh);
+    void append(std::shared_ptr<QPDFObject>&& obj);
     QPDFObjectHandle at(size_t idx) const;
     void remove_last();
     void setAt(size_t idx, QPDFObjectHandle oh);

--- a/libqpdf/qpdf/SparseOHArray.hh
+++ b/libqpdf/qpdf/SparseOHArray.hh
@@ -4,6 +4,8 @@
 #include <qpdf/QPDFObjectHandle.hh>
 #include <unordered_map>
 
+class QPDF_Array;
+
 class SparseOHArray
 {
   public:
@@ -25,6 +27,7 @@ class SparseOHArray
     const_iterator end() const;
 
   private:
+    friend class QPDF_Array;
     std::unordered_map<size_t, QPDFObjectHandle> elements;
     size_t n_elements;
 };


### PR DESCRIPTION
The main changes are:
- delay creation of QPDFObjectHandles until parse returns or objects are inserted into QPDF_Arrays/QPDF_Dictionaries.
- avoid unnecessary copying of maps and vectors.
- avoid the overhead of calling QPDFValue methods through QPDFObjectHandles methods.
- change to dictionary processing loop.