### PR TITLE
Do double indirect test correctly

### DIFF
--- a/qpdf/qtest/qpdf/parse-object.out
+++ b/qpdf/qtest/qpdf/parse-object.out
@@ -1,5 +1,5 @@
 [ /name 16059 3.14159 false << /key true /other [ (string1) (string2) ] >> null ]
 logic error parsing indirect: QPDFObjectHandle::parse called without context on an object with indirect references
 trailing data: parsed object (trailing test): trailing data found parsing object from string
-broken indirect object reference: parsed object: trailing data found parsing object from string
+WARNING: parsed object (offset 9): unknown token while reading object; treating as string
 test 31 done

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1245,14 +1245,13 @@ test_31(QPDF& pdf, char const* arg2)
     } catch (std::runtime_error const& e) {
         std::cout << "trailing data: " << e.what() << std::endl;
     }
-    try {
-        assert(QPDFObjectHandle::parse(&pdf, "5 0 R").isInteger());
-        QPDFObjectHandle::parse(&pdf, "5 0 R 0 R");
-        std::cout << "oops -- didn't throw" << std::endl;
-    } catch (std::runtime_error const& e) {
-        std::cout << "broken indirect object reference: " << e.what()
-                  << std::endl;
-    }
+    assert(
+        QPDFObjectHandle::parse(&pdf, "[5 0 R]").getArrayItem(0).isInteger());
+    // Make sure an indirect integer followed by "0 R" is not
+    // mistakenly parsed as an indirect object.
+    assert(
+        QPDFObjectHandle::parse(&pdf, "[5 0 R 0 R /X]").unparse() ==
+        "[ 5 0 R 0 (R) /X ]");
     assert(
         QPDFObjectHandle::parse(&pdf, "[1 0 R]", "indirect test").unparse() ==
         "[ 1 0 R ]");


### PR DESCRIPTION
I realized I had done it wrong before....parsing a string stops after the first successful object, so the error was from the exception in the assertion. That's why other tests wrap stuff in [].