### PR TITLE
In FUTURE make various QPDFObjectHandle methods const

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -792,12 +792,13 @@ class QPDF
     class Resolver
     {
         friend class QPDFObject;
+        friend class QPDF_Unresolved;
 
       private:
-        static void
-        resolve(QPDF* qpdf, QPDFObjGen const& og)
+        static QPDFObject*
+        resolved(QPDF* qpdf, QPDFObjGen og)
         {
-            qpdf->resolve(og);
+            return qpdf->resolve(og);
         }
     };
 
@@ -1056,7 +1057,7 @@ class QPDF
         QPDFObjGen exp_og,
         QPDFObjGen& og,
         bool skip_cache_if_in_xref);
-    void resolve(QPDFObjGen og);
+    QPDFObject* resolve(QPDFObjGen og);
     void resolveObjectsInStream(int obj_stream_number);
     void stopOnError(std::string const& message);
     QPDFObjectHandle reserveObjectIfNotExists(QPDFObjGen const& og);

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1371,12 +1371,12 @@ class QPDFObjectHandle
     QPDF_Real* asReal() const;
     QPDF_Reserved* asReserved() const;
     QPDF_Stream* asStream() const;
-    QPDF_Stream* asStreamWithAssert();
+    QPDF_Stream* asStreamWithAssert() const;
     QPDF_String* asString() const;
 
-    void typeWarning(char const* expected_type, std::string const& warning);
-    void objectWarning(std::string const& warning);
-    void assertType(char const* type_name, bool istype);
+    void typeWarning(char const* expected_type, std::string const& warning) const;
+    void objectWarning(std::string const& warning) const;
+    void assertType(char const* type_name, bool istype) const;
     void makeDirect(QPDFObjGen::set& visited, bool stop_at_streams);
     void disconnect();
     void setParsedOffset(qpdf_offset_t offset);

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1363,24 +1363,23 @@ class QPDFObjectHandle
     void writeJSON(int json_version, JSON::Writer& p, bool dereference_indirect = false);
 
   private:
-    QPDF_Array* asArray();
-    QPDF_Bool* asBool();
-    QPDF_Dictionary* asDictionary();
-    QPDF_InlineImage* asInlineImage();
-    QPDF_Integer* asInteger();
-    QPDF_Name* asName();
-    QPDF_Null* asNull();
-    QPDF_Operator* asOperator();
-    QPDF_Real* asReal();
-    QPDF_Reserved* asReserved();
-    QPDF_Stream* asStream();
+    QPDF_Array* asArray() const;
+    QPDF_Bool* asBool() const;
+    QPDF_Dictionary* asDictionary() const;
+    QPDF_InlineImage* asInlineImage() const;
+    QPDF_Integer* asInteger() const;
+    QPDF_Name* asName() const;
+    QPDF_Null* asNull() const;
+    QPDF_Operator* asOperator() const;
+    QPDF_Real* asReal() const;
+    QPDF_Reserved* asReserved() const;
+    QPDF_Stream* asStream() const;
     QPDF_Stream* asStreamWithAssert();
-    QPDF_String* asString();
+    QPDF_String* asString() const;
 
     void typeWarning(char const* expected_type, std::string const& warning);
     void objectWarning(std::string const& warning);
     void assertType(char const* type_name, bool istype);
-    inline bool dereference();
     void makeDirect(QPDFObjGen::set& visited, bool stop_at_streams);
     void disconnect();
     void setParsedOffset(qpdf_offset_t offset);

--- a/include/qpdf/QPDFObjectHandle_future.hh
+++ b/include/qpdf/QPDFObjectHandle_future.hh
@@ -296,48 +296,48 @@ class QPDFObjectHandle
     QPDFObjectHandle& operator=(QPDFObjectHandle&&) = default;
 
     QPDF_DLL
-    inline bool isInitialized() const;
+    inline bool isInitialized() const noexcept;
 
     // This method returns true if the QPDFObjectHandle objects point to exactly the same underlying
     // object, meaning that changes to one are reflected in the other, or "if you paint one, the
     // other one changes color." This does not perform a structural comparison of the contents of
     // the objects.
     QPDF_DLL
-    bool isSameObjectAs(QPDFObjectHandle const&) const;
+    bool isSameObjectAs(QPDFObjectHandle const&) const noexcept;
 
     // Return type code and type name of underlying object.  These are useful for doing rapid type
     // tests (like switch statements) or for testing and debugging.
     QPDF_DLL
-    qpdf_object_type_e getTypeCode();
+    qpdf_object_type_e getTypeCode() const;
     QPDF_DLL
-    char const* getTypeName();
+    char const* getTypeName() const;
 
     // Exactly one of these will return true for any initialized object. Operator and InlineImage
     // are only allowed in content streams.
     QPDF_DLL
-    bool isBool();
+    bool isBool() const;
     QPDF_DLL
-    bool isNull();
+    bool isNull() const;
     QPDF_DLL
-    bool isInteger();
+    bool isInteger() const;
     QPDF_DLL
-    bool isReal();
+    bool isReal() const;
     QPDF_DLL
-    bool isName();
+    bool isName() const;
     QPDF_DLL
-    bool isString();
+    bool isString() const;
     QPDF_DLL
-    bool isOperator();
+    bool isOperator() const;
     QPDF_DLL
-    bool isInlineImage();
+    bool isInlineImage() const;
     QPDF_DLL
-    bool isArray();
+    bool isArray() const;
     QPDF_DLL
-    bool isDictionary();
+    bool isDictionary() const;
     QPDF_DLL
-    bool isStream();
+    bool isStream() const;
     QPDF_DLL
-    bool isReserved();
+    bool isReserved() const;
 
     // True for objects that are direct nulls. Does not attempt to resolve objects. This is intended
     // for internal use, but it can be used as an efficient way to check for nulls that are not
@@ -352,23 +352,23 @@ class QPDFObjectHandle
     // This returns true for indirect objects from a QPDF that has been destroyed. Trying unparse
     // such an object will throw a logic_error.
     QPDF_DLL
-    bool isDestroyed();
+    bool isDestroyed() const;
 
     // True for everything except array, dictionary, stream, word, and inline image.
     QPDF_DLL
-    bool isScalar();
+    bool isScalar() const;
 
     // True if the object is a name object representing the provided name.
     QPDF_DLL
-    bool isNameAndEquals(std::string const& name);
+    bool isNameAndEquals(std::string const& name) const;
 
     // True if the object is a dictionary of the specified type and subtype, if any.
     QPDF_DLL
-    bool isDictionaryOfType(std::string const& type, std::string const& subtype = "");
+    bool isDictionaryOfType(std::string const& type, std::string const& subtype = "") const;
 
     // True if the object is a stream of the specified type and subtype, if any.
     QPDF_DLL
-    bool isStreamOfType(std::string const& type, std::string const& subtype = "");
+    bool isStreamOfType(std::string const& type, std::string const& subtype = "") const;
 
     // Public factory methods
 
@@ -413,7 +413,7 @@ class QPDFObjectHandle
     // object was created without parsing. If the object is in a stream, the offset is from the
     // beginning of the stream. Otherwise, the offset is from the beginning of the file.
     QPDF_DLL
-    qpdf_offset_t getParsedOffset();
+    qpdf_offset_t getParsedOffset() const;
 
     // Older method: stream_or_array should be the value of /Contents from a page object. It's more
     // convenient to just call QPDFPageObjectHelper::parsePageContents on the page object, and error
@@ -585,7 +585,7 @@ class QPDFObjectHandle
     QPDF_DLL
     void setObjectDescription(QPDF* owning_qpdf, std::string const& object_description);
     QPDF_DLL
-    bool hasObjectDescription();
+    bool hasObjectDescription() const;
 
     // Accessor methods
     //
@@ -635,57 +635,57 @@ class QPDFObjectHandle
 
     // Methods for bool objects
     QPDF_DLL
-    bool getBoolValue();
+    bool getBoolValue() const;
     QPDF_DLL
-    bool getValueAsBool(bool&);
+    bool getValueAsBool(bool&) const;
 
     // Methods for integer objects. Note: if an integer value is too big (too far away from zero in
     // either direction) to fit in the requested return type, the maximum or minimum value for that
     // return type may be returned. For example, on a system with 32-bit int, a numeric object with
     // a value of 2^40 (or anything too big for 32 bits) will be returned as INT_MAX.
     QPDF_DLL
-    long long getIntValue();
+    long long getIntValue() const;
     QPDF_DLL
-    bool getValueAsInt(long long&);
+    bool getValueAsInt(long long&) const;
     QPDF_DLL
-    int getIntValueAsInt();
+    int getIntValueAsInt() const;
     QPDF_DLL
-    bool getValueAsInt(int&);
+    bool getValueAsInt(int&) const;
     QPDF_DLL
-    unsigned long long getUIntValue();
+    unsigned long long getUIntValue() const;
     QPDF_DLL
-    bool getValueAsUInt(unsigned long long&);
+    bool getValueAsUInt(unsigned long long&) const;
     QPDF_DLL
-    unsigned int getUIntValueAsUInt();
+    unsigned int getUIntValueAsUInt() const;
     QPDF_DLL
-    bool getValueAsUInt(unsigned int&);
+    bool getValueAsUInt(unsigned int&) const;
 
     // Methods for real objects
     QPDF_DLL
-    std::string getRealValue();
+    std::string getRealValue() const;
     QPDF_DLL
-    bool getValueAsReal(std::string&);
+    bool getValueAsReal(std::string&) const;
 
     // Methods that work for both integer and real objects
     QPDF_DLL
-    bool isNumber();
+    bool isNumber() const;
     QPDF_DLL
-    double getNumericValue();
+    double getNumericValue() const;
     QPDF_DLL
-    bool getValueAsNumber(double&);
+    bool getValueAsNumber(double&) const;
 
     // Methods for name objects. The returned name value is in qpdf's canonical form with all
     // escaping resolved. See comments for newName() for details.
     QPDF_DLL
-    std::string getName();
+    std::string getName() const;
     QPDF_DLL
-    bool getValueAsName(std::string&);
+    bool getValueAsName(std::string&) const;
 
     // Methods for string objects
     QPDF_DLL
-    std::string getStringValue();
+    std::string getStringValue() const;
     QPDF_DLL
-    bool getValueAsString(std::string&);
+    bool getValueAsString(std::string&) const;
 
     // If a string starts with the UTF-16 marker, it is converted from UTF-16 to UTF-8. Otherwise,
     // it is treated as a string encoded with PDF Doc Encoding. PDF Doc Encoding is identical to
@@ -693,19 +693,19 @@ class QPDFObjectHandle
     // to Unicode. QPDF versions prior to version 8.0.0 erroneously left characters in that range
     // unmapped.
     QPDF_DLL
-    std::string getUTF8Value();
+    std::string getUTF8Value() const;
     QPDF_DLL
-    bool getValueAsUTF8(std::string&);
+    bool getValueAsUTF8(std::string&) const;
 
     // Methods for content stream objects
     QPDF_DLL
-    std::string getOperatorValue();
+    std::string getOperatorValue() const;
     QPDF_DLL
-    bool getValueAsOperator(std::string&);
+    bool getValueAsOperator(std::string&) const;
     QPDF_DLL
-    std::string getInlineImageValue();
+    std::string getInlineImageValue() const;
     QPDF_DLL
-    bool getValueAsInlineImage(std::string&);
+    bool getValueAsInlineImage(std::string&) const;
 
     // Methods for array objects; see also name and array objects.
 
@@ -720,26 +720,26 @@ class QPDFObjectHandle
     QPDFArrayItems aitems();
 
     QPDF_DLL
-    int getArrayNItems();
+    int getArrayNItems() const;
     QPDF_DLL
-    QPDFObjectHandle getArrayItem(int n);
+    QPDFObjectHandle getArrayItem(int n) const;
     // Note: QPDF arrays internally optimize memory for arrays containing lots of nulls. Calling
     // getArrayAsVector may cause a lot of memory to be allocated for very large arrays with lots of
     // nulls.
     QPDF_DLL
-    std::vector<QPDFObjectHandle> getArrayAsVector();
+    std::vector<QPDFObjectHandle> getArrayAsVector() const;
     QPDF_DLL
-    bool isRectangle();
+    bool isRectangle() const;
     // If the array is an array of four numeric values, return as a rectangle. Otherwise, return the
     // rectangle [0, 0, 0, 0]
     QPDF_DLL
-    Rectangle getArrayAsRectangle();
+    Rectangle getArrayAsRectangle() const;
     QPDF_DLL
-    bool isMatrix();
+    bool isMatrix() const;
     // If the array is an array of six numeric values, return as a matrix. Otherwise, return the
     // matrix [1, 0, 0, 1, 0, 0]
     QPDF_DLL
-    Matrix getArrayAsMatrix();
+    Matrix getArrayAsMatrix() const;
 
     // Methods for dictionary objects. In all dictionary methods, keys are specified/represented as
     // canonical name strings starting with a leading slash and not containing any PDF syntax
@@ -759,27 +759,27 @@ class QPDFObjectHandle
     // Return true if key is present.  Keys with null values are treated as if they are not present.
     // This is as per the PDF spec.
     QPDF_DLL
-    bool hasKey(std::string const&);
+    bool hasKey(std::string const&) const;
     // Return the value for the key.  If the key is not present, null is returned.
     QPDF_DLL
-    QPDFObjectHandle getKey(std::string const&);
+    QPDFObjectHandle getKey(std::string const&) const;
     // If the object is null, return null. Otherwise, call getKey(). This makes it easier to access
     // lower-level dictionaries, as in
     // auto font = page.getKeyIfDict("/Resources").getKeyIfDict("/Font");
     QPDF_DLL
-    QPDFObjectHandle getKeyIfDict(std::string const&);
+    QPDFObjectHandle getKeyIfDict(std::string const&) const;
     // Return all keys.  Keys with null values are treated as if they are not present.  This is as
     // per the PDF spec.
     QPDF_DLL
-    std::set<std::string> getKeys();
+    std::set<std::string> getKeys() const;
     // Return dictionary as a map.  Entries with null values are included.
     QPDF_DLL
-    std::map<std::string, QPDFObjectHandle> getDictAsMap();
+    std::map<std::string, QPDFObjectHandle> getDictAsMap() const;
 
     // Methods for name and array objects. The name value is in qpdf's canonical form with all
     // escaping resolved. See comments for newName() for details.
     QPDF_DLL
-    bool isOrHasName(std::string const&);
+    bool isOrHasName(std::string const&) const;
 
     // Make all resources in a resource dictionary indirect. This just goes through all entries of
     // top-level subdictionaries and converts any direct objects to indirect objects. This can be
@@ -829,7 +829,7 @@ class QPDFObjectHandle
     // method returns a set of all the keys in all top-level subdictionaries. For resources
     // dictionaries, this is the collection of names that may be referenced in the content stream.
     QPDF_DLL
-    std::set<std::string> getResourceNames();
+    std::set<std::string> getResourceNames() const;
 
     // Find a unique name within a resource dictionary starting with a given prefix. This method
     // works by appending a number to the given prefix. It searches starting with min_suffix and
@@ -844,7 +844,7 @@ class QPDFObjectHandle
     std::string getUniqueResourceName(
         std::string const& prefix,
         int& min_suffix,
-        std::set<std::string>* resource_names = nullptr);
+        std::set<std::string>* resource_names = nullptr) const;
 
     // A QPDFObjectHandle has an owning QPDF if it is associated with ("owned by") a specific QPDF
     // object. Indirect objects always have an owning QPDF. Direct objects that are read from the
@@ -964,7 +964,7 @@ class QPDFObjectHandle
 
     // Methods for stream objects
     QPDF_DLL
-    QPDFObjectHandle getDict();
+    QPDFObjectHandle getDict() const;
 
     // By default, or if true passed, QPDFWriter will attempt to filter a stream based on decode
     // level, whether compression is enabled, and its ability to filter. Passing false will prevent
@@ -1153,12 +1153,12 @@ class QPDFObjectHandle
     inline int getGeneration() const;
 
     QPDF_DLL
-    std::string unparse();
+    std::string unparse() const;
     QPDF_DLL
-    std::string unparseResolved();
+    std::string unparseResolved() const;
     // For strings only, force binary representation. Otherwise, same as unparse.
     QPDF_DLL
-    std::string unparseBinary();
+    std::string unparseBinary() const;
 
     // Return encoded as JSON. The constant JSON::LATEST can be used to specify the latest available
     // JSON version. The JSON is generated as follows:
@@ -1192,19 +1192,19 @@ class QPDFObjectHandle
     // the object. The effect of dereference_indirect applies only to this object. It is not
     // recursive.
     QPDF_DLL
-    JSON getJSON(int json_version, bool dereference_indirect = false);
+    JSON getJSON(int json_version, bool dereference_indirect = false) const;
 
     // Write the object encoded as JSON to a pipeline. This is equivalent to, but more efficient
     // than, calling getJSON(json_version, dereference_indirect).write(p, depth). See the
     // documentation for getJSON and JSON::write for further detail.
     QPDF_DLL
-    void
-    writeJSON(int json_version, Pipeline* p, bool dereference_indirect = false, size_t depth = 0);
+    void writeJSON(
+        int json_version, Pipeline* p, bool dereference_indirect = false, size_t depth = 0) const;
 
     // Deprecated version uses v1 for backward compatibility.
     // ABI: remove for qpdf 12
     [[deprecated("Use getJSON(int version)")]] QPDF_DLL JSON
-    getJSON(bool dereference_indirect = false);
+    getJSON(bool dereference_indirect = false) const;
 
     // This method can be called on a stream to get a more extended JSON representation of the
     // stream that includes the stream's data. The JSON object returned is always a dictionary whose
@@ -1257,7 +1257,7 @@ class QPDFObjectHandle
     // normally from the file have descriptions. See comments on setObjectDescription for additional
     // details.
     QPDF_DLL
-    void warnIfPossible(std::string const& warning);
+    void warnIfPossible(std::string const& warning) const;
 
     // Provide access to specific classes for recursive disconnected().
     class DisconnectAccess
@@ -1280,55 +1280,55 @@ class QPDFObjectHandle
     void assertInitialized() const;
 
     QPDF_DLL
-    void assertNull();
+    void assertNull() const;
     QPDF_DLL
-    void assertBool();
+    void assertBool() const;
     QPDF_DLL
-    void assertInteger();
+    void assertInteger() const;
     QPDF_DLL
-    void assertReal();
+    void assertReal() const;
     QPDF_DLL
-    void assertName();
+    void assertName() const;
     QPDF_DLL
-    void assertString();
+    void assertString() const;
     QPDF_DLL
-    void assertOperator();
+    void assertOperator() const;
     QPDF_DLL
-    void assertInlineImage();
+    void assertInlineImage() const;
     QPDF_DLL
-    void assertArray();
+    void assertArray() const;
     QPDF_DLL
-    void assertDictionary();
+    void assertDictionary() const;
     QPDF_DLL
-    void assertStream();
+    void assertStream() const;
     QPDF_DLL
-    void assertReserved();
+    void assertReserved() const;
 
     QPDF_DLL
-    void assertIndirect();
+    void assertIndirect() const;
     QPDF_DLL
-    void assertScalar();
+    void assertScalar() const;
     QPDF_DLL
-    void assertNumber();
+    void assertNumber() const;
 
     // The isPageObject method checks the /Type key of the object. This is not completely reliable
     // as there are some otherwise valid files whose /Type is wrong for page objects. qpdf is
     // slightly more accepting but may still return false here when treating the object as a page
     // would work. Use this sparingly.
     QPDF_DLL
-    bool isPageObject();
+    bool isPageObject() const;
     QPDF_DLL
-    bool isPagesObject();
+    bool isPagesObject() const;
     QPDF_DLL
-    void assertPageObject();
+    void assertPageObject() const;
 
     QPDF_DLL
-    bool isFormXObject();
+    bool isFormXObject() const;
 
     // Indicate if this is an image. If exclude_imagemask is true, don't count image masks as
     // images.
     QPDF_DLL
-    bool isImage(bool exclude_imagemask = true);
+    bool isImage(bool exclude_imagemask = true) const;
 
     // The following methods do not form part of the public API and are for internal use only.
 
@@ -1357,7 +1357,7 @@ class QPDFObjectHandle
         return obj.get();
     }
 
-    void writeJSON(int json_version, JSON::Writer& p, bool dereference_indirect = false);
+    void writeJSON(int json_version, JSON::Writer& p, bool dereference_indirect = false) const;
 
   private:
     QPDF_Array* asArray() const;
@@ -1371,12 +1371,12 @@ class QPDFObjectHandle
     QPDF_Real* asReal() const;
     QPDF_Reserved* asReserved() const;
     QPDF_Stream* asStream() const;
-    QPDF_Stream* asStreamWithAssert();
+    QPDF_Stream* asStreamWithAssert() const;
     QPDF_String* asString() const;
 
-    void typeWarning(char const* expected_type, std::string const& warning);
-    void objectWarning(std::string const& warning);
-    void assertType(char const* type_name, bool istype);
+    void typeWarning(char const* expected_type, std::string const& warning) const;
+    void objectWarning(std::string const& warning) const;
+    void assertType(char const* type_name, bool istype) const;
     void makeDirect(QPDFObjGen::set& visited, bool stop_at_streams);
     void disconnect();
     void setParsedOffset(qpdf_offset_t offset);
@@ -1405,11 +1405,11 @@ class QPDFObjectHandle
 // from being here.
 
 /* clang-format off */
-// Disable formatting for this declaration: emacs font-lock in cc-mode (as of 28.1) treats the rest
-// of the file as a string if clang-format removes the space after "operator", and as of
-// clang-format 15, there's no way to prevent it from doing so.
-QPDF_DLL
-QPDFObjectHandle operator ""_qpdf(char const* v, size_t len);
+  // Disable formatting for this declaration: emacs font-lock in cc-mode (as of 28.1) treats the rest
+  // of the file as a string if clang-format removes the space after "operator", and as of
+  // clang-format 15, there's no way to prevent it from doing so.
+  QPDF_DLL
+  QPDFObjectHandle operator ""_qpdf(char const* v, size_t len);
 /* clang-format on */
 
 #endif // QPDF_NO_QPDF_STRING
@@ -1629,7 +1629,7 @@ QPDFObjectHandle::isIndirect() const
 }
 
 inline bool
-QPDFObjectHandle::isInitialized() const
+QPDFObjectHandle::isInitialized() const noexcept
 {
     return obj != nullptr;
 }

--- a/include/qpdf/QPDFObjectHandle_future.hh
+++ b/include/qpdf/QPDFObjectHandle_future.hh
@@ -19,30 +19,25 @@
 // continue to consider qpdf to be licensed under those terms. Please
 // see the manual for additional information.
 
-#ifndef QPDFOBJECTHANDLE_HH
-#define QPDFOBJECTHANDLE_HH
+#ifndef QPDFOBJECTHANDLE_FUTURE_HH
+#define QPDFOBJECTHANDLE_FUTURE_HH
 
-#ifdef QPDF_FUTURE
-# include <qpdf/QPDFObjectHandle_future.hh>
-#else
+#include <qpdf/Constants.h>
+#include <qpdf/DLL.h>
+#include <qpdf/Types.h>
 
-# include <qpdf/Constants.h>
-# include <qpdf/DLL.h>
-# include <qpdf/Types.h>
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
 
-# include <functional>
-# include <map>
-# include <memory>
-# include <set>
-# include <string>
-# include <vector>
-
-# include <qpdf/Buffer.hh>
-# include <qpdf/InputSource.hh>
-# include <qpdf/JSON.hh>
-# include <qpdf/PointerHolder.hh> // unused -- remove in qpdf 12 (see #785)
-# include <qpdf/QPDFObjGen.hh>
-# include <qpdf/QPDFTokenizer.hh>
+#include <qpdf/Buffer.hh>
+#include <qpdf/InputSource.hh>
+#include <qpdf/JSON.hh>
+#include <qpdf/QPDFObjGen.hh>
+#include <qpdf/QPDFTokenizer.hh>
 
 class Pipeline;
 class QPDF;
@@ -294,6 +289,11 @@ class QPDFObjectHandle
     QPDFObjectHandle(QPDFObjectHandle const&) = default;
     QPDF_DLL
     QPDFObjectHandle& operator=(QPDFObjectHandle const&) = default;
+
+    QPDF_DLL
+    QPDFObjectHandle(QPDFObjectHandle&&) = default;
+    QPDF_DLL
+    QPDFObjectHandle& operator=(QPDFObjectHandle&&) = default;
 
     QPDF_DLL
     inline bool isInitialized() const;
@@ -1396,7 +1396,7 @@ class QPDFObjectHandle
     std::shared_ptr<QPDFObject> obj;
 };
 
-# ifndef QPDF_NO_QPDF_STRING
+#ifndef QPDF_NO_QPDF_STRING
 // This is short for QPDFObjectHandle::parse, so you can do
 
 // auto oh = "<< /Key (value) >>"_qpdf;
@@ -1412,7 +1412,7 @@ QPDF_DLL
 QPDFObjectHandle operator ""_qpdf(char const* v, size_t len);
 /* clang-format on */
 
-# endif // QPDF_NO_QPDF_STRING
+#endif // QPDF_NO_QPDF_STRING
 
 class QPDFObjectHandle::QPDFDictItems
 {
@@ -1634,5 +1634,4 @@ QPDFObjectHandle::isInitialized() const
     return obj != nullptr;
 }
 
-#endif // QPDF_FUTURE
-#endif // QPDFOBJECTHANDLE_HH
+#endif // QPDFOBJECTHANDLE_FUTURE_HH

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1728,11 +1728,11 @@ QPDF::readObjectAtOffset(
     return oh;
 }
 
-void
+QPDFObject*
 QPDF::resolve(QPDFObjGen og)
 {
     if (!isUnresolved(og)) {
-        return;
+        return m->obj_cache[og].object.get();
     }
 
     if (m->resolving.count(og)) {
@@ -1741,7 +1741,7 @@ QPDF::resolve(QPDFObjGen og)
         QTC::TC("qpdf", "QPDF recursion loop in resolve");
         warn(damagedPDF("", "loop detected resolving object " + og.unparse(' ')));
         updateCache(og, QPDF_Null::create(), -1, -1);
-        return;
+        return m->obj_cache[og].object.get();
     }
     ResolveRecorder rr(this, og);
 
@@ -1782,6 +1782,7 @@ QPDF::resolve(QPDFObjGen og)
 
     auto result(m->obj_cache[og].object);
     result->setDefaultDescription(this, og);
+    return result.get();
 }
 
 void

--- a/libqpdf/QPDFObject.cc
+++ b/libqpdf/QPDFObject.cc
@@ -4,13 +4,6 @@
 #include <qpdf/QPDF_Destroyed.hh>
 
 void
-QPDFObject::doResolve()
-{
-    auto og = value->og;
-    QPDF::Resolver::resolve(value->qpdf, og);
-}
-
-void
 QPDFObject::destroy()
 {
     value = QPDF_Destroyed::getInstance();

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -220,12 +220,19 @@ LastChar::getLastChar()
     return this->last_char;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isSameObjectAs(QPDFObjectHandle const& rhs) const
 {
     return this->obj == rhs.obj;
 }
-
+#else
+bool
+QPDFObjectHandle::isSameObjectAs(QPDFObjectHandle const& rhs) const noexcept
+{
+    return this->obj == rhs.obj;
+}
+#endif
 void
 QPDFObjectHandle::disconnect()
 {
@@ -237,14 +244,24 @@ QPDFObjectHandle::disconnect()
     }
 }
 
+#ifndef QPDF_FUTURE
 qpdf_object_type_e
 QPDFObjectHandle::getTypeCode()
+#else
+qpdf_object_type_e
+QPDFObjectHandle::getTypeCode() const
+#endif
 {
     return obj ? obj->getResolvedTypeCode() : ::ot_uninitialized;
 }
 
+#ifndef QPDF_FUTURE
 char const*
 QPDFObjectHandle::getTypeName()
+#else
+char const*
+QPDFObjectHandle::getTypeName() const
+#endif
 {
     return obj ? obj->getTypeName() : "uninitialized";
 }
@@ -316,7 +333,7 @@ QPDFObjectHandle::asStream() const
 }
 
 QPDF_Stream*
-QPDFObjectHandle::asStreamWithAssert()
+QPDFObjectHandle::asStreamWithAssert() const
 {
     auto stream = asStream();
     assertType("stream", stream);
@@ -329,14 +346,24 @@ QPDFObjectHandle::asString() const
     return obj ? obj->as<QPDF_String>() : nullptr;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isDestroyed()
+#else
+bool
+QPDFObjectHandle::isDestroyed() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_destroyed;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isBool()
+#else
+bool
+QPDFObjectHandle::isBool() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_boolean;
 }
@@ -349,47 +376,76 @@ QPDFObjectHandle::isDirectNull() const
     return (obj && getObjectID() == 0 && obj->getTypeCode() == ::ot_null);
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isNull()
+#else
+bool
+QPDFObjectHandle::isNull() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_null;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isInteger()
+#else
+bool
+QPDFObjectHandle::isInteger() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_integer;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isReal()
+#else
+bool
+QPDFObjectHandle::isReal() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_real;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isNumber()
+#else
+bool
+QPDFObjectHandle::isNumber() const
+#endif
 {
     return (isInteger() || isReal());
 }
 
+#ifndef QPDF_FUTURE
 double
 QPDFObjectHandle::getNumericValue()
+#else
+double
+QPDFObjectHandle::getNumericValue() const
+#endif
 {
-    double result = 0.0;
     if (isInteger()) {
-        result = static_cast<double>(getIntValue());
+        return static_cast<double>(getIntValue());
     } else if (isReal()) {
-        result = atof(getRealValue().c_str());
+        return atof(getRealValue().c_str());
     } else {
         typeWarning("number", "returning 0");
         QTC::TC("qpdf", "QPDFObjectHandle numeric non-numeric");
+        return 0;
     }
-    return result;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsNumber(double& value)
+#else
+bool
+QPDFObjectHandle::getValueAsNumber(double& value) const
+#endif
 {
     if (!isNumber()) {
         return false;
@@ -398,83 +454,148 @@ QPDFObjectHandle::getValueAsNumber(double& value)
     return true;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isName()
+#else
+bool
+QPDFObjectHandle::isName() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_name;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isString()
+#else
+bool
+QPDFObjectHandle::isString() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_string;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isOperator()
+#else
+bool
+QPDFObjectHandle::isOperator() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_operator;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isInlineImage()
+#else
+bool
+QPDFObjectHandle::isInlineImage() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_inlineimage;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isArray()
+#else
+bool
+QPDFObjectHandle::isArray() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_array;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isDictionary()
+#else
+bool
+QPDFObjectHandle::isDictionary() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_dictionary;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isStream()
+#else
+bool
+QPDFObjectHandle::isStream() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_stream;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isReserved()
+#else
+bool
+QPDFObjectHandle::isReserved() const
+#endif
 {
     return obj && obj->getResolvedTypeCode() == ::ot_reserved;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isScalar()
+#else
+bool
+QPDFObjectHandle::isScalar() const
+#endif
 {
     return isBool() || isInteger() || isName() || isNull() || isReal() || isString();
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isNameAndEquals(std::string const& name)
+#else
+bool
+QPDFObjectHandle::isNameAndEquals(std::string const& name) const
+#endif
 {
     return isName() && (getName() == name);
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isDictionaryOfType(std::string const& type, std::string const& subtype)
+#else
+bool
+QPDFObjectHandle::isDictionaryOfType(std::string const& type, std::string const& subtype) const
+#endif
 {
     return isDictionary() && (type.empty() || getKey("/Type").isNameAndEquals(type)) &&
         (subtype.empty() || getKey("/Subtype").isNameAndEquals(subtype));
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isStreamOfType(std::string const& type, std::string const& subtype)
+#else
+bool
+QPDFObjectHandle::isStreamOfType(std::string const& type, std::string const& subtype) const
+#endif
 {
     return isStream() && getDict().isDictionaryOfType(type, subtype);
 }
 
 // Bool accessors
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getBoolValue()
+#else
+bool
+QPDFObjectHandle::getBoolValue() const
+#endif
 {
     auto boolean = asBool();
     if (boolean) {
@@ -486,8 +607,13 @@ QPDFObjectHandle::getBoolValue()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsBool(bool& value)
+#else
+bool
+QPDFObjectHandle::getValueAsBool(bool& value) const
+#endif
 {
     auto boolean = asBool();
     if (boolean == nullptr) {
@@ -499,8 +625,13 @@ QPDFObjectHandle::getValueAsBool(bool& value)
 
 // Integer accessors
 
+#ifndef QPDF_FUTURE
 long long
 QPDFObjectHandle::getIntValue()
+#else
+long long
+QPDFObjectHandle::getIntValue() const
+#endif
 {
     auto integer = asInteger();
     if (integer) {
@@ -512,8 +643,13 @@ QPDFObjectHandle::getIntValue()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsInt(long long& value)
+#else
+bool
+QPDFObjectHandle::getValueAsInt(long long& value) const
+#endif
 {
     auto integer = asInteger();
     if (integer == nullptr) {
@@ -523,8 +659,13 @@ QPDFObjectHandle::getValueAsInt(long long& value)
     return true;
 }
 
+#ifndef QPDF_FUTURE
 int
 QPDFObjectHandle::getIntValueAsInt()
+#else
+int
+QPDFObjectHandle::getIntValueAsInt() const
+#endif
 {
     int result = 0;
     long long v = getIntValue();
@@ -542,8 +683,13 @@ QPDFObjectHandle::getIntValueAsInt()
     return result;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsInt(int& value)
+#else
+bool
+QPDFObjectHandle::getValueAsInt(int& value) const
+#endif
 {
     if (!isInteger()) {
         return false;
@@ -552,22 +698,31 @@ QPDFObjectHandle::getValueAsInt(int& value)
     return true;
 }
 
+#ifndef QPDF_FUTURE
 unsigned long long
 QPDFObjectHandle::getUIntValue()
+#else
+unsigned long long
+QPDFObjectHandle::getUIntValue() const
+#endif
 {
-    unsigned long long result = 0;
     long long v = getIntValue();
     if (v < 0) {
         QTC::TC("qpdf", "QPDFObjectHandle uint returning 0");
         warnIfPossible("unsigned value request for negative number; returning 0");
+        return 0;
     } else {
-        result = static_cast<unsigned long long>(v);
+        return static_cast<unsigned long long>(v);
     }
-    return result;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsUInt(unsigned long long& value)
+#else
+bool
+QPDFObjectHandle::getValueAsUInt(unsigned long long& value) const
+#endif
 {
     if (!isInteger()) {
         return false;
@@ -576,27 +731,35 @@ QPDFObjectHandle::getValueAsUInt(unsigned long long& value)
     return true;
 }
 
+#ifndef QPDF_FUTURE
 unsigned int
 QPDFObjectHandle::getUIntValueAsUInt()
+#else
+unsigned int
+QPDFObjectHandle::getUIntValueAsUInt() const
+#endif
 {
-    unsigned int result = 0;
     long long v = getIntValue();
     if (v < 0) {
         QTC::TC("qpdf", "QPDFObjectHandle uint uint returning 0");
         warnIfPossible("unsigned integer value request for negative number; returning 0");
-        result = 0;
+        return 0;
     } else if (v > UINT_MAX) {
         QTC::TC("qpdf", "QPDFObjectHandle uint returning UINT_MAX");
         warnIfPossible("requested value of unsigned integer is too big; returning UINT_MAX");
-        result = UINT_MAX;
+        return UINT_MAX;
     } else {
-        result = static_cast<unsigned int>(v);
+        return static_cast<unsigned int>(v);
     }
-    return result;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsUInt(unsigned int& value)
+#else
+bool
+QPDFObjectHandle::getValueAsUInt(unsigned int& value) const
+#endif
 {
     if (!isInteger()) {
         return false;
@@ -607,8 +770,13 @@ QPDFObjectHandle::getValueAsUInt(unsigned int& value)
 
 // Real accessors
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::getRealValue()
+#else
+std::string
+QPDFObjectHandle::getRealValue() const
+#endif
 {
     if (isReal()) {
         return obj->getStringValue();
@@ -619,8 +787,13 @@ QPDFObjectHandle::getRealValue()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsReal(std::string& value)
+#else
+bool
+QPDFObjectHandle::getValueAsReal(std::string& value) const
+#endif
 {
     if (!isReal()) {
         return false;
@@ -631,8 +804,13 @@ QPDFObjectHandle::getValueAsReal(std::string& value)
 
 // Name accessors
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::getName()
+#else
+std::string
+QPDFObjectHandle::getName() const
+#endif
 {
     if (isName()) {
         return obj->getStringValue();
@@ -643,8 +821,13 @@ QPDFObjectHandle::getName()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsName(std::string& value)
+#else
+bool
+QPDFObjectHandle::getValueAsName(std::string& value) const
+#endif
 {
     if (!isName()) {
         return false;
@@ -655,8 +838,13 @@ QPDFObjectHandle::getValueAsName(std::string& value)
 
 // String accessors
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::getStringValue()
+#else
+std::string
+QPDFObjectHandle::getStringValue() const
+#endif
 {
     if (isString()) {
         return obj->getStringValue();
@@ -667,8 +855,13 @@ QPDFObjectHandle::getStringValue()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsString(std::string& value)
+#else
+bool
+QPDFObjectHandle::getValueAsString(std::string& value) const
+#endif
 {
     if (!isString()) {
         return false;
@@ -677,8 +870,13 @@ QPDFObjectHandle::getValueAsString(std::string& value)
     return true;
 }
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::getUTF8Value()
+#else
+std::string
+QPDFObjectHandle::getUTF8Value() const
+#endif
 {
     auto str = asString();
     if (str) {
@@ -690,8 +888,13 @@ QPDFObjectHandle::getUTF8Value()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsUTF8(std::string& value)
+#else
+bool
+QPDFObjectHandle::getValueAsUTF8(std::string& value) const
+#endif
 {
     auto str = asString();
     if (str == nullptr) {
@@ -703,8 +906,13 @@ QPDFObjectHandle::getValueAsUTF8(std::string& value)
 
 // Operator and Inline Image accessors
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::getOperatorValue()
+#else
+std::string
+QPDFObjectHandle::getOperatorValue() const
+#endif
 {
     if (isOperator()) {
         return obj->getStringValue();
@@ -715,8 +923,13 @@ QPDFObjectHandle::getOperatorValue()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsOperator(std::string& value)
+#else
+bool
+QPDFObjectHandle::getValueAsOperator(std::string& value) const
+#endif
 {
     if (!isOperator()) {
         return false;
@@ -725,8 +938,13 @@ QPDFObjectHandle::getValueAsOperator(std::string& value)
     return true;
 }
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::getInlineImageValue()
+#else
+std::string
+QPDFObjectHandle::getInlineImageValue() const
+#endif
 {
     if (isInlineImage()) {
         return obj->getStringValue();
@@ -737,8 +955,13 @@ QPDFObjectHandle::getInlineImageValue()
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::getValueAsInlineImage(std::string& value)
+#else
+bool
+QPDFObjectHandle::getValueAsInlineImage(std::string& value) const
+#endif
 {
     if (!isInlineImage()) {
         return false;
@@ -755,8 +978,13 @@ QPDFObjectHandle::aitems()
     return *this;
 }
 
+#ifndef QPDF_FUTURE
 int
 QPDFObjectHandle::getArrayNItems()
+#else
+int
+QPDFObjectHandle::getArrayNItems() const
+#endif
 {
     if (auto array = asArray()) {
         return array->size();
@@ -767,8 +995,13 @@ QPDFObjectHandle::getArrayNItems()
     }
 }
 
+#ifndef QPDF_FUTURE
 QPDFObjectHandle
 QPDFObjectHandle::getArrayItem(int n)
+#else
+QPDFObjectHandle
+QPDFObjectHandle::getArrayItem(int n) const
+#endif
 {
     if (auto array = asArray()) {
         if (auto result = array->at(n); result.obj != nullptr) {
@@ -785,8 +1018,13 @@ QPDFObjectHandle::getArrayItem(int n)
     return QPDF_Null::create(obj, msg, "");
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isRectangle()
+#else
+bool
+QPDFObjectHandle::isRectangle() const
+#endif
 {
     if (auto array = asArray()) {
         for (int i = 0; i < 4; ++i) {
@@ -799,8 +1037,13 @@ QPDFObjectHandle::isRectangle()
     return false;
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isMatrix()
+#else
+bool
+QPDFObjectHandle::isMatrix() const
+#endif
 {
     if (auto array = asArray()) {
         for (int i = 0; i < 6; ++i) {
@@ -813,8 +1056,13 @@ QPDFObjectHandle::isMatrix()
     return false;
 }
 
+#ifndef QPDF_FUTURE
 QPDFObjectHandle::Rectangle
 QPDFObjectHandle::getArrayAsRectangle()
+#else
+QPDFObjectHandle::Rectangle
+QPDFObjectHandle::getArrayAsRectangle() const
+#endif
 {
     if (auto array = asArray()) {
         if (array->size() != 4) {
@@ -835,8 +1083,13 @@ QPDFObjectHandle::getArrayAsRectangle()
     return {};
 }
 
+#ifndef QPDF_FUTURE
 QPDFObjectHandle::Matrix
 QPDFObjectHandle::getArrayAsMatrix()
+#else
+QPDFObjectHandle::Matrix
+QPDFObjectHandle::getArrayAsMatrix() const
+#endif
 {
     if (auto array = asArray()) {
         if (array->size() != 6) {
@@ -853,8 +1106,13 @@ QPDFObjectHandle::getArrayAsMatrix()
     return {};
 }
 
+#ifndef QPDF_FUTURE
 std::vector<QPDFObjectHandle>
 QPDFObjectHandle::getArrayAsVector()
+#else
+std::vector<QPDFObjectHandle>
+QPDFObjectHandle::getArrayAsVector() const
+#endif
 {
     auto array = asArray();
     if (array) {
@@ -962,8 +1220,13 @@ QPDFObjectHandle::ditems()
     return {*this};
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::hasKey(std::string const& key)
+#else
+bool
+QPDFObjectHandle::hasKey(std::string const& key) const
+#endif
 {
     auto dict = asDictionary();
     if (dict) {
@@ -975,8 +1238,13 @@ QPDFObjectHandle::hasKey(std::string const& key)
     }
 }
 
+#ifndef QPDF_FUTURE
 QPDFObjectHandle
 QPDFObjectHandle::getKey(std::string const& key)
+#else
+QPDFObjectHandle
+QPDFObjectHandle::getKey(std::string const& key) const
+#endif
 {
     if (auto dict = asDictionary()) {
         return dict->getKey(key);
@@ -988,14 +1256,24 @@ QPDFObjectHandle::getKey(std::string const& key)
     }
 }
 
+#ifndef QPDF_FUTURE
 QPDFObjectHandle
 QPDFObjectHandle::getKeyIfDict(std::string const& key)
+#else
+QPDFObjectHandle
+QPDFObjectHandle::getKeyIfDict(std::string const& key) const
+#endif
 {
     return isNull() ? newNull() : getKey(key);
 }
 
+#ifndef QPDF_FUTURE
 std::set<std::string>
 QPDFObjectHandle::getKeys()
+#else
+std::set<std::string>
+QPDFObjectHandle::getKeys() const
+#endif
 {
     std::set<std::string> result;
     auto dict = asDictionary();
@@ -1008,8 +1286,13 @@ QPDFObjectHandle::getKeys()
     return result;
 }
 
+#ifndef QPDF_FUTURE
 std::map<std::string, QPDFObjectHandle>
 QPDFObjectHandle::getDictAsMap()
+#else
+std::map<std::string, QPDFObjectHandle>
+QPDFObjectHandle::getDictAsMap() const
+#endif
 {
     std::map<std::string, QPDFObjectHandle> result;
     auto dict = asDictionary();
@@ -1023,13 +1306,18 @@ QPDFObjectHandle::getDictAsMap()
 }
 
 // Array and Name accessors
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isOrHasName(std::string const& value)
+#else
+bool
+QPDFObjectHandle::isOrHasName(std::string const& value) const
+#endif
 {
     if (isNameAndEquals(value)) {
         return true;
     } else if (isArray()) {
-        for (auto& item: aitems()) {
+        for (auto& item: getArrayAsVector()) {
             if (item.isNameAndEquals(value)) {
                 return true;
             }
@@ -1152,8 +1440,13 @@ QPDFObjectHandle::mergeResources(
     }
 }
 
+#ifndef QPDF_FUTURE
 std::set<std::string>
 QPDFObjectHandle::getResourceNames()
+#else
+std::set<std::string>
+QPDFObjectHandle::getResourceNames() const
+#endif
 {
     // Return second-level dictionary keys
     std::set<std::string> result;
@@ -1171,9 +1464,15 @@ QPDFObjectHandle::getResourceNames()
     return result;
 }
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::getUniqueResourceName(
     std::string const& prefix, int& min_suffix, std::set<std::string>* namesp)
+#else
+std::string
+QPDFObjectHandle::getUniqueResourceName(
+    std::string const& prefix, int& min_suffix, std::set<std::string>* namesp) const
+#endif
 
 {
     std::set<std::string> names = (namesp ? *namesp : getResourceNames());
@@ -1255,8 +1554,13 @@ QPDFObjectHandle::replaceOrRemoveKey(std::string const& key, QPDFObjectHandle co
 }
 
 // Stream accessors
+#ifndef QPDF_FUTURE
 QPDFObjectHandle
 QPDFObjectHandle::getDict()
+#else
+QPDFObjectHandle
+QPDFObjectHandle::getDict() const
+#endif
 {
     return asStreamWithAssert()->getDict();
 }
@@ -1571,20 +1875,28 @@ QPDFObjectHandle::coalesceContentStreams()
     new_contents.replaceStreamData(provider, newNull(), newNull());
 }
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::unparse()
+#else
+std::string
+QPDFObjectHandle::unparse() const
+#endif
 {
-    std::string result;
     if (this->isIndirect()) {
-        result = getObjGen().unparse(' ') + " R";
+        return getObjGen().unparse(' ') + " R";
     } else {
-        result = unparseResolved();
+        return unparseResolved();
     }
-    return result;
 }
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::unparseResolved()
+#else
+std::string
+QPDFObjectHandle::unparseResolved() const
+#endif
 {
     if (!obj) {
         throw std::logic_error("attempted to dereference an uninitialized QPDFObjectHandle");
@@ -1592,11 +1904,15 @@ QPDFObjectHandle::unparseResolved()
     return obj->unparse();
 }
 
+#ifndef QPDF_FUTURE
 std::string
 QPDFObjectHandle::unparseBinary()
+#else
+std::string
+QPDFObjectHandle::unparseBinary() const
+#endif
 {
-    auto str = asString();
-    if (str) {
+    if (auto str = asString()) {
         return str->unparse(true);
     } else {
         return unparse();
@@ -1604,14 +1920,24 @@ QPDFObjectHandle::unparseBinary()
 }
 
 // Deprecated versionless getJSON to be removed in qpdf 12
+#ifndef QPDF_FUTURE
 JSON
 QPDFObjectHandle::getJSON(bool dereference_indirect)
+#else
+JSON
+QPDFObjectHandle::getJSON(bool dereference_indirect) const
+#endif
 {
     return getJSON(1, dereference_indirect);
 }
 
+#ifndef QPDF_FUTURE
 JSON
 QPDFObjectHandle::getJSON(int json_version, bool dereference_indirect)
+#else
+JSON
+QPDFObjectHandle::getJSON(int json_version, bool dereference_indirect) const
+#endif
 {
     if ((!dereference_indirect) && isIndirect()) {
         return JSON::makeString(unparse());
@@ -1626,8 +1952,13 @@ QPDFObjectHandle::getJSON(int json_version, bool dereference_indirect)
     }
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::writeJSON(int json_version, JSON::Writer& p, bool dereference_indirect)
+#else
+void
+QPDFObjectHandle::writeJSON(int json_version, JSON::Writer& p, bool dereference_indirect) const
+#endif
 {
     if (!dereference_indirect && isIndirect()) {
         p << "\"" << getObjGen().unparse(' ') << " R\"";
@@ -1638,8 +1969,14 @@ QPDFObjectHandle::writeJSON(int json_version, JSON::Writer& p, bool dereference_
     }
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::writeJSON(int json_version, Pipeline* p, bool dereference_indirect, size_t depth)
+#else
+void
+QPDFObjectHandle::writeJSON(
+    int json_version, Pipeline* p, bool dereference_indirect, size_t depth) const
+#endif
 {
     JSON::Writer jw{p, depth};
     writeJSON(json_version, jw, dereference_indirect);
@@ -1871,8 +2208,13 @@ QPDFObjectHandle::parse(
     return QPDFParser(input, object_description, tokenizer, decrypter, context).parse(empty, false);
 }
 
+#ifndef QPDF_FUTURE
 qpdf_offset_t
 QPDFObjectHandle::getParsedOffset()
+#else
+qpdf_offset_t
+QPDFObjectHandle::getParsedOffset() const
+#endif
 {
     return obj ? obj->getParsedOffset() : -1;
 }
@@ -2057,8 +2399,13 @@ QPDFObjectHandle::setObjectDescription(QPDF* owning_qpdf, std::string const& obj
     }
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::hasObjectDescription()
+#else
+bool
+QPDFObjectHandle::hasObjectDescription() const
+#endif
 {
     return obj && obj->hasDescription();
 }
@@ -2160,7 +2507,7 @@ QPDFObjectHandle::assertInitialized() const
 }
 
 void
-QPDFObjectHandle::typeWarning(char const* expected_type, std::string const& warning)
+QPDFObjectHandle::typeWarning(char const* expected_type, std::string const& warning) const
 {
     QPDF* context = nullptr;
     std::string description;
@@ -2179,11 +2526,16 @@ QPDFObjectHandle::typeWarning(char const* expected_type, std::string const& warn
             description,
             0,
             std::string("operation for ") + expected_type + " attempted on object of type " +
-                getTypeName() + ": " + warning));
+                obj->getTypeName() + ": " + warning));
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::warnIfPossible(std::string const& warning)
+#else
+void
+QPDFObjectHandle::warnIfPossible(std::string const& warning) const
+#endif
 {
     QPDF* context = nullptr;
     std::string description;
@@ -2195,7 +2547,7 @@ QPDFObjectHandle::warnIfPossible(std::string const& warning)
 }
 
 void
-QPDFObjectHandle::objectWarning(std::string const& warning)
+QPDFObjectHandle::objectWarning(std::string const& warning) const
 {
     QPDF* context = nullptr;
     std::string description;
@@ -2206,109 +2558,189 @@ QPDFObjectHandle::objectWarning(std::string const& warning)
 }
 
 void
-QPDFObjectHandle::assertType(char const* type_name, bool istype)
+QPDFObjectHandle::assertType(char const* type_name, bool istype) const
 {
     if (!istype) {
         throw std::runtime_error(
             std::string("operation for ") + type_name + " attempted on object of type " +
-            getTypeName());
+            (obj ? obj->getTypeName() : "uninitialized"));
     }
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertNull()
+#else
+void
+QPDFObjectHandle::assertNull() const
+#endif
 {
     assertType("null", isNull());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertBool()
+#else
+void
+QPDFObjectHandle::assertBool() const
+#endif
 {
     assertType("boolean", isBool());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertInteger()
+#else
+void
+QPDFObjectHandle::assertInteger() const
+#endif
 {
     assertType("integer", isInteger());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertReal()
+#else
+void
+QPDFObjectHandle::assertReal() const
+#endif
 {
     assertType("real", isReal());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertName()
+#else
+void
+QPDFObjectHandle::assertName() const
+#endif
 {
     assertType("name", isName());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertString()
+#else
+void
+QPDFObjectHandle::assertString() const
+#endif
 {
     assertType("string", isString());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertOperator()
+#else
+void
+QPDFObjectHandle::assertOperator() const
+#endif
 {
     assertType("operator", isOperator());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertInlineImage()
+#else
+void
+QPDFObjectHandle::assertInlineImage() const
+#endif
 {
     assertType("inlineimage", isInlineImage());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertArray()
+#else
+void
+QPDFObjectHandle::assertArray() const
+#endif
 {
     assertType("array", isArray());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertDictionary()
+#else
+void
+QPDFObjectHandle::assertDictionary() const
+#endif
 {
     assertType("dictionary", isDictionary());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertStream()
+#else
+void
+QPDFObjectHandle::assertStream() const
+#endif
 {
     assertType("stream", isStream());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertReserved()
+#else
+void
+QPDFObjectHandle::assertReserved() const
+#endif
 {
     assertType("reserved", isReserved());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertIndirect()
+#else
+void
+QPDFObjectHandle::assertIndirect() const
+#endif
 {
     if (!isIndirect()) {
         throw std::logic_error("operation for indirect object attempted on direct object");
     }
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertScalar()
+#else
+void
+QPDFObjectHandle::assertScalar() const
+#endif
 {
     assertType("scalar", isScalar());
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertNumber()
+#else
+void
+QPDFObjectHandle::assertNumber() const
+#endif
 {
     assertType("number", isNumber());
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isPageObject()
+#else
+bool
+QPDFObjectHandle::isPageObject() const
+#endif
 {
     // See comments in QPDFObjectHandle.hh.
     if (getOwningQPDF() == nullptr) {
@@ -2319,8 +2751,13 @@ QPDFObjectHandle::isPageObject()
     return isDictionaryOfType("/Page");
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isPagesObject()
+#else
+bool
+QPDFObjectHandle::isPagesObject() const
+#endif
 {
     if (getOwningQPDF() == nullptr) {
         return false;
@@ -2330,14 +2767,24 @@ QPDFObjectHandle::isPagesObject()
     return isDictionaryOfType("/Pages");
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isFormXObject()
+#else
+bool
+QPDFObjectHandle::isFormXObject() const
+#endif
 {
     return isStreamOfType("", "/Form");
 }
 
+#ifndef QPDF_FUTURE
 bool
 QPDFObjectHandle::isImage(bool exclude_imagemask)
+#else
+bool
+QPDFObjectHandle::isImage(bool exclude_imagemask) const
+#endif
 {
     return (
         isStreamOfType("", "/Image") &&
@@ -2358,8 +2805,13 @@ QPDFObjectHandle::checkOwnership(QPDFObjectHandle const& item) const
     }
 }
 
+#ifndef QPDF_FUTURE
 void
 QPDFObjectHandle::assertPageObject()
+#else
+void
+QPDFObjectHandle::assertPageObject() const
+#endif
 {
     if (!isPageObject()) {
         throw std::runtime_error("page operation called on non-Page object");

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -240,79 +240,79 @@ QPDFObjectHandle::disconnect()
 qpdf_object_type_e
 QPDFObjectHandle::getTypeCode()
 {
-    return dereference() ? this->obj->getTypeCode() : ::ot_uninitialized;
+    return obj ? obj->getResolvedTypeCode() : ::ot_uninitialized;
 }
 
 char const*
 QPDFObjectHandle::getTypeName()
 {
-    return dereference() ? this->obj->getTypeName() : "uninitialized";
+    return obj ? obj->getTypeName() : "uninitialized";
 }
 
 QPDF_Array*
-QPDFObjectHandle::asArray()
+QPDFObjectHandle::asArray() const
 {
-    return dereference() ? obj->as<QPDF_Array>() : nullptr;
+    return obj ? obj->as<QPDF_Array>() : nullptr;
 }
 
 QPDF_Bool*
-QPDFObjectHandle::asBool()
+QPDFObjectHandle::asBool() const
 {
-    return dereference() ? obj->as<QPDF_Bool>() : nullptr;
+    return obj ? obj->as<QPDF_Bool>() : nullptr;
 }
 
 QPDF_Dictionary*
-QPDFObjectHandle::asDictionary()
+QPDFObjectHandle::asDictionary() const
 {
-    return dereference() ? obj->as<QPDF_Dictionary>() : nullptr;
+    return obj ? obj->as<QPDF_Dictionary>() : nullptr;
 }
 
 QPDF_InlineImage*
-QPDFObjectHandle::asInlineImage()
+QPDFObjectHandle::asInlineImage() const
 {
-    return dereference() ? obj->as<QPDF_InlineImage>() : nullptr;
+    return obj ? obj->as<QPDF_InlineImage>() : nullptr;
 }
 
 QPDF_Integer*
-QPDFObjectHandle::asInteger()
+QPDFObjectHandle::asInteger() const
 {
-    return dereference() ? obj->as<QPDF_Integer>() : nullptr;
+    return obj ? obj->as<QPDF_Integer>() : nullptr;
 }
 
 QPDF_Name*
-QPDFObjectHandle::asName()
+QPDFObjectHandle::asName() const
 {
-    return dereference() ? obj->as<QPDF_Name>() : nullptr;
+    return obj ? obj->as<QPDF_Name>() : nullptr;
 }
 
 QPDF_Null*
-QPDFObjectHandle::asNull()
+QPDFObjectHandle::asNull() const
 {
-    return dereference() ? obj->as<QPDF_Null>() : nullptr;
+    return obj ? obj->as<QPDF_Null>() : nullptr;
 }
 
 QPDF_Operator*
-QPDFObjectHandle::asOperator()
+QPDFObjectHandle::asOperator() const
 {
-    return dereference() ? obj->as<QPDF_Operator>() : nullptr;
+    return obj ? obj->as<QPDF_Operator>() : nullptr;
 }
 
 QPDF_Real*
-QPDFObjectHandle::asReal()
+QPDFObjectHandle::asReal() const
 {
-    return dereference() ? obj->as<QPDF_Real>() : nullptr;
+    return obj ? obj->as<QPDF_Real>() : nullptr;
 }
 
 QPDF_Reserved*
-QPDFObjectHandle::asReserved()
+QPDFObjectHandle::asReserved() const
 {
-    return dereference() ? obj->as<QPDF_Reserved>() : nullptr;
+    return obj ? obj->as<QPDF_Reserved>() : nullptr;
 }
 
 QPDF_Stream*
-QPDFObjectHandle::asStream()
+QPDFObjectHandle::asStream() const
 {
-    return dereference() ? obj->as<QPDF_Stream>() : nullptr;
+    return obj ? obj->as<QPDF_Stream>() : nullptr;
 }
 
 QPDF_Stream*
@@ -324,21 +324,21 @@ QPDFObjectHandle::asStreamWithAssert()
 }
 
 QPDF_String*
-QPDFObjectHandle::asString()
+QPDFObjectHandle::asString() const
 {
-    return dereference() ? obj->as<QPDF_String>() : nullptr;
+    return obj ? obj->as<QPDF_String>() : nullptr;
 }
 
 bool
 QPDFObjectHandle::isDestroyed()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_destroyed);
+    return obj && obj->getResolvedTypeCode() == ::ot_destroyed;
 }
 
 bool
 QPDFObjectHandle::isBool()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_boolean);
+    return obj && obj->getResolvedTypeCode() == ::ot_boolean;
 }
 
 bool
@@ -346,25 +346,25 @@ QPDFObjectHandle::isDirectNull() const
 {
     // Don't call dereference() -- this is a const method, and we know
     // objid == 0, so there's nothing to resolve.
-    return (isInitialized() && (getObjectID() == 0) && (obj->getTypeCode() == ::ot_null));
+    return (obj && getObjectID() == 0 && obj->getTypeCode() == ::ot_null);
 }
 
 bool
 QPDFObjectHandle::isNull()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_null);
+    return obj && obj->getResolvedTypeCode() == ::ot_null;
 }
 
 bool
 QPDFObjectHandle::isInteger()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_integer);
+    return obj && obj->getResolvedTypeCode() == ::ot_integer;
 }
 
 bool
 QPDFObjectHandle::isReal()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_real);
+    return obj && obj->getResolvedTypeCode() == ::ot_real;
 }
 
 bool
@@ -401,49 +401,49 @@ QPDFObjectHandle::getValueAsNumber(double& value)
 bool
 QPDFObjectHandle::isName()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_name);
+    return obj && obj->getResolvedTypeCode() == ::ot_name;
 }
 
 bool
 QPDFObjectHandle::isString()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_string);
+    return obj && obj->getResolvedTypeCode() == ::ot_string;
 }
 
 bool
 QPDFObjectHandle::isOperator()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_operator);
+    return obj && obj->getResolvedTypeCode() == ::ot_operator;
 }
 
 bool
 QPDFObjectHandle::isInlineImage()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_inlineimage);
+    return obj && obj->getResolvedTypeCode() == ::ot_inlineimage;
 }
 
 bool
 QPDFObjectHandle::isArray()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_array);
+    return obj && obj->getResolvedTypeCode() == ::ot_array;
 }
 
 bool
 QPDFObjectHandle::isDictionary()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_dictionary);
+    return obj && obj->getResolvedTypeCode() == ::ot_dictionary;
 }
 
 bool
 QPDFObjectHandle::isStream()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_stream);
+    return obj && obj->getResolvedTypeCode() == ::ot_stream;
 }
 
 bool
 QPDFObjectHandle::isReserved()
 {
-    return dereference() && (obj->getTypeCode() == ::ot_reserved);
+    return obj && obj->getResolvedTypeCode() == ::ot_reserved;
 }
 
 bool
@@ -1586,7 +1586,7 @@ QPDFObjectHandle::unparse()
 std::string
 QPDFObjectHandle::unparseResolved()
 {
-    if (!dereference()) {
+    if (!obj) {
         throw std::logic_error("attempted to dereference an uninitialized QPDFObjectHandle");
     }
     return obj->unparse();
@@ -1615,7 +1615,7 @@ QPDFObjectHandle::getJSON(int json_version, bool dereference_indirect)
 {
     if ((!dereference_indirect) && isIndirect()) {
         return JSON::makeString(unparse());
-    } else if (!dereference()) {
+    } else if (!obj) {
         throw std::logic_error("attempted to dereference an uninitialized QPDFObjectHandle");
     } else {
         Pl_Buffer p{"json"};
@@ -1631,7 +1631,7 @@ QPDFObjectHandle::writeJSON(int json_version, JSON::Writer& p, bool dereference_
 {
     if (!dereference_indirect && isIndirect()) {
         p << "\"" << getObjGen().unparse(' ') << " R\"";
-    } else if (!dereference()) {
+    } else if (!obj) {
         throw std::logic_error("attempted to dereference an uninitialized QPDFObjectHandle");
     } else {
         obj->writeJSON(json_version, p);
@@ -1874,11 +1874,7 @@ QPDFObjectHandle::parse(
 qpdf_offset_t
 QPDFObjectHandle::getParsedOffset()
 {
-    if (dereference()) {
-        return this->obj->getParsedOffset();
-    } else {
-        return -1;
-    }
+    return obj ? obj->getParsedOffset() : -1;
 }
 
 QPDFObjectHandle
@@ -2055,9 +2051,7 @@ QPDFObjectHandle::newReserved(QPDF* qpdf)
 void
 QPDFObjectHandle::setObjectDescription(QPDF* owning_qpdf, std::string const& object_description)
 {
-    // This is called during parsing on newly created direct objects, so we can't call dereference()
-    // here.
-    if (isInitialized() && obj.get()) {
+    if (obj) {
         auto descr = std::make_shared<QPDFValue::Description>(object_description);
         obj->setDescription(owning_qpdf, descr);
     }
@@ -2066,13 +2060,13 @@ QPDFObjectHandle::setObjectDescription(QPDF* owning_qpdf, std::string const& obj
 bool
 QPDFObjectHandle::hasObjectDescription()
 {
-    return dereference() && obj.get() && obj->hasDescription();
+    return obj && obj->hasDescription();
 }
 
 QPDFObjectHandle
 QPDFObjectHandle::shallowCopy()
 {
-    if (!dereference()) {
+    if (!obj) {
         throw std::logic_error("operation attempted on uninitialized QPDFObjectHandle");
     }
     return {obj->copy()};
@@ -2081,7 +2075,7 @@ QPDFObjectHandle::shallowCopy()
 QPDFObjectHandle
 QPDFObjectHandle::unsafeShallowCopy()
 {
-    if (!dereference()) {
+    if (!obj) {
         throw std::logic_error("operation attempted on uninitialized QPDFObjectHandle");
     }
     return {obj->copy(true)};
@@ -2172,10 +2166,10 @@ QPDFObjectHandle::typeWarning(char const* expected_type, std::string const& warn
     std::string description;
     // Type checks above guarantee that the object has been dereferenced. Nevertheless, dereference
     // throws exceptions in the test suite
-    if (!dereference()) {
+    if (!obj) {
         throw std::logic_error("attempted to dereference an uninitialized QPDFObjectHandle");
     }
-    this->obj->getDescription(context, description);
+    obj->getDescription(context, description);
     // Null context handled by warn
     warn(
         context,
@@ -2193,7 +2187,7 @@ QPDFObjectHandle::warnIfPossible(std::string const& warning)
 {
     QPDF* context = nullptr;
     std::string description;
-    if (dereference() && obj->getDescription(context, description)) {
+    if (obj && obj->getDescription(context, description)) {
         warn(context, QPDFExc(qpdf_e_damaged_pdf, "", description, 0, warning));
     } else {
         *QPDFLogger::defaultLogger()->getError() << warning << "\n";
@@ -2205,8 +2199,8 @@ QPDFObjectHandle::objectWarning(std::string const& warning)
 {
     QPDF* context = nullptr;
     std::string description;
-    // Type checks above guarantee that the object has been dereferenced.
-    this->obj->getDescription(context, description);
+    // Type checks above guarantee that the object is initialized.
+    obj->getDescription(context, description);
     // Null context handled by warn
     warn(context, QPDFExc(qpdf_e_object, "", description, 0, warning));
 }
@@ -2370,16 +2364,6 @@ QPDFObjectHandle::assertPageObject()
     if (!isPageObject()) {
         throw std::runtime_error("page operation called on non-Page object");
     }
-}
-
-inline bool
-QPDFObjectHandle::dereference()
-{
-    if (!isInitialized()) {
-        return false;
-    }
-    this->obj->resolve();
-    return true;
 }
 
 void

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -130,8 +130,7 @@ QPDF_Array::unparse()
             for (int j = next; j < key; ++j) {
                 result += "null ";
             }
-            item.second->resolve();
-            auto og = item.second->getObjGen();
+            auto og = item.second->resolved_object()->getObjGen();
             result += og.isIndirect() ? og.unparse(' ') + " R " : item.second->unparse() + " ";
             next = ++key;
         }
@@ -140,8 +139,7 @@ QPDF_Array::unparse()
         }
     } else {
         for (auto const& item: elements) {
-            item->resolve();
-            auto og = item->getObjGen();
+            auto og = item->resolved_object()->getObjGen();
             result += og.isIndirect() ? og.unparse(' ') + " R " : item->unparse() + " ";
         }
     }

--- a/libqpdf/QPDF_Unresolved.cc
+++ b/libqpdf/QPDF_Unresolved.cc
@@ -1,6 +1,7 @@
 #include <qpdf/QPDF_Unresolved.hh>
 
-#include <stdexcept>
+#include <qpdf/QPDF.hh>
+#include <qpdf/QPDFObject_private.hh>
 
 QPDF_Unresolved::QPDF_Unresolved(QPDF* qpdf, QPDFObjGen const& og) :
     QPDFValue(::ot_unresolved, "unresolved", qpdf, og)
@@ -16,19 +17,23 @@ QPDF_Unresolved::create(QPDF* qpdf, QPDFObjGen const& og)
 std::shared_ptr<QPDFObject>
 QPDF_Unresolved::copy(bool shallow)
 {
-    throw std::logic_error("attempted to shallow copy an unresolved QPDFObjectHandle");
-    return nullptr;
+    return QPDF::Resolver::resolved(qpdf, og)->copy(shallow);
 }
 
 std::string
 QPDF_Unresolved::unparse()
 {
-    throw std::logic_error("attempted to unparse an unresolved QPDFObjectHandle");
-    return "";
+    return QPDF::Resolver::resolved(qpdf, og)->unparse();
 }
 
 void
 QPDF_Unresolved::writeJSON(int json_version, JSON::Writer& p)
 {
-    throw std::logic_error("attempted to get JSON from an unresolved QPDFObjectHandle");
+    QPDF::Resolver::resolved(qpdf, og)->writeJSON(json_version, p);
+}
+
+std::string
+QPDF_Unresolved::getStringValue() const
+{
+    return QPDF::Resolver::resolved(qpdf, og)->getStringValue();
 }

--- a/libqpdf/qpdf/QPDF_Unresolved.hh
+++ b/libqpdf/qpdf/QPDF_Unresolved.hh
@@ -11,6 +11,7 @@ class QPDF_Unresolved: public QPDFValue
     std::shared_ptr<QPDFObject> copy(bool shallow = false) override;
     std::string unparse() override;
     void writeJSON(int json_version, JSON::Writer& p) override;
+    std::string getStringValue() const override;
 
   private:
     QPDF_Unresolved(QPDF* qpdf, QPDFObjGen const& og);


### PR DESCRIPTION
Making methods const where possible 

- makes code clearer,
- avoids unnecessary copying, and
- gives compilers greater scope for optimization.

In order to allow object handle methods to be made const it is necessary to refactor resolving  of objects. In particular, QPDF_Unresolved objects are made responsible for copying, unparsing, etc themselves. Where QPDFObject methods are accessing QPDFValue data members directly rather than through QPDFValue methods, the QPDFObject method is made responsible for handling unresolved objects correctly. At a basic level, this is achieved by modifying the QPDF::resolve method to return a pointer to the resolved object.

In addition to permitting QPDFObjectHandle methods to be made const, this approach to resolving object handles is also more efficient. Accessing unresolved object handles is (relatively) rare: it only applies to indirect objects and only to the first significant access to an object (or even, any object of an object stream). Confining the necessary checks to unresolved object
access only rather than to any object access reduces overhead. 