### PR TITLE
 Add new Buffer method copy and deprecate copy constructor / assignment operator

### DIFF
--- a/include/qpdf/Buffer.hh
+++ b/include/qpdf/Buffer.hh
@@ -41,10 +41,10 @@ class Buffer
     QPDF_DLL
     Buffer(unsigned char* buf, size_t size);
 
-    QPDF_DLL
-    Buffer(Buffer const&);
-    QPDF_DLL
-    Buffer& operator=(Buffer const&);
+    [[deprecated("Move Buffer or use Buffer::copy instead")]] QPDF_DLL Buffer(Buffer const&);
+    [[deprecated("Move Buffer or use Buffer::copy instead")]] QPDF_DLL Buffer&
+    operator=(Buffer const&);
+
     QPDF_DLL
     Buffer(Buffer&&) noexcept;
     QPDF_DLL
@@ -55,6 +55,14 @@ class Buffer
     unsigned char const* getBuffer() const;
     QPDF_DLL
     unsigned char* getBuffer();
+
+    // Create a new copy of the Buffer. The new Buffer owns an independent copy of the data.
+    QPDF_DLL
+    Buffer copy() const;
+
+    // Only used during CI testing.
+    // ABI: remove when removing copy constructor / assignment operator
+    static void setTestMode() noexcept;
 
   private:
     class Members

--- a/libqpdf/Pl_LZWDecoder.cc
+++ b/libqpdf/Pl_LZWDecoder.cc
@@ -129,7 +129,7 @@ Pl_LZWDecoder::addToTable(unsigned char next)
     unsigned char* new_data = entry.getBuffer();
     memcpy(new_data, last_data, last_size);
     new_data[last_size] = next;
-    this->table.push_back(entry);
+    this->table.push_back(std::move(entry));
 }
 
 void

--- a/libtests/buffer.cc
+++ b/libtests/buffer.cc
@@ -19,7 +19,34 @@ int
 main()
 {
     {
-        // Test that buffers can be copied by value.
+        // Test that buffers can be copied by value using Buffer::copy.
+        Buffer bc1(2);
+        unsigned char* bc1p = bc1.getBuffer();
+        bc1p[0] = 'Q';
+        bc1p[1] = 'W';
+        Buffer bc2(bc1.copy());
+        bc1p[0] = 'R';
+        unsigned char* bc2p = bc2.getBuffer();
+        assert(bc2p != bc1p);
+        assert(bc2p[0] == 'Q');
+        assert(bc2p[1] == 'W');
+        bc2 = bc1.copy();
+        bc2p = bc2.getBuffer();
+        assert(bc2p != bc1p);
+        assert(bc2p[0] == 'R');
+        assert(bc2p[1] == 'W');
+    }
+
+#ifdef _MSC_VER
+# pragma warning(disable : 4996)
+#endif
+#if (defined(__GNUC__) || defined(__clang__))
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    {
+        // Test that buffers can be copied by value using copy construction / assignment.
+        Buffer::setTestMode();
         Buffer bc1(2);
         unsigned char* bc1p = bc1.getBuffer();
         bc1p[0] = 'Q';
@@ -36,6 +63,9 @@ main()
         assert(bc2p[0] == 'R');
         assert(bc2p[1] == 'W');
     }
+#if (defined(__GNUC__) || defined(__clang__))
+# pragma GCC diagnostic pop
+#endif
 
     {
         // Test that buffers can be moved.


### PR DESCRIPTION
Add to change log:

Add new method Buffer::copy and deprecate Buffer copy constructor and assignment operator. Buffer copy operations are expensive as they always involve copying the buffer content. Use "buffer2 = buffer1.copy();" or "Buffer buffer2{buffer1.copy()};" to make it explicit that copying is intended.

Add to release notes:

Add new method Buffer::copy and deprecate Buffer copy constructor and assignment operator. 


Add to release notes - planned changes for 12.x:

Buffer copy constructor and assignment operator will be removed. Buffer copy operations are expensive as they always involve copying the buffer content. Use "buffer2 = buffer1.copy();" or "Buffer buffer2{buffer1.copy()};" to make it explicit that copying is intended.

