### PR TITLE
Avoid unnecessary copying of stream dictionary in QPDF::readObject

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1344,21 +1344,16 @@ QPDF::readObject(
             size_t length = 0;
 
             try {
-                std::map<std::string, QPDFObjectHandle> dict = object.getDictAsMap();
+                auto length_obj = object.getKey("/Length");
 
-                if (dict.count("/Length") == 0) {
-                    QTC::TC("qpdf", "QPDF stream without length");
-                    throw damagedPDF(input, offset, "stream dictionary lacks /Length key");
-                }
-
-                QPDFObjectHandle length_obj = dict["/Length"];
                 if (!length_obj.isInteger()) {
+                    if (length_obj.isNull()) {
+                        QTC::TC("qpdf", "QPDF stream without length");
+                        throw damagedPDF(input, offset, "stream dictionary lacks /Length key");
+                    }
                     QTC::TC("qpdf", "QPDF stream length not integer");
                     throw damagedPDF(
-                        input,
-                        offset,
-                        "/Length key in stream dictionary is not "
-                        "an integer");
+                        input, offset, "/Length key in stream dictionary is not an integer");
                 }
 
                 length = toS(length_obj.getUIntValue());

--- a/qpdf/qtest/qpdf/issue-100.out
+++ b/qpdf/qtest/qpdf/issue-100.out
@@ -9,7 +9,7 @@ WARNING: issue-100.pdf (object 5 0, offset 297): unknown token while reading obj
 WARNING: issue-100.pdf (object 5 0, offset 304): unknown token while reading object; treating as string
 WARNING: issue-100.pdf (object 5 0, offset 304): too many errors; giving up on reading object
 WARNING: issue-100.pdf (object 5 0, offset 308): expected endobj
-WARNING: issue-100.pdf (object 5 0, offset 418): /Length key in stream dictionary is not an integer
+WARNING: issue-100.pdf (object 5 0, offset 418): stream dictionary lacks /Length key
 WARNING: issue-100.pdf (object 5 0, offset 489): attempting to recover stream length
 WARNING: issue-100.pdf (object 5 0, offset 489): recovered stream length: 12
 WARNING: issue-100.pdf (trailer, offset 953): expected dictionary key but found non-name object; inserting key /QPDFFake1

--- a/qpdf/qtest/qpdf/issue-117.out
+++ b/qpdf/qtest/qpdf/issue-117.out
@@ -2,7 +2,7 @@ WARNING: issue-117.pdf: file is damaged
 WARNING: issue-117.pdf (offset 3526): xref not found
 WARNING: issue-117.pdf: Attempting to reconstruct cross-reference table
 WARNING: issue-117.pdf (offset 66): loop detected resolving object 2 0
-WARNING: issue-117.pdf (object 2 0, offset 22): /Length key in stream dictionary is not an integer
+WARNING: issue-117.pdf (object 2 0, offset 22): stream dictionary lacks /Length key
 WARNING: issue-117.pdf (object 2 0, offset 67): attempting to recover stream length
 WARNING: issue-117.pdf (object 2 0, offset 67): recovered stream length: 91
 WARNING: issue-117.pdf (object 5 0, offset 1559): expected endstream

--- a/qpdf/qtest/qpdf/issue-335a.out
+++ b/qpdf/qtest/qpdf/issue-335a.out
@@ -1019,22 +1019,22 @@ WARNING: issue-335a.pdf (trailer, offset 20748): stream keyword followed by extr
 WARNING: issue-335a.pdf (trailer, offset 20679): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 20749): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 20749): unable to recover stream data; treating stream as empty
-WARNING: issue-335a.pdf (trailer, offset 20756): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 20756): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 20787): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 20787): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 20812): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (trailer, offset 20803): expected dictionary key but found non-name object; inserting key /QPDFFake1
 WARNING: issue-335a.pdf (trailer, offset 20803): dictionary has duplicated key /Length; last occurrence overrides earlier ones
 WARNING: issue-335a.pdf (trailer, offset 20843): stream keyword followed by extraneous whitespace
-WARNING: issue-335a.pdf (trailer, offset 20800): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 20800): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 20844): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 20844): unable to recover stream data; treating stream as empty
-WARNING: issue-335a.pdf (trailer, offset 20851): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 20851): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 20882): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 20882): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 20914): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (trailer, offset 20898): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 20895): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 20895): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 20929): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 20929): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 20949): unexpected >
@@ -1047,7 +1047,7 @@ WARNING: issue-335a.pdf (trailer, offset 20973): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 20973): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 21042): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (trailer, offset 21026): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 21023): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 21023): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 21057): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 21057): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 21077): unexpected >
@@ -1116,7 +1116,7 @@ WARNING: issue-335a.pdf (trailer, offset 21444): unknown token while reading obj
 WARNING: issue-335a.pdf (trailer, offset 21452): invalid character (-) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 21819): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (trailer, offset 21819): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21407): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 21407): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 21438): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 21438): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 21452): invalid character (-) in hexstring
@@ -1171,13 +1171,13 @@ WARNING: issue-335a.pdf (trailer, offset 21936): dictionary has duplicated key /
 WARNING: issue-335a.pdf (trailer, offset 21936): expected dictionary key but found non-name object; inserting key /QPDFFake7
 WARNING: issue-335a.pdf (trailer, offset 21936): expected dictionary key but found non-name object; inserting key /QPDFFake8
 WARNING: issue-335a.pdf (trailer, offset 21936): expected dictionary key but found non-name object; inserting key /QPDFFake9
-WARNING: issue-335a.pdf (trailer, offset 21932): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 21932): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 22052): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 22052): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 22000): invalid character (t) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 22088): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (trailer, offset 22087): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22083): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 22083): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 22136): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 22136): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 22178): unknown token while reading object; treating as string
@@ -1194,7 +1194,7 @@ WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but fou
 WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but found non-name object; inserting key /QPDFFake4
 WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but found non-name object; inserting key /QPDFFake5
 WARNING: issue-335a.pdf (trailer, offset 22276): stream keyword followed by carriage return only
-WARNING: issue-335a.pdf (trailer, offset 22173): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 22173): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 22276): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 22276): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 22202): unknown token while reading object; treating as string
@@ -1219,7 +1219,7 @@ WARNING: issue-335a.pdf (trailer, offset 22373): attempting to recover stream le
 WARNING: issue-335a.pdf (trailer, offset 22373): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 22437): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (trailer, offset 22436): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22432): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 22432): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 22484): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 22484): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 22650): unknown token while reading object; treating as string
@@ -1278,7 +1278,7 @@ WARNING: issue-335a.pdf (trailer, offset 22817): attempting to recover stream le
 WARNING: issue-335a.pdf (trailer, offset 22817): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 22702): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (trailer, offset 22701): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22697): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (trailer, offset 22697): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (trailer, offset 22748): attempting to recover stream length
 WARNING: issue-335a.pdf (trailer, offset 22748): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (trailer, offset 22845): unknown token while reading object; treating as string
@@ -1308,7 +1308,7 @@ WARNING: issue-335a.pdf (object 5 0, offset 23451): invalid character (ÿ) in hex
 WARNING: issue-335a.pdf (object 5 0, offset 23458): unknown token while reading object; treating as string
 WARNING: issue-335a.pdf (object 5 0, offset 23444): expected dictionary key but found non-name object; inserting key /QPDFFake1
 WARNING: issue-335a.pdf (object 5 0, offset 23444): expected dictionary key but found non-name object; inserting key /QPDFFake2
-WARNING: issue-335a.pdf (object 5 0, offset 23440): /Length key in stream dictionary is not an integer
+WARNING: issue-335a.pdf (object 5 0, offset 23440): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (object 5 0, offset 23485): attempting to recover stream length
 WARNING: issue-335a.pdf (object 5 0, offset 23485): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (object 5 0, offset 24974): expected endobj

--- a/qpdf/qtest/qpdf/issue-51.out
+++ b/qpdf/qtest/qpdf/issue-51.out
@@ -5,7 +5,7 @@ WARNING: issue-51.pdf (object 7 0, offset 553): expected endobj
 WARNING: issue-51.pdf (object 1 0, offset 236): dictionary has duplicated key /00000000; last occurrence overrides earlier ones
 WARNING: issue-51.pdf (object 1 0, offset 359): expected endobj
 WARNING: issue-51.pdf (offset 70): loop detected resolving object 2 0
-WARNING: issue-51.pdf (object 2 0, offset 26): /Length key in stream dictionary is not an integer
+WARNING: issue-51.pdf (object 2 0, offset 26): stream dictionary lacks /Length key
 WARNING: issue-51.pdf (object 2 0, offset 71): attempting to recover stream length
 WARNING: issue-51.pdf (object 2 0, offset 71): unable to recover stream data; treating stream as empty
 WARNING: issue-51.pdf (object 2 0, offset 977): expected endobj


### PR DESCRIPTION
Unless I am missing something, there is no reason to differentiate between a missing /Length key and one with a null value.