### PR TITLE
Remove custom jpeg library installation for mac build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,11 +90,6 @@ jobs:
     needs: Prebuild
     steps:
       - uses: actions/checkout@v3
-      - name: 'Download external libs'
-        uses: actions/download-artifact@v3
-        with:
-          name: external-libs
-          path: .
       - name: 'Mac build and test'
         run: build-scripts/build-mac
   AppImage:

--- a/build-scripts/build-mac
+++ b/build-scripts/build-mac
@@ -1,13 +1,6 @@
 #!/bin/bash
 set -ex
 cd $(dirname $0)/..
-unzip qpdf-external-libs-src.zip
-tar xzf external-libs-src/jpegsrc*
-cd jpeg-*
-./configure
-make -k
-sudo make install
-cd ..
 cmake -S . -B build -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release
 cmake --build build --verbose -j$(sysctl -n hw.ncpu) -- -k
 (cd build; ctest --verbose)


### PR DESCRIPTION
Let's see whether current macos runners have libjpeg pre-installed.