### PR TITLE
Add new convenience class QPDFObjGen::Guard

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1017,7 +1017,7 @@ class QPDF
       public:
         std::map<QPDFObjGen, QPDFObjectHandle> object_map;
         std::vector<QPDFObjectHandle> to_copy;
-        std::set<QPDFObjGen> visiting;
+        QPDFObjGen::set visiting;
     };
 
     class EncryptionParameters

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1252,8 +1252,8 @@ class QPDF
 
     void getAllPagesInternal(
         QPDFObjectHandle cur_pages,
-        std::set<QPDFObjGen>& visited,
-        std::set<QPDFObjGen>& seen);
+        QPDFObjGen::set& visited,
+        QPDFObjGen::set& seen);
     void insertPage(QPDFObjectHandle newpage, int pos);
     void flattenPagesTree();
     void insertPageobjToPage(

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1645,7 +1645,7 @@ class QPDF
         ObjUser const& ou,
         QPDFObjectHandle oh,
         std::function<int(QPDFObjectHandle&)> skip_stream_parameters,
-        std::set<QPDFObjGen>& visited,
+        QPDFObjGen::set& visited,
         bool top);
     void filterCompressedObjects(std::map<int, int> const& object_stream_data);
 

--- a/include/qpdf/QPDFAcroFormDocumentHelper.hh
+++ b/include/qpdf/QPDFAcroFormDocumentHelper.hh
@@ -254,7 +254,7 @@ class QPDFAcroFormDocumentHelper: public QPDFDocumentHelper
         QPDFObjectHandle field,
         QPDFObjectHandle parent,
         int depth,
-        std::set<QPDFObjGen>& visited);
+        QPDFObjGen::set& visited);
     QPDFObjectHandle getOrCreateAcroForm();
     void adjustInheritedFields(
         QPDFObjectHandle obj,

--- a/include/qpdf/QPDFJob.hh
+++ b/include/qpdf/QPDFJob.hh
@@ -571,7 +571,7 @@ class QPDFJob
 
     // JSON
     void doJSON(QPDF& pdf, Pipeline*);
-    std::set<QPDFObjGen> getWantedJSONObjects();
+    QPDFObjGen::set getWantedJSONObjects();
     void doJSONObject(
         Pipeline* p, bool& first, std::string const& key, QPDFObjectHandle&);
     void doJSONObjects(Pipeline* p, bool& first, QPDF& pdf);

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1611,7 +1611,7 @@ class QPDFObjectHandle
     void objectWarning(std::string const& warning);
     void assertType(char const* type_name, bool istype);
     inline bool dereference();
-    void makeDirect(std::set<QPDFObjGen>& visited, bool stop_at_streams);
+    void makeDirect(QPDFObjGen::set& visited, bool stop_at_streams);
     void disconnect();
     void setParsedOffset(qpdf_offset_t offset);
     void parseContentStream_internal(

--- a/include/qpdf/QPDFOutlineDocumentHelper.hh
+++ b/include/qpdf/QPDFOutlineDocumentHelper.hh
@@ -22,13 +22,13 @@
 #ifndef QPDFOUTLINEDOCUMENTHELPER_HH
 #define QPDFOUTLINEDOCUMENTHELPER_HH
 
+#include <qpdf/QPDF.hh>
 #include <qpdf/QPDFDocumentHelper.hh>
 #include <qpdf/QPDFNameTreeObjectHelper.hh>
+#include <qpdf/QPDFObjGen.hh>
 #include <qpdf/QPDFOutlineObjectHelper.hh>
 
-#include <qpdf/QPDF.hh>
 #include <map>
-#include <set>
 #include <vector>
 
 #include <qpdf/DLL.h>
@@ -69,16 +69,16 @@ class QPDFOutlineDocumentHelper: public QPDFDocumentHelper
     {
         friend class QPDFOutlineObjectHelper;
 
+        // ABI: remove  QPDF_DLL and pass og by value.
         QPDF_DLL
         static bool
         checkSeen(QPDFOutlineDocumentHelper& dh, QPDFObjGen const& og)
         {
-            return dh.checkSeen(og);
+            return !dh.m->seen.add(og);
         }
     };
 
   private:
-    bool checkSeen(QPDFObjGen const& og);
     void initializeByPage();
 
     class Members
@@ -94,7 +94,7 @@ class QPDFOutlineDocumentHelper: public QPDFDocumentHelper
         Members(Members const&) = delete;
 
         std::vector<QPDFOutlineObjectHelper> outlines;
-        std::set<QPDFObjGen> seen;
+        QPDFObjGen::set seen;
         QPDFObjectHandle dest_dict;
         std::shared_ptr<QPDFNameTreeObjectHelper> names_dest;
         std::map<QPDFObjGen, std::vector<QPDFOutlineObjectHelper>> by_page;

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2511,7 +2511,7 @@ QPDF::getCompressibleObjGens()
     QPDFObjectHandle encryption_dict = this->m->trailer.getKey("/Encrypt");
     QPDFObjGen encryption_dict_og = encryption_dict.getObjGen();
 
-    std::set<QPDFObjGen> visited;
+    QPDFObjGen::set visited;
     std::list<QPDFObjectHandle> queue;
     queue.push_front(this->m->trailer);
     std::vector<QPDFObjGen> result;
@@ -2520,7 +2520,7 @@ QPDF::getCompressibleObjGens()
         queue.pop_front();
         if (obj.isIndirect()) {
             QPDFObjGen og = obj.getObjGen();
-            if (visited.count(og)) {
+            if (!visited.add(og)) {
                 QTC::TC("qpdf", "QPDF loop detected traversing objects");
                 continue;
             }
@@ -2532,7 +2532,6 @@ QPDF::getCompressibleObjGens()
                           obj.hasKey("/Contents")))) {
                 result.push_back(og);
             }
-            visited.insert(og);
         }
         if (obj.isStream()) {
             QPDFObjectHandle dict = obj.getDict();

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -57,7 +57,7 @@ QPDFAcroFormDocumentHelper::addFormField(QPDFFormFieldObjectHelper ff)
             "/Fields", QPDFObjectHandle::newArray());
     }
     fields.appendItem(ff.getObjectHandle());
-    std::set<QPDFObjGen> visited;
+    QPDFObjGen::set visited;
     traverseField(
         ff.getObjectHandle(), QPDFObjectHandle::newNull(), 0, visited);
 }
@@ -167,7 +167,7 @@ QPDFAcroFormDocumentHelper::setFormFieldName(
     QPDFFormFieldObjectHelper ff, std::string const& name)
 {
     ff.setFieldAttribute("/T", name);
-    std::set<QPDFObjGen> visited;
+    QPDFObjGen::set visited;
     auto ff_oh = ff.getObjectHandle();
     traverseField(ff_oh, ff_oh.getKey("/Parent"), 0, visited);
 }
@@ -273,7 +273,7 @@ QPDFAcroFormDocumentHelper::analyze()
     // Traverse /AcroForm to find annotations and map them
     // bidirectionally to fields.
 
-    std::set<QPDFObjGen> visited;
+    QPDFObjGen::set visited;
     int nfields = fields.getArrayNItems();
     QPDFObjectHandle null(QPDFObjectHandle::newNull());
     for (int i = 0; i < nfields; ++i) {
@@ -319,7 +319,7 @@ QPDFAcroFormDocumentHelper::traverseField(
     QPDFObjectHandle field,
     QPDFObjectHandle parent,
     int depth,
-    std::set<QPDFObjGen>& visited)
+    QPDFObjGen::set& visited)
 {
     if (depth > 100) {
         // Arbitrarily cut off recursion at a fixed depth to avoid
@@ -341,12 +341,11 @@ QPDFAcroFormDocumentHelper::traverseField(
         return;
     }
     QPDFObjGen og(field.getObjGen());
-    if (visited.count(og) != 0) {
+    if (!visited.add(og)) {
         QTC::TC("qpdf", "QPDFAcroFormDocumentHelper loop");
         field.warnIfPossible("loop detected while traversing /AcroForm");
         return;
     }
-    visited.insert(og);
 
     // A dictionary encountered while traversing the /AcroForm field
     // may be a form field, an annotation, or the merger of the two. A

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -188,12 +188,11 @@ QPDFAcroFormDocumentHelper::getFieldsWithQualifiedName(std::string const& name)
 {
     analyze();
     // Keep from creating an empty entry
-    std::set<QPDFObjGen> result;
     auto iter = this->m->name_to_fields.find(name);
     if (iter != this->m->name_to_fields.end()) {
-        result = iter->second;
+        return iter->second;
     }
-    return result;
+    return {};
 }
 
 std::vector<QPDFAnnotationObjectHelper>

--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -217,18 +217,12 @@ std::vector<QPDFFormFieldObjectHelper>
 QPDFAcroFormDocumentHelper::getFormFieldsForPage(QPDFPageObjectHelper ph)
 {
     analyze();
-    std::set<QPDFObjGen> added;
+    QPDFObjGen::set todo;
     std::vector<QPDFFormFieldObjectHelper> result;
-    auto widget_annotations = getWidgetAnnotationsForPage(ph);
-    for (auto annot: widget_annotations) {
-        auto field = getFieldForAnnotation(annot);
-        field = field.getTopLevelField();
-        auto og = field.getObjectHandle().getObjGen();
-        if (!added.count(og)) {
-            added.insert(og);
-            if (field.getObjectHandle().isDictionary()) {
-                result.push_back(field);
-            }
+    for (auto& annot: getWidgetAnnotationsForPage(ph)) {
+        auto field = getFieldForAnnotation(annot).getTopLevelField();
+        if (todo.add(field) && field.getObjectHandle().isDictionary()) {
+            result.push_back(field);
         }
     }
     return result;

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -1001,18 +1001,16 @@ QPDFJob::parse_object_id(
     }
 }
 
-std::set<QPDFObjGen>
+QPDFObjGen::set
 QPDFJob::getWantedJSONObjects()
 {
-    std::set<QPDFObjGen> wanted_og;
+    QPDFObjGen::set wanted_og;
     for (auto const& iter: m->json_objects) {
         bool trailer;
         int obj = 0;
         int gen = 0;
         parse_object_id(iter, trailer, obj, gen);
-        if (obj) {
-            wanted_og.insert(QPDFObjGen(obj, gen));
-        }
+        wanted_og.add(QPDFObjGen(obj, gen));
     }
     return wanted_og;
 }

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -1043,7 +1043,7 @@ QPDFJob::doJSONObjects(Pipeline* p, bool& first, QPDF& pdf)
         bool first_object = true;
         JSON::writeDictionaryOpen(p, first_object, 1);
         bool all_objects = m->json_objects.empty();
-        std::set<QPDFObjGen> wanted_og = getWantedJSONObjects();
+        auto wanted_og = getWantedJSONObjects();
         for (auto& obj: pdf.getAllObjects()) {
             std::string key = obj.unparse();
             if (this->m->json_version > 1) {
@@ -1063,11 +1063,8 @@ QPDFJob::doJSONObjects(Pipeline* p, bool& first, QPDF& pdf)
         if (this->m->json_objects.count("trailer")) {
             json_objects.insert("trailer");
         }
-        auto wanted = getWantedJSONObjects();
-        for (auto const& og: wanted) {
-            std::ostringstream s;
-            s << "obj:" << og.unparse(' ') << " R";
-            json_objects.insert(s.str());
+        for (auto og: getWantedJSONObjects()) {
+            json_objects.emplace("obj:" + og.unparse(' ') + " R");
         }
         pdf.writeJSON(
             this->m->json_version,
@@ -1088,7 +1085,7 @@ QPDFJob::doJSONObjectinfo(Pipeline* p, bool& first, QPDF& pdf)
     bool first_object = true;
     JSON::writeDictionaryOpen(p, first_object, 1);
     bool all_objects = m->json_objects.empty();
-    std::set<QPDFObjGen> wanted_og = getWantedJSONObjects();
+    auto wanted_og = getWantedJSONObjects();
     for (auto& obj: pdf.getAllObjects()) {
         if (all_objects || wanted_og.count(obj.getObjGen())) {
             auto j_details = JSON::makeDictionary();

--- a/libqpdf/QPDFObjGen.cc
+++ b/libqpdf/QPDFObjGen.cc
@@ -1,7 +1,12 @@
 #include <qpdf/QPDFObjGen.hh>
 
-#include <qpdf/QUtil.hh>
+#include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFObjectHelper.hh>
+#include <qpdf/QPDFObject_private.hh>
 
+#include <stdexcept>
+
+// ABI: inline and pass og by value
 std::ostream&
 operator<<(std::ostream& os, const QPDFObjGen& og)
 {
@@ -9,8 +14,55 @@ operator<<(std::ostream& os, const QPDFObjGen& og)
     return os;
 }
 
+// ABI: inline
 std::string
 QPDFObjGen::unparse(char separator) const
 {
-    return std::to_string(this->obj) + separator + std::to_string(this->gen);
+    return std::to_string(obj) + separator + std::to_string(gen);
+}
+
+bool
+QPDFObjGen::set::add(QPDFObjectHandle const& oh)
+{
+    if (auto* ptr = oh.getObjectPtr()) {
+        return add(ptr->getObjGen());
+    } else {
+        throw std::logic_error("attempt to retrieve QPDFObjGen from "
+                               "uninitialized QPDFObjectHandle");
+        return false;
+    }
+}
+
+bool
+QPDFObjGen::set::add(QPDFObjectHelper const& helper)
+{
+    if (auto* ptr = helper.getObjectHandle().getObjectPtr()) {
+        return add(ptr->getObjGen());
+    } else {
+        throw std::logic_error("attempt to retrieve QPDFObjGen from "
+                               "uninitialized QPDFObjectHandle");
+        return false;
+    }
+}
+
+void
+QPDFObjGen::set::erase(QPDFObjectHandle const& oh)
+{
+    if (auto* ptr = oh.getObjectPtr()) {
+        erase(ptr->getObjGen());
+    } else {
+        throw std::logic_error("attempt to retrieve QPDFObjGen from "
+                               "uninitialized QPDFObjectHandle");
+    }
+}
+
+void
+QPDFObjGen::set::erase(QPDFObjectHelper const& helper)
+{
+    if (auto* ptr = helper.getObjectHandle().getObjectPtr()) {
+        erase(ptr->getObjGen());
+    } else {
+        throw std::logic_error("attempt to retrieve QPDFObjGen from "
+                               "uninitialized QPDFObjectHandle");
+    }
 }

--- a/libqpdf/QPDFOutlineDocumentHelper.cc
+++ b/libqpdf/QPDFOutlineDocumentHelper.cc
@@ -15,13 +15,8 @@ QPDFOutlineDocumentHelper::QPDFOutlineDocumentHelper(QPDF& qpdf) :
         return;
     }
     QPDFObjectHandle cur = outlines.getKey("/First");
-    std::set<QPDFObjGen> seen;
-    while (!cur.isNull()) {
-        auto og = cur.getObjGen();
-        if (seen.count(og)) {
-            break;
-        }
-        seen.insert(og);
+    QPDFObjGen::set seen;
+    while (!cur.isNull() && seen.add(cur)) {
         this->m->outlines.push_back(
             QPDFOutlineObjectHelper::Accessor::create(cur, *this, 1));
         cur = cur.getKey("/Next");
@@ -103,14 +98,4 @@ QPDFOutlineDocumentHelper::resolveNamedDest(QPDFObjectHandle name)
         result = QPDFObjectHandle::newNull();
     }
     return result;
-}
-
-bool
-QPDFOutlineDocumentHelper::checkSeen(QPDFObjGen const& og)
-{
-    if (this->m->seen.count(og) > 0) {
-        return true;
-    }
-    this->m->seen.insert(og);
-    return false;
 }

--- a/libqpdf/QPDF_optimization.cc
+++ b/libqpdf/QPDF_optimization.cc
@@ -284,7 +284,7 @@ QPDF::updateObjectMaps(
     QPDFObjectHandle oh,
     std::function<int(QPDFObjectHandle&)> skip_stream_parameters)
 {
-    std::set<QPDFObjGen> visited;
+    QPDFObjGen::set visited;
     updateObjectMapsInternal(ou, oh, skip_stream_parameters, visited, true);
 }
 
@@ -293,7 +293,7 @@ QPDF::updateObjectMapsInternal(
     ObjUser const& ou,
     QPDFObjectHandle oh,
     std::function<int(QPDFObjectHandle&)> skip_stream_parameters,
-    std::set<QPDFObjGen>& visited,
+    QPDFObjGen::set& visited,
     bool top)
 {
     // Traverse the object tree from this point taking care to avoid
@@ -310,13 +310,12 @@ QPDF::updateObjectMapsInternal(
 
     if (oh.isIndirect()) {
         QPDFObjGen og(oh.getObjGen());
-        if (visited.count(og)) {
+        if (!visited.add(og)) {
             QTC::TC("qpdf", "QPDF opt loop detected");
             return;
         }
         this->m->obj_user_to_objects[ou].insert(og);
         this->m->object_to_obj_users[og].insert(ou);
-        visited.insert(og);
     }
 
     if (oh.isArray()) {


### PR DESCRIPTION
Support the common pattern of using sets of QPDFObjGen s to detect loops.  

To reduce boiler plate and for a slight performance improvement.