### PR TITLE
Refactor QPDFObjectHandle::ditems

### DIFF
--- a/examples/pdf-mod-info.cc
+++ b/examples/pdf-mod-info.cc
@@ -31,7 +31,7 @@ dumpInfoDict(
 {
     QPDFObjectHandle trailer = pdf.getTrailer();
     if (trailer.hasKey("/Info")) {
-        for (auto& it: trailer.getKey("/Info").ditems()) {
+        for (auto it: trailer.getKey("/Info").dItems()) {
             std::string val;
             if (it.second.isString()) {
                 val = it.second.getStringValue();

--- a/examples/pdf-name-number-tree.cc
+++ b/examples/pdf-name-number-tree.cc
@@ -86,7 +86,7 @@ main(int argc, char* argv[])
     // look at it using dictionary and array iterators.
     std::cout << "Keys in name tree object:" << std::endl;
     QPDFObjectHandle names;
-    for (auto const& i: name_tree_oh.ditems()) {
+    for (auto i: name_tree_oh.dItems()) {
         std::cout << i.first << std::endl;
         if (i.first == "/Names") {
             names = i.second;

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -886,6 +886,7 @@ class QPDFObjectHandle
     // }
     class QPDFDictItems;
     class DictItems;
+    class DictKeys;
     class DictValues;
 
     QPDF_DLL
@@ -893,6 +894,8 @@ class QPDFObjectHandle
 
     QPDF_DLL
     DictItems dItems();
+    QPDF_DLL
+    DictKeys dKeys();
     QPDF_DLL
     DictValues dValues();
 
@@ -1802,6 +1805,64 @@ class QPDFObjectHandle::DictItems
         }
         QPDF_DLL
         value_type operator*();
+        QPDF_DLL
+        bool operator==(iterator const& other) const;
+        QPDF_DLL
+        bool
+        operator!=(iterator const& other) const
+        {
+            return !operator==(other);
+        }
+
+      private:
+        using diter = std::map<std::string, QPDFObjectHandle>::iterator;
+
+        iterator(std::pair<diter, diter> iter);
+
+        std::pair<diter, diter> iters;
+    };
+
+    QPDF_DLL
+    iterator begin();
+    QPDF_DLL
+    iterator end();
+
+  private:
+    QPDFObjectHandle oh;
+};
+
+class QPDFObjectHandle::DictKeys
+{
+  public:
+    QPDF_DLL
+    DictKeys(QPDFObjectHandle oh);
+
+    class iterator
+    {
+        friend class DictKeys;
+
+      public:
+        typedef std::string T;
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T;
+        using difference_type = long;
+        using pointer = T*;
+        using reference = T const&;
+
+        QPDF_DLL
+        virtual ~iterator() = default;
+        QPDF_DLL
+        iterator& operator++();
+        QPDF_DLL
+        iterator
+        operator++(int)
+        {
+            iterator t = *this;
+            ++(*this);
+            return t;
+        }
+        QPDF_DLL
+        reference operator*();
         QPDF_DLL
         bool operator==(iterator const& other) const;
         QPDF_DLL

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1719,7 +1719,6 @@ class QPDFObjectHandle::QPDFDictItems
 
       private:
         iterator(QPDFObjectHandle& oh, bool for_begin);
-        void updateIValue();
 
         class Members
         {
@@ -1730,14 +1729,13 @@ class QPDFObjectHandle::QPDFDictItems
             ~Members() = default;
 
           private:
-            Members(QPDFObjectHandle& oh, bool for_begin);
+            using diter = std::map<std::string, QPDFObjectHandle>::iterator;
+            Members(QPDF_Dictionary* dict, bool for_begin);
             Members() = delete;
             Members(Members const&) = delete;
 
-            QPDFObjectHandle& oh;
-            std::set<std::string> keys;
-            std::set<std::string>::iterator iter;
-            bool is_end;
+            std::pair<diter, diter> iters;
+            diter begin;
         };
         std::shared_ptr<Members> m;
         value_type ivalue;

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -885,8 +885,13 @@ class QPDFObjectHandle
     //     // iter.second is the value
     // }
     class QPDFDictItems;
+    class DictItems;
+
     QPDF_DLL
     QPDFDictItems ditems();
+
+    QPDF_DLL
+    DictItems dItems();
 
     // Return true if key is present.  Keys with null values are treated as if
     // they are not present.  This is as per the PDF spec.
@@ -1739,6 +1744,76 @@ class QPDFObjectHandle::QPDFDictItems
         };
         std::shared_ptr<Members> m;
         value_type ivalue;
+    };
+
+    QPDF_DLL
+    iterator begin();
+    QPDF_DLL
+    iterator end();
+
+  private:
+    QPDFObjectHandle oh;
+};
+
+class QPDFObjectHandle::DictItems
+{
+    // This class allows C++-style iteration, including range-for
+    // iteration, around dictionaries. You can write
+
+    // for (auto iter: DictItems(dictionary_obj))
+    // {
+    //     // iter.first is a string
+    //     // iter.second is a QPDFObjectHandle
+    // }
+
+    // See examples/pdf-name-number-tree.cc for a demonstration of
+    // using this API.
+
+  public:
+    QPDF_DLL
+    DictItems(QPDFObjectHandle oh);
+
+    class iterator
+    {
+        friend class DictItems;
+
+      public:
+        typedef std::pair<std::string, QPDFObjectHandle> T;
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T;
+        using difference_type = long;
+        using pointer = T*;
+        using reference = T&;
+
+        QPDF_DLL
+        virtual ~iterator() = default;
+        QPDF_DLL
+        iterator& operator++();
+        QPDF_DLL
+        iterator
+        operator++(int)
+        {
+            iterator t = *this;
+            ++(*this);
+            return t;
+        }
+        QPDF_DLL
+        value_type operator*();
+        QPDF_DLL
+        bool operator==(iterator const& other) const;
+        QPDF_DLL
+        bool
+        operator!=(iterator const& other) const
+        {
+            return !operator==(other);
+        }
+
+      private:
+        using diter = std::map<std::string, QPDFObjectHandle>::iterator;
+
+        iterator(std::pair<diter, diter> iter);
+
+        std::pair<diter, diter> iters;
     };
 
     QPDF_DLL

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -886,12 +886,15 @@ class QPDFObjectHandle
     // }
     class QPDFDictItems;
     class DictItems;
+    class DictValues;
 
     QPDF_DLL
     QPDFDictItems ditems();
 
     QPDF_DLL
     DictItems dItems();
+    QPDF_DLL
+    DictValues dValues();
 
     // Return true if key is present.  Keys with null values are treated as if
     // they are not present.  This is as per the PDF spec.
@@ -1779,6 +1782,64 @@ class QPDFObjectHandle::DictItems
 
       public:
         typedef std::pair<std::string, QPDFObjectHandle> T;
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T;
+        using difference_type = long;
+        using pointer = T*;
+        using reference = T&;
+
+        QPDF_DLL
+        virtual ~iterator() = default;
+        QPDF_DLL
+        iterator& operator++();
+        QPDF_DLL
+        iterator
+        operator++(int)
+        {
+            iterator t = *this;
+            ++(*this);
+            return t;
+        }
+        QPDF_DLL
+        value_type operator*();
+        QPDF_DLL
+        bool operator==(iterator const& other) const;
+        QPDF_DLL
+        bool
+        operator!=(iterator const& other) const
+        {
+            return !operator==(other);
+        }
+
+      private:
+        using diter = std::map<std::string, QPDFObjectHandle>::iterator;
+
+        iterator(std::pair<diter, diter> iter);
+
+        std::pair<diter, diter> iters;
+    };
+
+    QPDF_DLL
+    iterator begin();
+    QPDF_DLL
+    iterator end();
+
+  private:
+    QPDFObjectHandle oh;
+};
+
+class QPDFObjectHandle::DictValues
+{
+  public:
+    QPDF_DLL
+    DictValues(QPDFObjectHandle oh);
+
+    class iterator
+    {
+        friend class DictValues;
+
+      public:
+        typedef QPDFObjectHandle T;
         using iterator_category = std::input_iterator_tag;
         using value_type = T;
         using difference_type = long;

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2240,8 +2240,8 @@ QPDF::reserveObjects(QPDFObjectHandle foreign, ObjCopier& obj_copier, bool top)
         }
     } else if (foreign.isDictionary()) {
         QTC::TC("qpdf", "QPDF reserve dictionary");
-        for (auto const& key: foreign.getKeys()) {
-            reserveObjects(foreign.getKey(key), obj_copier, false);
+        for (auto item: foreign.dItems()) {
+            reserveObjects(item.second, obj_copier, false);
         }
     } else if (foreign.isStream()) {
         QTC::TC("qpdf", "QPDF reserve stream");
@@ -2284,12 +2284,11 @@ QPDF::replaceForeignIndirectObjects(
     } else if (foreign.isDictionary()) {
         QTC::TC("qpdf", "QPDF replace dictionary");
         result = QPDFObjectHandle::newDictionary();
-        std::set<std::string> keys = foreign.getKeys();
-        for (auto const& iter: keys) {
+        for (auto item: foreign.dItems()) {
             result.replaceKey(
-                iter,
+                item.first,
                 replaceForeignIndirectObjects(
-                    foreign.getKey(iter), obj_copier, false));
+                    item.second, obj_copier, false));
         }
     } else if (foreign.isStream()) {
         QTC::TC("qpdf", "QPDF replace stream");
@@ -2297,13 +2296,11 @@ QPDF::replaceForeignIndirectObjects(
         result = obj_copier.object_map[foreign_og];
         result.assertStream();
         QPDFObjectHandle dict = result.getDict();
-        QPDFObjectHandle old_dict = foreign.getDict();
-        std::set<std::string> keys = old_dict.getKeys();
-        for (auto const& iter: keys) {
+        for (auto item: foreign.getDict().dItems()) {
             dict.replaceKey(
-                iter,
+                item.first,
                 replaceForeignIndirectObjects(
-                    old_dict.getKey(iter), obj_copier, false));
+                    item.second, obj_copier, false));
         }
         copyStreamData(result, foreign);
     } else {

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2287,8 +2287,7 @@ QPDF::replaceForeignIndirectObjects(
         for (auto item: foreign.dItems()) {
             result.replaceKey(
                 item.first,
-                replaceForeignIndirectObjects(
-                    item.second, obj_copier, false));
+                replaceForeignIndirectObjects(item.second, obj_copier, false));
         }
     } else if (foreign.isStream()) {
         QTC::TC("qpdf", "QPDF replace stream");
@@ -2299,8 +2298,7 @@ QPDF::replaceForeignIndirectObjects(
         for (auto item: foreign.getDict().dItems()) {
             dict.replaceKey(
                 item.first,
-                replaceForeignIndirectObjects(
-                    item.second, obj_copier, false));
+                replaceForeignIndirectObjects(item.second, obj_copier, false));
         }
         copyStreamData(result, foreign);
     } else {

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2538,28 +2538,19 @@ QPDF::getCompressibleObjGens()
             visited.insert(og);
         }
         if (obj.isStream()) {
-            QPDFObjectHandle dict = obj.getDict();
-            std::set<std::string> keys = dict.getKeys();
-            for (std::set<std::string>::reverse_iterator iter = keys.rbegin();
-                 iter != keys.rend();
-                 ++iter) {
-                std::string const& key = *iter;
-                QPDFObjectHandle value = dict.getKey(key);
-                if (key == "/Length") {
+            auto it = queue.begin();
+            for (auto item: obj.getDict().dItems()) {
+                if (item.first == "/Length") {
                     // omit stream lengths
-                    if (value.isIndirect()) {
-                        QTC::TC("qpdf", "QPDF exclude indirect length");
-                    }
+                    QTC::TC("qpdf", "QPDF exclude indirect length");
                 } else {
-                    queue.push_front(value);
+                    queue.insert(it, item.second);
                 }
             }
         } else if (obj.isDictionary()) {
-            std::set<std::string> keys = obj.getKeys();
-            for (std::set<std::string>::reverse_iterator iter = keys.rbegin();
-                 iter != keys.rend();
-                 ++iter) {
-                queue.push_front(obj.getKey(*iter));
+            auto it = queue.begin();
+            for (auto oh: obj.dValues()) {
+                queue.insert(it, oh);
             }
         } else if (obj.isArray()) {
             int n = obj.getArrayNItems();

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -735,7 +735,7 @@ QPDFAcroFormDocumentHelper::adjustAppearanceStream(
     // the stream contents.
     resources.mergeResources(merge_with, &dr_map);
     // Remove empty subdictionaries
-    for (auto iter: resources.ditems()) {
+    for (auto iter: resources.dItems()) {
         if (iter.second.isDictionary() && (iter.second.getKeys().size() == 0)) {
             resources.removeKey(iter.first);
         }
@@ -1079,12 +1079,12 @@ QPDFAcroFormDocumentHelper::transformAnnotations(
             return dict.replaceKeyAndGetNew(key, old.copyStream());
         };
         if (apdict.isDictionary()) {
-            for (auto& ap: apdict.ditems()) {
+            for (auto ap: apdict.dItems()) {
                 if (ap.second.isStream()) {
                     streams.push_back(
                         replace_stream(apdict, ap.first, ap.second));
                 } else if (ap.second.isDictionary()) {
-                    for (auto& ap2: ap.second.ditems()) {
+                    for (auto ap2: ap.second.dItems()) {
                         if (ap2.second.isStream()) {
                             streams.push_back(
                                 // line-break

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -1054,7 +1054,7 @@ QPDFJob::doListAttachments(QPDF& pdf)
                     v << "    " << i2.first << " -> " << i2.second << "\n";
                 }
                 v << "  all data streams:\n";
-                for (auto i2: efoh->getEmbeddedFileStreams().ditems()) {
+                for (auto i2: efoh->getEmbeddedFileStreams().dItems()) {
                     auto efs = QPDFEFStreamObjectHelper(i2.second);
                     v << "    " << i2.first << " -> "
                       << efs.getObjectHandle().getObjGen().unparse(',') << "\n";
@@ -1582,7 +1582,7 @@ QPDFJob::doJSONAttachments(Pipeline* p, bool& first, QPDF& pdf)
         }
         auto j_streams =
             j_details.addDictionaryMember("streams", JSON::makeDictionary());
-        for (auto i2: fsoh->getEmbeddedFileStreams().ditems()) {
+        for (auto i2: fsoh->getEmbeddedFileStreams().dItems()) {
             auto efs = QPDFEFStreamObjectHelper(i2.second);
             auto j_stream =
                 j_streams.addDictionaryMember(i2.first, JSON::makeDictionary());

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1112,12 +1112,12 @@ QPDFObjectHandle::makeResourcesIndirect(QPDF& owning_qpdf)
     if (!isDictionary()) {
         return;
     }
-    for (auto const& i1: ditems()) {
+    for (auto i1: dItems()) {
         QPDFObjectHandle sub = i1.second;
         if (!sub.isDictionary()) {
             continue;
         }
-        for (auto i2: sub.ditems()) {
+        for (auto i2: sub.dItems()) {
             std::string const& key = i2.first;
             QPDFObjectHandle val = i2.second;
             if (!val.isIndirect()) {
@@ -1139,7 +1139,7 @@ QPDFObjectHandle::mergeResources(
 
     auto make_og_to_name = [](QPDFObjectHandle& dict,
                               std::map<QPDFObjGen, std::string>& og_to_name) {
-        for (auto i: dict.ditems()) {
+        for (auto i: dict.dItems()) {
             if (i.second.isIndirect()) {
                 og_to_name[i.second.getObjGen()] = i.first;
             }
@@ -1148,7 +1148,7 @@ QPDFObjectHandle::mergeResources(
 
     // This algorithm is described in comments in QPDFObjectHandle.hh
     // above the declaration of mergeResources.
-    for (auto o_top: other.ditems()) {
+    for (auto o_top: other.dItems()) {
         std::string const& rtype = o_top.first;
         QPDFObjectHandle other_val = o_top.second;
         if (hasKey(rtype)) {
@@ -1168,7 +1168,7 @@ QPDFObjectHandle::mergeResources(
                 std::set<std::string> rnames;
                 int min_suffix = 1;
                 bool initialized_maps = false;
-                for (auto ov_iter: other_val.ditems()) {
+                for (auto ov_iter: other_val.dItems()) {
                     std::string const& key = ov_iter.first;
                     QPDFObjectHandle rval = ov_iter.second;
                     if (!this_val.hasKey(key)) {

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1019,6 +1019,12 @@ QPDFObjectHandle::dItems()
     return {*this};
 }
 
+QPDFObjectHandle::DictKeys
+QPDFObjectHandle::dKeys()
+{
+    return {*this};
+}
+
 QPDFObjectHandle::DictValues
 QPDFObjectHandle::dValues()
 {
@@ -2683,6 +2689,47 @@ QPDFObjectHandle::DictItems::iterator::operator*()
 
 bool
 QPDFObjectHandle::DictItems::iterator::operator==(iterator const& other) const
+{
+    return iters.first == other.iters.first;
+}
+
+QPDFObjectHandle::DictKeys::DictKeys(QPDFObjectHandle oh) :
+    oh(oh.isDictionary() ? oh : newDictionary())
+{
+}
+
+QPDFObjectHandle::DictKeys::iterator
+QPDFObjectHandle::DictKeys::begin()
+{
+    return iterator(oh.asDictionary()->getBegin());
+}
+
+QPDFObjectHandle::DictKeys::iterator
+QPDFObjectHandle::DictKeys::end()
+{
+    return iterator(oh.asDictionary()->getEnd());
+}
+
+QPDFObjectHandle::DictKeys::iterator::iterator(std::pair<diter, diter> iter) :
+    iters(iter)
+{
+}
+
+QPDFObjectHandle::DictKeys::iterator&
+QPDFObjectHandle::DictKeys::iterator::operator++()
+{
+    QPDF_Dictionary::increment(iters);
+    return *this;
+}
+
+QPDFObjectHandle::DictKeys::iterator::reference
+QPDFObjectHandle::DictKeys::iterator::operator*()
+{
+    return iters.first->first;
+}
+
+bool
+QPDFObjectHandle::DictKeys::iterator::operator==(iterator const& other) const
 {
     return iters.first == other.iters.first;
 }

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1019,6 +1019,12 @@ QPDFObjectHandle::dItems()
     return {*this};
 }
 
+QPDFObjectHandle::DictValues
+QPDFObjectHandle::dValues()
+{
+    return {*this};
+}
+
 bool
 QPDFObjectHandle::hasKey(std::string const& key)
 {
@@ -2677,6 +2683,47 @@ QPDFObjectHandle::DictItems::iterator::operator*()
 
 bool
 QPDFObjectHandle::DictItems::iterator::operator==(iterator const& other) const
+{
+    return iters.first == other.iters.first;
+}
+
+QPDFObjectHandle::DictValues::DictValues(QPDFObjectHandle oh) :
+    oh(oh.isDictionary() ? oh : newDictionary())
+{
+}
+
+QPDFObjectHandle::DictValues::iterator
+QPDFObjectHandle::DictValues::begin()
+{
+    return iterator(oh.asDictionary()->getBegin());
+}
+
+QPDFObjectHandle::DictValues::iterator
+QPDFObjectHandle::DictValues::end()
+{
+    return iterator(oh.asDictionary()->getEnd());
+}
+
+QPDFObjectHandle::DictValues::iterator::iterator(std::pair<diter, diter> iter) :
+    iters(iter)
+{
+}
+
+QPDFObjectHandle::DictValues::iterator&
+QPDFObjectHandle::DictValues::iterator::operator++()
+{
+    QPDF_Dictionary::increment(iters);
+    return *this;
+}
+
+QPDFObjectHandle::DictValues::iterator::value_type
+QPDFObjectHandle::DictValues::iterator::operator*()
+{
+    return iters.first->second;
+}
+
+bool
+QPDFObjectHandle::DictValues::iterator::operator==(iterator const& other) const
 {
     return iters.first == other.iters.first;
 }

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1245,11 +1245,10 @@ QPDFObjectHandle::getResourceNames()
     if (!isDictionary()) {
         return result;
     }
-    for (auto const& key: getKeys()) {
-        QPDFObjectHandle val = getKey(key);
+    for (auto val: dValues()) {
         if (val.isDictionary()) {
-            for (auto const& val_key: val.getKeys()) {
-                result.insert(val_key);
+            for (auto key: val.dKeys()) {
+                result.insert(std::move(key));
             }
         }
     }
@@ -2256,10 +2255,9 @@ QPDFObjectHandle::makeDirect(
         this->obj = QPDF_Array::create(items);
     } else if (isDictionary()) {
         std::map<std::string, QPDFObjectHandle> items;
-        auto dict = asDictionary();
-        for (auto const& key: getKeys()) {
-            items[key] = dict->getKey(key);
-            items[key].makeDirect(visited, stop_at_streams);
+        for (auto item: dItems()) {
+            item.second.makeDirect(visited, stop_at_streams);
+            items[std::move(item.first)] = item.second;
         }
         this->obj = QPDF_Dictionary::create(items);
     } else if (isStream()) {

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1010,7 +1010,13 @@ QPDFObjectHandle::eraseItemAndGetOld(int at)
 QPDFObjectHandle::QPDFDictItems
 QPDFObjectHandle::ditems()
 {
-    return QPDFDictItems(*this);
+    return {*this};
+}
+
+QPDFObjectHandle::DictItems
+QPDFObjectHandle::dItems()
+{
+    return {*this};
 }
 
 bool
@@ -2632,6 +2638,47 @@ QPDFObjectHandle::QPDFDictItems::iterator
 QPDFObjectHandle::QPDFDictItems::end()
 {
     return iterator(oh, false);
+}
+
+QPDFObjectHandle::DictItems::DictItems(QPDFObjectHandle oh) :
+    oh(oh.isDictionary() ? oh : newDictionary())
+{
+}
+
+QPDFObjectHandle::DictItems::iterator
+QPDFObjectHandle::DictItems::begin()
+{
+    return iterator(oh.asDictionary()->getBegin());
+}
+
+QPDFObjectHandle::DictItems::iterator
+QPDFObjectHandle::DictItems::end()
+{
+    return iterator(oh.asDictionary()->getEnd());
+}
+
+QPDFObjectHandle::DictItems::iterator::iterator(std::pair<diter, diter> iter) :
+    iters(iter)
+{
+}
+
+QPDFObjectHandle::DictItems::iterator&
+QPDFObjectHandle::DictItems::iterator::operator++()
+{
+    QPDF_Dictionary::increment(iters);
+    return *this;
+}
+
+QPDFObjectHandle::DictItems::iterator::value_type
+QPDFObjectHandle::DictItems::iterator::operator*()
+{
+    return *iters.first;
+}
+
+bool
+QPDFObjectHandle::DictItems::iterator::operator==(iterator const& other) const
+{
+    return iters.first == other.iters.first;
 }
 
 QPDFObjectHandle::QPDFArrayItems::QPDFArrayItems(QPDFObjectHandle const& oh) :

--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -1262,10 +1262,8 @@ QPDFWriter::enqueueObject(QPDFObjectHandle object)
                 enqueueObject(item);
             }
         } else if (object.isDictionary()) {
-            for (auto& item: object.getDictAsMap()) {
-                if (!item.second.isNull()) {
-                    enqueueObject(item.second);
-                }
+            for (auto item: object.dItems()) {
+                enqueueObject(item.second);
             }
         }
     } else {
@@ -1661,26 +1659,24 @@ QPDFWriter::unparseObject(
         writeString("<<");
         writeStringQDF("\n");
 
-        for (auto& item: object.getDictAsMap()) {
-            if (!item.second.isNull()) {
-                auto const& key = item.first;
-                writeStringQDF(indent);
-                writeStringQDF("  ");
-                writeStringNoQDF(" ");
-                writeString(QPDF_Name::normalizeName(key));
-                writeString(" ");
-                if (key == "/Contents" && object.isDictionaryOfType("/Sig") &&
-                    object.hasKey("/ByteRange")) {
-                    QTC::TC("qpdf", "QPDFWriter no encryption sig contents");
-                    unparseChild(
-                        item.second,
-                        level + 1,
-                        child_flags | f_hex_string | f_no_encryption);
-                } else {
-                    unparseChild(item.second, level + 1, child_flags);
-                }
-                writeStringQDF("\n");
+        for (auto item: object.dItems()) {
+            auto const& key = item.first;
+            writeStringQDF(indent);
+            writeStringQDF("  ");
+            writeStringNoQDF(" ");
+            writeString(QPDF_Name::normalizeName(key));
+            writeString(" ");
+            if (key == "/Contents" && object.isDictionaryOfType("/Sig") &&
+                object.hasKey("/ByteRange")) {
+                QTC::TC("qpdf", "QPDFWriter no encryption sig contents");
+                unparseChild(
+                    item.second,
+                    level + 1,
+                    child_flags | f_hex_string | f_no_encryption);
+            } else {
+                unparseChild(item.second, level + 1, child_flags);
             }
+            writeStringQDF("\n");
         }
 
         if (flags & f_stream) {

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -127,19 +127,12 @@ QPDF_Dictionary::getAsMap() const
 void
 QPDF_Dictionary::replaceKey(std::string const& key, QPDFObjectHandle value)
 {
-    if (value.isNull()) {
-        // The PDF spec doesn't distinguish between keys with null
-        // values and missing keys.
-        removeKey(key);
-    } else {
-        // add or replace value
-        this->items[key] = value;
-    }
+    this->items[key] = value;
 }
 
 void
 QPDF_Dictionary::removeKey(std::string const& key)
 {
-    // no-op if key does not exist
-    this->items.erase(key);
+    static QPDFObjectHandle null_oh = QPDFObjectHandle::newNull();
+    this->items[key] = null_oh;
 }

--- a/libqpdf/qpdf/QPDF_Dictionary.hh
+++ b/libqpdf/qpdf/QPDF_Dictionary.hh
@@ -11,6 +11,7 @@
 class QPDF_Dictionary: public QPDFValue
 {
     friend class QPDFObjectHandle::QPDFDictItems::iterator;
+    friend class QPDFObjectHandle::DictItems::iterator;
 
   public:
     virtual ~QPDF_Dictionary() = default;

--- a/libqpdf/qpdf/QPDF_Dictionary.hh
+++ b/libqpdf/qpdf/QPDF_Dictionary.hh
@@ -35,6 +35,40 @@ class QPDF_Dictionary: public QPDFValue
     // Remove key, doing nothing if key does not exist
     void removeKey(std::string const& key);
 
+    // Methods to support iteration over dictionaries, skipping null elements.
+    // These methods use pairs of map iterators, where the first element of the
+    // pair is an iterator pointing to the current (non-null) element, and the
+    // second element is the end iterator. The increment method increments the
+    // iterator pair to the next non-null map element.
+    using diter = std::map<std::string, QPDFObjectHandle>::iterator;
+
+    std::pair<diter, diter>
+    getBegin()
+    {
+        auto begin = items.begin();
+        auto end = items.end();
+        while (begin != end && begin->second.isNull()) {
+            ++begin;
+        }
+        return {begin, end};
+    }
+    std::pair<diter, diter>
+    getEnd()
+    {
+        auto end = items.end();
+        return {end, end};
+    }
+    static void
+    increment(std::pair<diter, diter>& iter)
+    {
+        if (iter.first != iter.second) {
+            ++iter.first;
+            while (iter.first != iter.second && iter.first->second.isNull()) {
+                ++iter.first;
+            }
+        }
+    }
+
   private:
     QPDF_Dictionary(std::map<std::string, QPDFObjectHandle> const& items);
     QPDF_Dictionary(std::map<std::string, QPDFObjectHandle>&& items);

--- a/libqpdf/qpdf/QPDF_Dictionary.hh
+++ b/libqpdf/qpdf/QPDF_Dictionary.hh
@@ -10,6 +10,8 @@
 
 class QPDF_Dictionary: public QPDFValue
 {
+    friend class QPDFObjectHandle::QPDFDictItems::iterator;
+
   public:
     virtual ~QPDF_Dictionary() = default;
     static std::shared_ptr<QPDFObject>

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -266,7 +266,7 @@ test_0_1(QPDF& pdf, char const* arg2)
     } else if (qtest.isDictionary()) {
         QTC::TC("qpdf", "main QTest dictionary");
         std::cout << "/QTest is a dictionary" << std::endl;
-        for (auto& iter: qtest.ditems()) {
+        for (auto iter: qtest.ditems()) {
             QTC::TC(
                 "qpdf",
                 "main QTest dictionary indirect",
@@ -1507,9 +1507,21 @@ test_42(QPDF& pdf, char const* arg2)
         ++i;
         --i;
         assert(i->second.getName() == "/Value1");
-        // // Following test only works with dItems. Use i-- instead.
+        // // Following test does not work. Use i-- instead.
         --i;
         // // assert((--i)->second.getName() == "/Value1");
+        assert(i == di.end());
+    }
+    {
+        // Exercise iterators directly
+        auto di = dictionary.dItems();
+        auto i = di.begin();
+        assert((*i).first == "/Key1");
+        assert((*i).second.getName() == "/Value1");
+        assert((*i++).second.getName() == "/Value1");
+        ++i;
+        assert(i == di.end());
+        ++i;
         assert(i == di.end());
     }
     assert("" == qtest.getStringValue());

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1492,12 +1492,25 @@ test_42(QPDF& pdf, char const* arg2)
         auto di = dictionary.ditems();
         auto i = di.begin();
         assert(i->first == "/Key1");
-        auto& i_value = *i;
         assert(i->second.getName() == "/Value1");
-        ++i;
+        // Following test only works with dItems. Use i++ instead.
+        i++;
+        // assert((i++)->second.getName() == "/Value1");
         ++i;
         assert(i == di.end());
-        assert(!i_value.second.isInitialized());
+        ++i;
+        assert(i == di.end());
+        --i;
+        assert(i == di.end());
+
+        i = di.begin();
+        ++i;
+        --i;
+        assert(i->second.getName() == "/Value1");
+        // // Following test only works with dItems. Use i-- instead.
+        --i;
+        // // assert((--i)->second.getName() == "/Value1");
+        assert(i == di.end());
     }
     assert("" == qtest.getStringValue());
     array.getArrayItem(-1).assertNull();


### PR DESCRIPTION
This changes how QPDF_Dictionary handles insertion of QPDF_Nulls / erasure of elements in order to make safe iteration over dictionaries more efficient.

QPDFDictionaryItems has been refactored to access items through iterators of the underlying map in QPDF_Dictionary.

A replacement has been added which returns values rather than references to a copy of the underlying dictionary item. Returning references to a copy has a number of subtle problems, including references returned by the iterator being affected by subsequent iterator operation of this or any other iterator of the same QPDFDictionaryItems instance.  The change was not included in QPDFDictionaryItems since it is API breaking.

Use of dItems is more efficient than using getDictionaryAsMap.

Postfix in/decrement operators of QPDFDictionaryItems are broken. This has not been fixed since it has not created problems in practice and since dItems should be used in preference to ditems.
