### PR TITLE
Refactor setting of object descriptions in QPDF::JSONReactor

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -32,6 +32,7 @@
 #include <memory>
 #include <stdio.h>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <qpdf/Buffer.hh>
@@ -50,6 +51,7 @@ class BitStream;
 class BitWriter;
 class QPDFLogger;
 class QPDFParser;
+struct JSON_Descr;
 
 class QPDF
 {
@@ -1152,6 +1154,7 @@ class QPDF
         QPDF& pdf;
         std::shared_ptr<InputSource> is;
         bool must_be_complete;
+        std::shared_ptr<std::variant<std::string, JSON_Descr>> descr;
         bool errors;
         bool parse_error;
         bool saw_qpdf;

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -32,7 +32,6 @@
 #include <memory>
 #include <stdio.h>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include <qpdf/Buffer.hh>
@@ -51,7 +50,6 @@ class BitStream;
 class BitWriter;
 class QPDFLogger;
 class QPDFParser;
-struct JSON_Descr;
 
 class QPDF
 {
@@ -1110,72 +1108,7 @@ class QPDF
         std::set<QPDFObjGen>::const_iterator iter;
     };
 
-    class JSONReactor: public JSON::Reactor
-    {
-      public:
-        JSONReactor(
-            QPDF&, std::shared_ptr<InputSource> is, bool must_be_complete);
-        virtual ~JSONReactor() = default;
-        virtual void dictionaryStart() override;
-        virtual void arrayStart() override;
-        virtual void containerEnd(JSON const& value) override;
-        virtual void topLevelScalar() override;
-        virtual bool
-        dictionaryItem(std::string const& key, JSON const& value) override;
-        virtual bool arrayItem(JSON const& value) override;
-
-        bool anyErrors() const;
-
-      private:
-        enum state_e {
-            st_initial,
-            st_top,
-            st_qpdf,
-            st_qpdf_meta,
-            st_objects,
-            st_trailer,
-            st_object_top,
-            st_stream,
-            st_object,
-            st_ignore,
-        };
-
-        void containerStart();
-        void nestedState(std::string const& key, JSON const& value, state_e);
-        void setObjectDescription(QPDFObjectHandle& oh, JSON const& value);
-        QPDFObjectHandle makeObject(JSON const& value);
-        void error(qpdf_offset_t offset, std::string const& message);
-        QPDFObjectHandle reserveObject(int obj, int gen);
-        void replaceObject(
-            QPDFObjectHandle to_replace,
-            QPDFObjectHandle replacement,
-            JSON const& value);
-
-        QPDF& pdf;
-        std::shared_ptr<InputSource> is;
-        bool must_be_complete;
-        std::shared_ptr<std::variant<std::string, JSON_Descr>> descr;
-        bool errors;
-        bool parse_error;
-        bool saw_qpdf;
-        bool saw_qpdf_meta;
-        bool saw_objects;
-        bool saw_json_version;
-        bool saw_pdf_version;
-        bool saw_trailer;
-        state_e state;
-        state_e next_state;
-        std::string cur_object;
-        bool saw_value;
-        bool saw_stream;
-        bool saw_dict;
-        bool saw_data;
-        bool saw_datafile;
-        bool this_stream_needs_data;
-        std::vector<state_e> state_stack;
-        std::vector<QPDFObjectHandle> object_stack;
-        std::set<QPDFObjGen> reserved;
-    };
+    class JSONReactor;
 
     void parse(char const* password);
     void inParse(bool);

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -2176,7 +2176,8 @@ QPDFObjectHandle::setObjectDescription(
     // This is called during parsing on newly created direct objects,
     // so we can't call dereference() here.
     if (isInitialized() && obj.get()) {
-        auto descr = std::make_shared<std::string>(object_description);
+        auto descr =
+            std::make_shared<QPDFValue::Description>(object_description);
         obj->setDescription(owning_qpdf, descr);
     }
 }

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -9,3 +9,20 @@ QPDFValue::do_create(QPDFValue* object)
     obj->value = std::shared_ptr<QPDFValue>(object);
     return obj;
 }
+
+std::string
+QPDFValue::getDescription()
+{
+    auto description = object_description ? *object_description : "";
+    if (auto pos = description.find("$OG"); pos != std::string::npos) {
+        description.replace(pos, 3, og.unparse(' '));
+    }
+    if (auto pos = description.find("$PO"); pos != std::string::npos) {
+        qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
+            : (type_code == ::ot_array)                      ? 1
+                                                             : 0;
+
+        description.replace(pos, 3, std::to_string(parsed_offset + shift));
+    }
+    return description;
+}

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -35,6 +35,8 @@ QPDFValue::getDescription()
                 return description;
             }
         }
+    } else if (og.isIndirect()) {
+        return "object " + og.unparse(' ');
     }
     return {};
 }

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -34,6 +34,14 @@ QPDFValue::getDescription()
                 }
                 return description;
             }
+        case 1:
+            {
+                auto j_descr = std::get<1>(*object_description);
+                return (
+                    *j_descr.input +
+                    (j_descr.object.empty() ? "" : ", " + j_descr.object) +
+                    " at offset " + std::to_string(parsed_offset));
+            }
         }
     } else if (og.isIndirect()) {
         return "object " + og.unparse(' ');

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -13,16 +13,28 @@ QPDFValue::do_create(QPDFValue* object)
 std::string
 QPDFValue::getDescription()
 {
-    auto description = object_description ? *object_description : "";
-    if (auto pos = description.find("$OG"); pos != std::string::npos) {
-        description.replace(pos, 3, og.unparse(' '));
-    }
-    if (auto pos = description.find("$PO"); pos != std::string::npos) {
-        qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
-            : (type_code == ::ot_array)                      ? 1
-                                                             : 0;
+    if (object_description) {
+        switch (object_description->index()) {
+        case 0:
+            {
+                auto description = std::get<0>(*object_description);
 
-        description.replace(pos, 3, std::to_string(parsed_offset + shift));
+                if (auto pos = description.find("$OG");
+                    pos != std::string::npos) {
+                    description.replace(pos, 3, og.unparse(' '));
+                }
+                if (auto pos = description.find("$PO");
+                    pos != std::string::npos) {
+                    qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
+                        : (type_code == ::ot_array)                      ? 1
+                                                                         : 0;
+
+                    description.replace(
+                        pos, 3, std::to_string(parsed_offset + shift));
+                }
+                return description;
+            }
+        }
     }
-    return description;
+    return {};
 }

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -123,7 +123,7 @@ QPDF_Stream::QPDF_Stream(
         throw std::logic_error("stream object instantiated with non-dictionary "
                                "object for dictionary");
     }
-    auto descr = std::make_shared<std::string>(
+    auto descr = std::make_shared<QPDFValue::Description>(
         qpdf->getFilename() + ", stream object " + og.unparse(' '));
     setDescription(qpdf, descr, offset);
 }
@@ -283,7 +283,9 @@ QPDF_Stream::getStreamJSON(
 
 void
 QPDF_Stream::setDescription(
-    QPDF* qpdf, std::shared_ptr<std::string>& description, qpdf_offset_t offset)
+    QPDF* qpdf,
+    std::shared_ptr<QPDFValue::Description>& description,
+    qpdf_offset_t offset)
 {
     this->QPDFValue::setDescription(qpdf, description, offset);
     setDictDescription();

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -226,7 +226,15 @@ provide_data(
 class QPDF::JSONReactor: public JSON::Reactor
 {
   public:
-    JSONReactor(QPDF&, std::shared_ptr<InputSource> is, bool must_be_complete);
+    JSONReactor(
+        QPDF& pdf, std::shared_ptr<InputSource> is, bool must_be_complete) :
+        pdf(pdf),
+        is(is),
+        must_be_complete(must_be_complete),
+        descr(std::make_shared<QPDFValue::Description>(QPDFValue::JSON_Descr(
+            std::make_shared<std::string>(is->getName()), "")))
+    {
+    }
     virtual ~JSONReactor() = default;
     virtual void dictionaryStart() override;
     virtual void arrayStart() override;
@@ -265,56 +273,29 @@ class QPDF::JSONReactor: public JSON::Reactor
 
     QPDF& pdf;
     std::shared_ptr<InputSource> is;
-    bool must_be_complete;
+    bool must_be_complete{true};
     std::shared_ptr<QPDFValue::Description> descr;
-    bool errors;
-    bool parse_error;
-    bool saw_qpdf;
-    bool saw_qpdf_meta;
-    bool saw_objects;
-    bool saw_json_version;
-    bool saw_pdf_version;
-    bool saw_trailer;
-    state_e state;
-    state_e next_state;
+    bool errors{false};
+    bool parse_error{false};
+    bool saw_qpdf{false};
+    bool saw_qpdf_meta{false};
+    bool saw_objects{false};
+    bool saw_json_version{false};
+    bool saw_pdf_version{false};
+    bool saw_trailer{false};
+    state_e state{st_initial};
+    state_e next_state{st_top};
     std::string cur_object;
-    bool saw_value;
-    bool saw_stream;
-    bool saw_dict;
-    bool saw_data;
-    bool saw_datafile;
-    bool this_stream_needs_data;
-    std::vector<state_e> state_stack;
+    bool saw_value{false};
+    bool saw_stream{false};
+    bool saw_dict{false};
+    bool saw_data{false};
+    bool saw_datafile{false};
+    bool this_stream_needs_data{false};
+    std::vector<state_e> state_stack{st_initial};
     std::vector<QPDFObjectHandle> object_stack;
     std::set<QPDFObjGen> reserved;
 };
-
-QPDF::JSONReactor::JSONReactor(
-    QPDF& pdf, std::shared_ptr<InputSource> is, bool must_be_complete) :
-    pdf(pdf),
-    is(is),
-    must_be_complete(must_be_complete),
-    descr(std::make_shared<QPDFValue::Description>(QPDFValue::JSON_Descr(
-        std::make_shared<std::string>(is->getName()), ""))),
-    errors(false),
-    parse_error(false),
-    saw_qpdf(false),
-    saw_qpdf_meta(false),
-    saw_objects(false),
-    saw_json_version(false),
-    saw_pdf_version(false),
-    saw_trailer(false),
-    state(st_initial),
-    next_state(st_top),
-    saw_value(false),
-    saw_stream(false),
-    saw_dict(false),
-    saw_data(false),
-    saw_datafile(false),
-    this_stream_needs_data(false)
-{
-    state_stack.push_back(st_initial);
-}
 
 void
 QPDF::JSONReactor::error(qpdf_offset_t offset, std::string const& msg)

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -223,13 +223,79 @@ provide_data(
     };
 }
 
+class QPDF::JSONReactor: public JSON::Reactor
+{
+  public:
+    JSONReactor(QPDF&, std::shared_ptr<InputSource> is, bool must_be_complete);
+    virtual ~JSONReactor() = default;
+    virtual void dictionaryStart() override;
+    virtual void arrayStart() override;
+    virtual void containerEnd(JSON const& value) override;
+    virtual void topLevelScalar() override;
+    virtual bool
+    dictionaryItem(std::string const& key, JSON const& value) override;
+    virtual bool arrayItem(JSON const& value) override;
+
+    bool anyErrors() const;
+
+  private:
+    enum state_e {
+        st_initial,
+        st_top,
+        st_qpdf,
+        st_qpdf_meta,
+        st_objects,
+        st_trailer,
+        st_object_top,
+        st_stream,
+        st_object,
+        st_ignore,
+    };
+
+    void containerStart();
+    void nestedState(std::string const& key, JSON const& value, state_e);
+    void setObjectDescription(QPDFObjectHandle& oh, JSON const& value);
+    QPDFObjectHandle makeObject(JSON const& value);
+    void error(qpdf_offset_t offset, std::string const& message);
+    QPDFObjectHandle reserveObject(int obj, int gen);
+    void replaceObject(
+        QPDFObjectHandle to_replace,
+        QPDFObjectHandle replacement,
+        JSON const& value);
+
+    QPDF& pdf;
+    std::shared_ptr<InputSource> is;
+    bool must_be_complete;
+    std::shared_ptr<QPDFValue::Description> descr;
+    bool errors;
+    bool parse_error;
+    bool saw_qpdf;
+    bool saw_qpdf_meta;
+    bool saw_objects;
+    bool saw_json_version;
+    bool saw_pdf_version;
+    bool saw_trailer;
+    state_e state;
+    state_e next_state;
+    std::string cur_object;
+    bool saw_value;
+    bool saw_stream;
+    bool saw_dict;
+    bool saw_data;
+    bool saw_datafile;
+    bool this_stream_needs_data;
+    std::vector<state_e> state_stack;
+    std::vector<QPDFObjectHandle> object_stack;
+    std::set<QPDFObjGen> reserved;
+};
+
 QPDF::JSONReactor::JSONReactor(
     QPDF& pdf, std::shared_ptr<InputSource> is, bool must_be_complete) :
     pdf(pdf),
     is(is),
     must_be_complete(must_be_complete),
-    descr(std::make_shared<std::variant<std::string, JSON_Descr>>(
-        JSON_Descr(std::make_shared<std::string>(is->getName()), ""))),
+    descr(std::make_shared<QPDFValue::Description>(QPDFValue::JSON_Descr(
+        std::make_shared<std::string>(is->getName()), ""))),
     errors(false),
     parse_error(false),
     saw_qpdf(false),
@@ -679,10 +745,10 @@ QPDF::JSONReactor::arrayItem(JSON const& value)
 void
 QPDF::JSONReactor::setObjectDescription(QPDFObjectHandle& oh, JSON const& value)
 {
-    auto j_descr = std::get<JSON_Descr>(*descr);
+    auto j_descr = std::get<QPDFValue::JSON_Descr>(*descr);
     if (j_descr.object != cur_object) {
         descr = std::make_shared<QPDFValue::Description>(
-            JSON_Descr(j_descr.input, cur_object));
+            QPDFValue::JSON_Descr(j_descr.input, cur_object));
     }
 
     oh.getObjectPtr()->setDescription(&pdf, descr, value.getStart());

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -71,7 +71,7 @@ class QPDFObject
     void
     setDescription(
         QPDF* qpdf,
-        std::shared_ptr<std::string>& description,
+        std::shared_ptr<QPDFValue::Description>& description,
         qpdf_offset_t offset = -1)
     {
         return value->setDescription(qpdf, description, offset);

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -2,6 +2,7 @@
 #define QPDFPARSER_HH
 
 #include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFValue.hh>
 
 #include <memory>
 #include <string>
@@ -21,8 +22,8 @@ class QPDFParser
         tokenizer(tokenizer),
         decrypter(decrypter),
         context(context),
-        description(std::make_shared<std::string>(
-            input->getName() + ", " + object_description + " at offset $PO"))
+        description(std::make_shared<QPDFValue::Description>(std::string(
+            input->getName() + ", " + object_description + " at offset $PO")))
     {
     }
     virtual ~QPDFParser() = default;
@@ -49,7 +50,7 @@ class QPDFParser
     QPDFTokenizer& tokenizer;
     QPDFObjectHandle::StringDecrypter* decrypter;
     QPDF* context;
-    std::shared_ptr<std::string> description;
+    std::shared_ptr<QPDFValue::Description> description;
 };
 
 #endif // QPDFPARSER_HH

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -40,11 +40,6 @@ class QPDFValue
     void
     setDefaultDescription(QPDF* a_qpdf, QPDFObjGen const& a_og)
     {
-        static auto default_description{
-            std::make_shared<Description>("object $OG")};
-        if (!object_description) {
-            object_description = default_description;
-        }
         qpdf = a_qpdf;
         og = a_og;
     }
@@ -52,7 +47,7 @@ class QPDFValue
     bool
     hasDescription()
     {
-        return object_description != nullptr;
+        return object_description || og.isIndirect();
     }
     void
     setParsedOffset(qpdf_offset_t offset)

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -44,22 +44,7 @@ class QPDFValue
         qpdf = a_qpdf;
         og = a_og;
     }
-    std::string
-    getDescription()
-    {
-        auto description = object_description ? *object_description : "";
-        if (auto pos = description.find("$OG"); pos != std::string::npos) {
-            description.replace(pos, 3, og.unparse(' '));
-        }
-        if (auto pos = description.find("$PO"); pos != std::string::npos) {
-            qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
-                : (type_code == ::ot_array)                      ? 1
-                                                                 : 0;
-
-            description.replace(pos, 3, std::to_string(parsed_offset + shift));
-        }
-        return description;
-    }
+    std::string getDescription();
     bool
     hasDescription()
     {

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -52,8 +52,7 @@ class QPDFValue
     bool
     hasDescription()
     {
-        return qpdf != nullptr && object_description &&
-            !getDescription().empty();
+        return object_description != nullptr;
     }
     void
     setParsedOffset(qpdf_offset_t offset)

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -14,18 +14,6 @@ class QPDF;
 class QPDFObjectHandle;
 class QPDFObject;
 
-struct JSON_Descr
-{
-    JSON_Descr(std::shared_ptr<std::string> input, std::string const& object) :
-        input(input),
-        object(object)
-    {
-    }
-
-    std::shared_ptr<std::string> input;
-    std::string object;
-};
-
 class QPDFValue
 {
     friend class QPDFObject;
@@ -36,6 +24,19 @@ class QPDFValue
     virtual std::shared_ptr<QPDFObject> copy(bool shallow = false) = 0;
     virtual std::string unparse() = 0;
     virtual JSON getJSON(int json_version) = 0;
+
+    struct JSON_Descr
+    {
+        JSON_Descr(
+            std::shared_ptr<std::string> input, std::string const& object) :
+            input(input),
+            object(object)
+        {
+        }
+
+        std::shared_ptr<std::string> input;
+        std::string object;
+    };
 
     using Description = std::variant<std::string, JSON_Descr>;
 

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -8,6 +8,7 @@
 #include <qpdf/Types.h>
 
 #include <string>
+#include <variant>
 
 class QPDF;
 class QPDFObjectHandle;
@@ -23,10 +24,13 @@ class QPDFValue
     virtual std::shared_ptr<QPDFObject> copy(bool shallow = false) = 0;
     virtual std::string unparse() = 0;
     virtual JSON getJSON(int json_version) = 0;
+
+    using Description = std::variant<std::string>;
+
     virtual void
     setDescription(
         QPDF* qpdf_p,
-        std::shared_ptr<std::string>& description,
+        std::shared_ptr<Description>& description,
         qpdf_offset_t offset)
     {
         qpdf = qpdf_p;
@@ -37,7 +41,7 @@ class QPDFValue
     setDefaultDescription(QPDF* a_qpdf, QPDFObjGen const& a_og)
     {
         static auto default_description{
-            std::make_shared<std::string>("object $OG")};
+            std::make_shared<Description>("object $OG")};
         if (!object_description) {
             object_description = default_description;
         }
@@ -49,7 +53,7 @@ class QPDFValue
     hasDescription()
     {
         return qpdf != nullptr && object_description &&
-            !object_description->empty();
+            !getDescription().empty();
     }
     void
     setParsedOffset(qpdf_offset_t offset)
@@ -108,7 +112,7 @@ class QPDFValue
   private:
     QPDFValue(QPDFValue const&) = delete;
     QPDFValue& operator=(QPDFValue const&) = delete;
-    std::shared_ptr<std::string> object_description;
+    std::shared_ptr<Description> object_description;
 
     const qpdf_object_type_e type_code{::ot_uninitialized};
     char const* type_name{"uninitialized"};

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -14,6 +14,18 @@ class QPDF;
 class QPDFObjectHandle;
 class QPDFObject;
 
+struct JSON_Descr
+{
+    JSON_Descr(std::shared_ptr<std::string> input, std::string const& object) :
+        input(input),
+        object(object)
+    {
+    }
+
+    std::shared_ptr<std::string> input;
+    std::string object;
+};
+
 class QPDFValue
 {
     friend class QPDFObject;
@@ -25,7 +37,7 @@ class QPDFValue
     virtual std::string unparse() = 0;
     virtual JSON getJSON(int json_version) = 0;
 
-    using Description = std::variant<std::string>;
+    using Description = std::variant<std::string, JSON_Descr>;
 
     virtual void
     setDescription(

--- a/libqpdf/qpdf/QPDF_Stream.hh
+++ b/libqpdf/qpdf/QPDF_Stream.hh
@@ -27,7 +27,9 @@ class QPDF_Stream: public QPDFValue
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual void setDescription(
-        QPDF*, std::shared_ptr<std::string>& description, qpdf_offset_t offset);
+        QPDF*,
+        std::shared_ptr<QPDFValue::Description>& description,
+        qpdf_offset_t offset);
     virtual void disconnect();
     QPDFObjectHandle getDict() const;
     bool isDataModified() const;


### PR DESCRIPTION
This provides slightly less information in error messages, but improves run time for the JSON input test by around 13%. 