### PR TITLE
Forward declare JSON_array for C++20 compatibility.

### DIFF
--- a/include/qpdf/JSON.hh
+++ b/include/qpdf/JSON.hh
@@ -374,16 +374,7 @@ class JSON
         std::map<std::string, JSON> members;
         std::set<std::string> parsed_keys;
     };
-    struct JSON_array: public JSON_value
-    {
-        JSON_array() :
-            JSON_value(vt_array)
-        {
-        }
-        virtual ~JSON_array() = default;
-        virtual void write(Pipeline*, size_t depth) const;
-        std::vector<JSON> elements;
-    };
+    struct JSON_array;
     struct JSON_string: public JSON_value
     {
         JSON_string(std::string const& utf8);
@@ -453,6 +444,17 @@ class JSON
     };
 
     std::shared_ptr<Members> m;
+};
+
+struct JSON::JSON_array: public JSON_value
+{
+    JSON_array() :
+        JSON_value(vt_array)
+    {
+    }
+    virtual ~JSON_array() = default;
+    virtual void write(Pipeline*, size_t depth) const;
+    std::vector<JSON> elements;
 };
 
 #endif // JSON_HH


### PR DESCRIPTION
In C++20 the destructor for vector<T> is constexpr. This requires that T not be an incomplete type where the destructor is called.

JSON_array's `vector<JSON> elements` field violates this because JSON is still an incomplete type when JSON_array's destructor is defined.

To fix this forward declare JSON_array and only define it afer JSON's definition ends (once it is a complete type).

No new tests since I'm not really sure how to test it and qpdf doesn't officially support C++20 yet. If there's a regression I'll notice it on my end, but I'll only check once per release until my company is a bit farther along in our C++20 migration.