### PR TITLE
Added method qpdfjob_run_from_json_with_result for C# wrapper

### DIFF
--- a/include/qpdf/qpdfjob-c.h
+++ b/include/qpdf/qpdfjob-c.h
@@ -81,6 +81,13 @@ extern "C" {
     QPDF_DLL
     int qpdfjob_run_from_json(char const* json);
 
+    /* A method that outputs out and err as a string instead of writing it
+    * to the console so that it can be captured and used from another
+    * language like C#
+    */
+    QPDF_DLL
+    int qpdfjob_run_from_json_with_result(char const* json, char const** cout_result, char const** cerr_result);
+
     /* FULL INTERFACE -- new in qpdf11. Similar to the qpdf-c.h API,
      * you must call qpdfjob_init to get a qpdfjob_handle and, when
      * done, call qpdfjob_cleanup to free resources. Remaining methods

--- a/libqpdf/qpdfjob-c.cc
+++ b/libqpdf/qpdfjob-c.cc
@@ -161,6 +161,27 @@ qpdfjob_run_from_json(char const* json)
     });
 }
 
+int
+qpdfjob_run_from_json_with_result(char const* json, char const** cout_result, char const** cerr_result)
+{
+    int result = 0;
+    std::ostringstream cout;
+    std::ostringstream cerr;
+    QPDFJob j;
+    j.setOutputStreams(&cout, &cerr);
+    try {
+        j.initializeFromJson(json);
+        j.run();
+        result = j.getExitCode();
+    } catch (std::exception& e) {
+        std::cerr << "qpdfjob json: " << e.what() << std::endl;
+        result = QPDFJob::EXIT_ERROR;
+    }
+    *cout_result = QUtil::copy_string(cout.str());
+    *cerr_result = QUtil::copy_string(cerr.str());
+    return result;
+}
+
 void
 qpdfjob_register_progress_reporter(
     qpdfjob_handle j,


### PR DESCRIPTION
is it possible for you to add this method to your repository so that I don't have to add it when I make a new C# wrapper for qpdf? I use this method to capture the output of cout and cerr so that I can return it to my C# wrapper.