### PR TITLE
Refactor creation of object descriptions

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -32,6 +32,7 @@
 #include <memory>
 #include <stdio.h>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <qpdf/Buffer.hh>
@@ -50,6 +51,7 @@ class BitStream;
 class BitWriter;
 class QPDFLogger;
 class QPDFParser;
+struct JSON_Descr;
 
 class QPDF
 {
@@ -1152,6 +1154,7 @@ class QPDF
         QPDF& pdf;
         std::shared_ptr<InputSource> is;
         bool must_be_complete;
+        std::shared_ptr<std::variant<std::string, JSON_Descr>> descr;
         bool errors;
         bool parse_error;
         bool saw_qpdf;

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -32,7 +32,6 @@
 #include <memory>
 #include <stdio.h>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include <qpdf/Buffer.hh>
@@ -51,7 +50,6 @@ class BitStream;
 class BitWriter;
 class QPDFLogger;
 class QPDFParser;
-struct JSON_Descr;
 
 class QPDF
 {
@@ -1110,72 +1108,7 @@ class QPDF
         std::set<QPDFObjGen>::const_iterator iter;
     };
 
-    class JSONReactor: public JSON::Reactor
-    {
-      public:
-        JSONReactor(
-            QPDF&, std::shared_ptr<InputSource> is, bool must_be_complete);
-        virtual ~JSONReactor() = default;
-        virtual void dictionaryStart() override;
-        virtual void arrayStart() override;
-        virtual void containerEnd(JSON const& value) override;
-        virtual void topLevelScalar() override;
-        virtual bool
-        dictionaryItem(std::string const& key, JSON const& value) override;
-        virtual bool arrayItem(JSON const& value) override;
-
-        bool anyErrors() const;
-
-      private:
-        enum state_e {
-            st_initial,
-            st_top,
-            st_qpdf,
-            st_qpdf_meta,
-            st_objects,
-            st_trailer,
-            st_object_top,
-            st_stream,
-            st_object,
-            st_ignore,
-        };
-
-        void containerStart();
-        void nestedState(std::string const& key, JSON const& value, state_e);
-        void setObjectDescription(QPDFObjectHandle& oh, JSON const& value);
-        QPDFObjectHandle makeObject(JSON const& value);
-        void error(qpdf_offset_t offset, std::string const& message);
-        QPDFObjectHandle reserveObject(int obj, int gen);
-        void replaceObject(
-            QPDFObjectHandle to_replace,
-            QPDFObjectHandle replacement,
-            JSON const& value);
-
-        QPDF& pdf;
-        std::shared_ptr<InputSource> is;
-        bool must_be_complete;
-        std::shared_ptr<std::variant<std::string, JSON_Descr>> descr;
-        bool errors;
-        bool parse_error;
-        bool saw_qpdf;
-        bool saw_qpdf_meta;
-        bool saw_objects;
-        bool saw_json_version;
-        bool saw_pdf_version;
-        bool saw_trailer;
-        state_e state;
-        state_e next_state;
-        std::string cur_object;
-        bool saw_value;
-        bool saw_stream;
-        bool saw_dict;
-        bool saw_data;
-        bool saw_datafile;
-        bool this_stream_needs_data;
-        std::vector<state_e> state_stack;
-        std::vector<QPDFObjectHandle> object_stack;
-        std::set<QPDFObjGen> reserved;
-    };
+    class JSONReactor;
 
     void parse(char const* password);
     void inParse(bool);

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -802,12 +802,10 @@ QPDFObjectHandle::getArrayNItems()
 QPDFObjectHandle
 QPDFObjectHandle::getArrayItem(int n)
 {
-    QPDFObjectHandle result;
     auto array = asArray();
     if (array && (n < array->getNItems()) && (n >= 0)) {
-        result = array->getItem(n);
+        return array->getItem(n);
     } else {
-        result = newNull();
         if (array) {
             objectWarning("returning null for out of bounds array access");
             QTC::TC("qpdf", "QPDFObjectHandle array bounds");
@@ -817,9 +815,8 @@ QPDFObjectHandle::getArrayItem(int n)
         }
         static auto constexpr msg =
             " -> null returned from invalid array access"sv;
-        result.obj->setChildDescription(obj, msg, "");
+        return QPDF_Null::create(obj, msg, "");
     }
-    return result;
 }
 
 bool
@@ -1028,19 +1025,15 @@ QPDFObjectHandle::hasKey(std::string const& key)
 QPDFObjectHandle
 QPDFObjectHandle::getKey(std::string const& key)
 {
-    QPDFObjectHandle result;
-    auto dict = asDictionary();
-    if (dict) {
-        result = dict->getKey(key);
+    if (auto dict = asDictionary()) {
+        return dict->getKey(key);
     } else {
         typeWarning("dictionary", "returning null for attempted key retrieval");
         QTC::TC("qpdf", "QPDFObjectHandle dictionary null for getKey");
-        result = newNull();
         static auto constexpr msg =
             " -> null returned from getting key $VD from non-Dictionary"sv;
-        result.obj->setChildDescription(obj, msg, key);
+        return QPDF_Null::create(obj, msg, "");
     }
-    return result;
 }
 
 QPDFObjectHandle

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -36,6 +36,8 @@
 #include <stdexcept>
 #include <stdlib.h>
 
+using namespace std::literals;
+
 namespace
 {
     class TerminateParsing
@@ -813,13 +815,9 @@ QPDFObjectHandle::getArrayItem(int n)
             typeWarning("array", "returning null");
             QTC::TC("qpdf", "QPDFObjectHandle array null for non-array");
         }
-        QPDF* context = nullptr;
-        std::string description;
-        if (obj->getDescription(context, description)) {
-            result.setObjectDescription(
-                context,
-                description + " -> null returned from invalid array access");
-        }
+        static auto constexpr msg =
+            " -> null returned from invalid array access"sv;
+        result.obj->setChildDescription(obj, msg, "");
     }
     return result;
 }
@@ -1038,14 +1036,9 @@ QPDFObjectHandle::getKey(std::string const& key)
         typeWarning("dictionary", "returning null for attempted key retrieval");
         QTC::TC("qpdf", "QPDFObjectHandle dictionary null for getKey");
         result = newNull();
-        QPDF* qpdf = nullptr;
-        std::string description;
-        if (obj->getDescription(qpdf, description)) {
-            result.setObjectDescription(
-                qpdf,
-                (description + " -> null returned from getting key " + key +
-                 " from non-Dictionary"));
-        }
+        static auto constexpr msg =
+            " -> null returned from getting key $VD from non-Dictionary"sv;
+        result.obj->setChildDescription(obj, msg, key);
     }
     return result;
 }

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -2176,7 +2176,8 @@ QPDFObjectHandle::setObjectDescription(
     // This is called during parsing on newly created direct objects,
     // so we can't call dereference() here.
     if (isInitialized() && obj.get()) {
-        auto descr = std::make_shared<std::string>(object_description);
+        auto descr =
+            std::make_shared<QPDFValue::Description>(object_description);
         obj->setDescription(owning_qpdf, descr);
     }
 }

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -9,3 +9,20 @@ QPDFValue::do_create(QPDFValue* object)
     obj->value = std::shared_ptr<QPDFValue>(object);
     return obj;
 }
+
+std::string
+QPDFValue::getDescription()
+{
+    auto description = object_description ? *object_description : "";
+    if (auto pos = description.find("$OG"); pos != std::string::npos) {
+        description.replace(pos, 3, og.unparse(' '));
+    }
+    if (auto pos = description.find("$PO"); pos != std::string::npos) {
+        qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
+            : (type_code == ::ot_array)                      ? 1
+                                                             : 0;
+
+        description.replace(pos, 3, std::to_string(parsed_offset + shift));
+    }
+    return description;
+}

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -35,6 +35,8 @@ QPDFValue::getDescription()
                 return description;
             }
         }
+    } else if (og.isIndirect()) {
+        return "object " + og.unparse(' ');
     }
     return {};
 }

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -34,6 +34,14 @@ QPDFValue::getDescription()
                 }
                 return description;
             }
+        case 1:
+            {
+                auto j_descr = std::get<1>(*object_description);
+                return (
+                    *j_descr.input +
+                    (j_descr.object.empty() ? "" : ", " + j_descr.object) +
+                    " at offset " + std::to_string(parsed_offset));
+            }
         }
     } else if (og.isIndirect()) {
         return "object " + og.unparse(' ');

--- a/libqpdf/QPDFValue.cc
+++ b/libqpdf/QPDFValue.cc
@@ -13,16 +13,28 @@ QPDFValue::do_create(QPDFValue* object)
 std::string
 QPDFValue::getDescription()
 {
-    auto description = object_description ? *object_description : "";
-    if (auto pos = description.find("$OG"); pos != std::string::npos) {
-        description.replace(pos, 3, og.unparse(' '));
-    }
-    if (auto pos = description.find("$PO"); pos != std::string::npos) {
-        qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
-            : (type_code == ::ot_array)                      ? 1
-                                                             : 0;
+    if (object_description) {
+        switch (object_description->index()) {
+        case 0:
+            {
+                auto description = std::get<0>(*object_description);
 
-        description.replace(pos, 3, std::to_string(parsed_offset + shift));
+                if (auto pos = description.find("$OG");
+                    pos != std::string::npos) {
+                    description.replace(pos, 3, og.unparse(' '));
+                }
+                if (auto pos = description.find("$PO");
+                    pos != std::string::npos) {
+                    qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
+                        : (type_code == ::ot_array)                      ? 1
+                                                                         : 0;
+
+                    description.replace(
+                        pos, 3, std::to_string(parsed_offset + shift));
+                }
+                return description;
+            }
+        }
     }
-    return description;
+    return {};
 }

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -1,6 +1,9 @@
 #include <qpdf/QPDF_Dictionary.hh>
 
+#include <qpdf/QPDFObject_private.hh>
 #include <qpdf/QPDF_Name.hh>
+
+using namespace std::literals;
 
 QPDF_Dictionary::QPDF_Dictionary(
     std::map<std::string, QPDFObjectHandle> const& items) :
@@ -98,10 +101,8 @@ QPDF_Dictionary::getKey(std::string const& key)
         return item->second;
     } else {
         auto null = QPDFObjectHandle::newNull();
-        if (qpdf != nullptr) {
-            null.setObjectDescription(
-                qpdf, getDescription() + " -> dictionary key " + key);
-        }
+        static auto constexpr msg = " -> dictionary key $VD"sv;
+        null.getObj()->setChildDescription(shared_from_this(), msg, key);
         return null;
     }
 }

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -2,6 +2,7 @@
 
 #include <qpdf/QPDFObject_private.hh>
 #include <qpdf/QPDF_Name.hh>
+#include <qpdf/QPDF_Null.hh>
 
 using namespace std::literals;
 
@@ -100,10 +101,8 @@ QPDF_Dictionary::getKey(std::string const& key)
         // May be a null object
         return item->second;
     } else {
-        auto null = QPDFObjectHandle::newNull();
         static auto constexpr msg = " -> dictionary key $VD"sv;
-        null.getObj()->setChildDescription(shared_from_this(), msg, key);
-        return null;
+        return QPDF_Null::create(shared_from_this(), msg, key);
     }
 }
 

--- a/libqpdf/QPDF_Null.cc
+++ b/libqpdf/QPDF_Null.cc
@@ -1,5 +1,7 @@
 #include <qpdf/QPDF_Null.hh>
 
+#include <qpdf/QPDFObject_private.hh>
+
 QPDF_Null::QPDF_Null() :
     QPDFValue(::ot_null, "null")
 {
@@ -9,6 +11,28 @@ std::shared_ptr<QPDFObject>
 QPDF_Null::create()
 {
     return do_create(new QPDF_Null());
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Null::create(
+    std::shared_ptr<QPDFObject> parent,
+    std::string_view const& static_descr,
+    std::string var_descr)
+{
+    auto n = do_create(new QPDF_Null());
+    n->setChildDescription(parent, static_descr, var_descr);
+    return n;
+}
+
+std::shared_ptr<QPDFObject>
+QPDF_Null::create(
+    std::shared_ptr<QPDFValue> parent,
+    std::string_view const& static_descr,
+    std::string var_descr)
+{
+    auto n = do_create(new QPDF_Null());
+    n->setChildDescription(parent, static_descr, var_descr);
+    return n;
 }
 
 std::shared_ptr<QPDFObject>

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -123,7 +123,7 @@ QPDF_Stream::QPDF_Stream(
         throw std::logic_error("stream object instantiated with non-dictionary "
                                "object for dictionary");
     }
-    auto descr = std::make_shared<std::string>(
+    auto descr = std::make_shared<QPDFValue::Description>(
         qpdf->getFilename() + ", stream object " + og.unparse(' '));
     setDescription(qpdf, descr, offset);
 }
@@ -283,7 +283,9 @@ QPDF_Stream::getStreamJSON(
 
 void
 QPDF_Stream::setDescription(
-    QPDF* qpdf, std::shared_ptr<std::string>& description, qpdf_offset_t offset)
+    QPDF* qpdf,
+    std::shared_ptr<QPDFValue::Description>& description,
+    qpdf_offset_t offset)
 {
     this->QPDFValue::setDescription(qpdf, description, offset);
     setDictDescription();

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -223,13 +223,79 @@ provide_data(
     };
 }
 
+class QPDF::JSONReactor: public JSON::Reactor
+{
+  public:
+    JSONReactor(QPDF&, std::shared_ptr<InputSource> is, bool must_be_complete);
+    virtual ~JSONReactor() = default;
+    virtual void dictionaryStart() override;
+    virtual void arrayStart() override;
+    virtual void containerEnd(JSON const& value) override;
+    virtual void topLevelScalar() override;
+    virtual bool
+    dictionaryItem(std::string const& key, JSON const& value) override;
+    virtual bool arrayItem(JSON const& value) override;
+
+    bool anyErrors() const;
+
+  private:
+    enum state_e {
+        st_initial,
+        st_top,
+        st_qpdf,
+        st_qpdf_meta,
+        st_objects,
+        st_trailer,
+        st_object_top,
+        st_stream,
+        st_object,
+        st_ignore,
+    };
+
+    void containerStart();
+    void nestedState(std::string const& key, JSON const& value, state_e);
+    void setObjectDescription(QPDFObjectHandle& oh, JSON const& value);
+    QPDFObjectHandle makeObject(JSON const& value);
+    void error(qpdf_offset_t offset, std::string const& message);
+    QPDFObjectHandle reserveObject(int obj, int gen);
+    void replaceObject(
+        QPDFObjectHandle to_replace,
+        QPDFObjectHandle replacement,
+        JSON const& value);
+
+    QPDF& pdf;
+    std::shared_ptr<InputSource> is;
+    bool must_be_complete;
+    std::shared_ptr<QPDFValue::Description> descr;
+    bool errors;
+    bool parse_error;
+    bool saw_qpdf;
+    bool saw_qpdf_meta;
+    bool saw_objects;
+    bool saw_json_version;
+    bool saw_pdf_version;
+    bool saw_trailer;
+    state_e state;
+    state_e next_state;
+    std::string cur_object;
+    bool saw_value;
+    bool saw_stream;
+    bool saw_dict;
+    bool saw_data;
+    bool saw_datafile;
+    bool this_stream_needs_data;
+    std::vector<state_e> state_stack;
+    std::vector<QPDFObjectHandle> object_stack;
+    std::set<QPDFObjGen> reserved;
+};
+
 QPDF::JSONReactor::JSONReactor(
     QPDF& pdf, std::shared_ptr<InputSource> is, bool must_be_complete) :
     pdf(pdf),
     is(is),
     must_be_complete(must_be_complete),
-    descr(std::make_shared<std::variant<std::string, JSON_Descr>>(
-        JSON_Descr(std::make_shared<std::string>(is->getName()), ""))),
+    descr(std::make_shared<QPDFValue::Description>(QPDFValue::JSON_Descr(
+        std::make_shared<std::string>(is->getName()), ""))),
     errors(false),
     parse_error(false),
     saw_qpdf(false),
@@ -679,10 +745,10 @@ QPDF::JSONReactor::arrayItem(JSON const& value)
 void
 QPDF::JSONReactor::setObjectDescription(QPDFObjectHandle& oh, JSON const& value)
 {
-    auto j_descr = std::get<JSON_Descr>(*descr);
+    auto j_descr = std::get<QPDFValue::JSON_Descr>(*descr);
     if (j_descr.object != cur_object) {
         descr = std::make_shared<QPDFValue::Description>(
-            JSON_Descr(j_descr.input, cur_object));
+            QPDFValue::JSON_Descr(j_descr.input, cur_object));
     }
 
     oh.getObjectPtr()->setDescription(&pdf, descr, value.getStart());

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -71,7 +71,7 @@ class QPDFObject
     void
     setDescription(
         QPDF* qpdf,
-        std::shared_ptr<std::string>& description,
+        std::shared_ptr<QPDFValue::Description>& description,
         qpdf_offset_t offset = -1)
     {
         return value->setDescription(qpdf, description, offset);

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -12,6 +12,7 @@
 #include <qpdf/Types.h>
 
 #include <string>
+#include <string_view>
 
 class QPDF;
 class QPDFObjectHandle;
@@ -75,6 +76,25 @@ class QPDFObject
         qpdf_offset_t offset = -1)
     {
         return value->setDescription(qpdf, description, offset);
+    }
+    void
+    setChildDescription(
+        std::shared_ptr<QPDFObject> parent,
+        std::string_view const& static_descr,
+        std::string var_descr)
+    {
+        auto qpdf = parent ? parent->value->qpdf : nullptr;
+        value->setChildDescription(
+            qpdf, parent->value, static_descr, var_descr);
+    }
+    void
+    setChildDescription(
+        std::shared_ptr<QPDFValue> parent,
+        std::string_view const& static_descr,
+        std::string var_descr)
+    {
+        auto qpdf = parent ? parent->qpdf : nullptr;
+        value->setChildDescription(qpdf, parent, static_descr, var_descr);
     }
     bool
     getDescription(QPDF*& qpdf, std::string& description)

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -2,6 +2,7 @@
 #define QPDFPARSER_HH
 
 #include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFValue.hh>
 
 #include <memory>
 #include <string>
@@ -21,8 +22,8 @@ class QPDFParser
         tokenizer(tokenizer),
         decrypter(decrypter),
         context(context),
-        description(std::make_shared<std::string>(
-            input->getName() + ", " + object_description + " at offset $PO"))
+        description(std::make_shared<QPDFValue::Description>(std::string(
+            input->getName() + ", " + object_description + " at offset $PO")))
     {
     }
     virtual ~QPDFParser() = default;
@@ -49,7 +50,7 @@ class QPDFParser
     QPDFTokenizer& tokenizer;
     QPDFObjectHandle::StringDecrypter* decrypter;
     QPDF* context;
-    std::shared_ptr<std::string> description;
+    std::shared_ptr<QPDFValue::Description> description;
 };
 
 #endif // QPDFPARSER_HH

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -40,11 +40,6 @@ class QPDFValue
     void
     setDefaultDescription(QPDF* a_qpdf, QPDFObjGen const& a_og)
     {
-        static auto default_description{
-            std::make_shared<Description>("object $OG")};
-        if (!object_description) {
-            object_description = default_description;
-        }
         qpdf = a_qpdf;
         og = a_og;
     }
@@ -52,7 +47,7 @@ class QPDFValue
     bool
     hasDescription()
     {
-        return object_description != nullptr;
+        return object_description || og.isIndirect();
     }
     void
     setParsedOffset(qpdf_offset_t offset)

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -44,22 +44,7 @@ class QPDFValue
         qpdf = a_qpdf;
         og = a_og;
     }
-    std::string
-    getDescription()
-    {
-        auto description = object_description ? *object_description : "";
-        if (auto pos = description.find("$OG"); pos != std::string::npos) {
-            description.replace(pos, 3, og.unparse(' '));
-        }
-        if (auto pos = description.find("$PO"); pos != std::string::npos) {
-            qpdf_offset_t shift = (type_code == ::ot_dictionary) ? 2
-                : (type_code == ::ot_array)                      ? 1
-                                                                 : 0;
-
-            description.replace(pos, 3, std::to_string(parsed_offset + shift));
-        }
-        return description;
-    }
+    std::string getDescription();
     bool
     hasDescription()
     {

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -52,8 +52,7 @@ class QPDFValue
     bool
     hasDescription()
     {
-        return qpdf != nullptr && object_description &&
-            !getDescription().empty();
+        return object_description != nullptr;
     }
     void
     setParsedOffset(qpdf_offset_t offset)

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -14,18 +14,6 @@ class QPDF;
 class QPDFObjectHandle;
 class QPDFObject;
 
-struct JSON_Descr
-{
-    JSON_Descr(std::shared_ptr<std::string> input, std::string const& object) :
-        input(input),
-        object(object)
-    {
-    }
-
-    std::shared_ptr<std::string> input;
-    std::string object;
-};
-
 class QPDFValue
 {
     friend class QPDFObject;
@@ -36,6 +24,19 @@ class QPDFValue
     virtual std::shared_ptr<QPDFObject> copy(bool shallow = false) = 0;
     virtual std::string unparse() = 0;
     virtual JSON getJSON(int json_version) = 0;
+
+    struct JSON_Descr
+    {
+        JSON_Descr(
+            std::shared_ptr<std::string> input, std::string const& object) :
+            input(input),
+            object(object)
+        {
+        }
+
+        std::shared_ptr<std::string> input;
+        std::string object;
+    };
 
     using Description = std::variant<std::string, JSON_Descr>;
 

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -8,6 +8,7 @@
 #include <qpdf/Types.h>
 
 #include <string>
+#include <variant>
 
 class QPDF;
 class QPDFObjectHandle;
@@ -23,10 +24,13 @@ class QPDFValue
     virtual std::shared_ptr<QPDFObject> copy(bool shallow = false) = 0;
     virtual std::string unparse() = 0;
     virtual JSON getJSON(int json_version) = 0;
+
+    using Description = std::variant<std::string>;
+
     virtual void
     setDescription(
         QPDF* qpdf_p,
-        std::shared_ptr<std::string>& description,
+        std::shared_ptr<Description>& description,
         qpdf_offset_t offset)
     {
         qpdf = qpdf_p;
@@ -37,7 +41,7 @@ class QPDFValue
     setDefaultDescription(QPDF* a_qpdf, QPDFObjGen const& a_og)
     {
         static auto default_description{
-            std::make_shared<std::string>("object $OG")};
+            std::make_shared<Description>("object $OG")};
         if (!object_description) {
             object_description = default_description;
         }
@@ -49,7 +53,7 @@ class QPDFValue
     hasDescription()
     {
         return qpdf != nullptr && object_description &&
-            !object_description->empty();
+            !getDescription().empty();
     }
     void
     setParsedOffset(qpdf_offset_t offset)
@@ -108,7 +112,7 @@ class QPDFValue
   private:
     QPDFValue(QPDFValue const&) = delete;
     QPDFValue& operator=(QPDFValue const&) = delete;
-    std::shared_ptr<std::string> object_description;
+    std::shared_ptr<Description> object_description;
 
     const qpdf_object_type_e type_code{::ot_uninitialized};
     char const* type_name{"uninitialized"};

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -14,6 +14,18 @@ class QPDF;
 class QPDFObjectHandle;
 class QPDFObject;
 
+struct JSON_Descr
+{
+    JSON_Descr(std::shared_ptr<std::string> input, std::string const& object) :
+        input(input),
+        object(object)
+    {
+    }
+
+    std::shared_ptr<std::string> input;
+    std::string object;
+};
+
 class QPDFValue
 {
     friend class QPDFObject;
@@ -25,7 +37,7 @@ class QPDFValue
     virtual std::string unparse() = 0;
     virtual JSON getJSON(int json_version) = 0;
 
-    using Description = std::variant<std::string>;
+    using Description = std::variant<std::string, JSON_Descr>;
 
     virtual void
     setDescription(

--- a/libqpdf/qpdf/QPDF_Null.hh
+++ b/libqpdf/qpdf/QPDF_Null.hh
@@ -8,6 +8,14 @@ class QPDF_Null: public QPDFValue
   public:
     virtual ~QPDF_Null() = default;
     static std::shared_ptr<QPDFObject> create();
+    static std::shared_ptr<QPDFObject> create(
+        std::shared_ptr<QPDFObject> parent,
+        std::string_view const& static_descr,
+        std::string var_descr);
+    static std::shared_ptr<QPDFObject> create(
+        std::shared_ptr<QPDFValue> parent,
+        std::string_view const& static_descr,
+        std::string var_descr);
     virtual std::shared_ptr<QPDFObject> copy(bool shallow = false);
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);

--- a/libqpdf/qpdf/QPDF_Stream.hh
+++ b/libqpdf/qpdf/QPDF_Stream.hh
@@ -27,7 +27,9 @@ class QPDF_Stream: public QPDFValue
     virtual std::string unparse();
     virtual JSON getJSON(int json_version);
     virtual void setDescription(
-        QPDF*, std::shared_ptr<std::string>& description, qpdf_offset_t offset);
+        QPDF*,
+        std::shared_ptr<QPDFValue::Description>& description,
+        qpdf_offset_t offset);
     virtual void disconnect();
     QPDFObjectHandle getDict() const;
     bool isDataModified() const;


### PR DESCRIPTION
This PR is based on the observation that only a very small proportion of the object descriptions created are actually used. It therefore makes sense to minimize the cost of creating and storing object descriptions at the expense of making it more expensive to access object descriptions.

This is achieved by storing the minimal amount of information required to create object descriptions with each object and assembling that information into the object description string at the point of retrieval.

This process was started in #844, which replaced object description strings with shared pointers to template strings, with individual information that was already available such as the obj gen and offset being filled in at the point of retrieval. This PR extends this by allowing the shared pointer not only to point at template strings but also at structs with additional information such as an object's parent. This makes it possible for example to create the parent's object description if and only if it is required at the point a child object's object description is retrieved.

