### PR TITLE
Tune QPDFWriter::writeString etc methods

### DIFF
--- a/include/qpdf/QPDFWriter.hh
+++ b/include/qpdf/QPDFWriter.hh
@@ -36,6 +36,7 @@
 #include <set>
 #include <stdio.h>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <qpdf/Constants.h>
@@ -553,10 +554,10 @@ class QPDFWriter
 
     unsigned int bytesNeeded(long long n);
     void writeBinary(unsigned long long val, unsigned int bytes);
-    void writeString(std::string const& str);
+    void writeString(std::string_view str);
     void writeBuffer(std::shared_ptr<Buffer>&);
-    void writeStringQDF(std::string const& str);
-    void writeStringNoQDF(std::string const& str);
+    void writeStringQDF(std::string_view str);
+    void writeStringNoQDF(std::string_view str);
     void writePad(size_t nspaces);
     void assignCompressedObjectNumbers(QPDFObjGen const& og);
     void enqueueObject(QPDFObjectHandle object);

--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -982,9 +982,10 @@ QPDFWriter::writeBinary(unsigned long long val, unsigned int bytes)
 }
 
 void
-QPDFWriter::writeString(std::string const& str)
+QPDFWriter::writeString(std::string_view str)
 {
-    this->m->pipeline->writeString(str);
+    m->pipeline->write(
+        reinterpret_cast<unsigned char const*>(str.data()), str.size());
 }
 
 void
@@ -994,18 +995,20 @@ QPDFWriter::writeBuffer(std::shared_ptr<Buffer>& b)
 }
 
 void
-QPDFWriter::writeStringQDF(std::string const& str)
+QPDFWriter::writeStringQDF(std::string_view str)
 {
-    if (this->m->qdf_mode) {
-        writeString(str);
+    if (m->qdf_mode) {
+        m->pipeline->write(
+            reinterpret_cast<unsigned char const*>(str.data()), str.size());
     }
 }
 
 void
-QPDFWriter::writeStringNoQDF(std::string const& str)
+QPDFWriter::writeStringNoQDF(std::string_view str)
 {
-    if (!this->m->qdf_mode) {
-        writeString(str);
+    if (!m->qdf_mode) {
+        m->pipeline->write(
+            reinterpret_cast<unsigned char const*>(str.data()), str.size());
     }
 }
 


### PR DESCRIPTION
Use string_view parameters and call pipeline write methods directly.

Reduces run time by around 2%, so its probably worth to include this in 11.3