### PR TITLE
Change code formatting from clang-format >= 15 to clang-format-16

### DIFF
--- a/format-code
+++ b/format-code
@@ -23,7 +23,7 @@ cd $(dirname $0)
 for i in $(find . -name 'build*' -prune -o '(' \
 		-name '*.hh' -o -name '*.h' -o -name '*.cc' -o -name '*.c' \
 		')' -print); do
-    if clang-format < $i >| $i.new; then
+    if clang-format-16 < $i >| $i.new; then
 	if diff -q $i $i.new >/dev/null 2>/dev/null; then
 	    echo "okay:    $i"
 	    rm $i.new

--- a/manual/contributing.rst
+++ b/manual/contributing.rst
@@ -20,11 +20,10 @@ https://github.com/qpdf/qpdf/discussions.
 Code Formatting
 ---------------
 
-The qpdf source code is formatting using clang-format ≥ version 15
+The qpdf source code is formatting using clang-format version 16
 with a :file:`.clang-format` file at the top of the source tree. The
 :file:`format-code` script reformats all the source code in the
-repository. You must have ``clang-format`` in your path, and it must be
-at least version 15.
+repository. You must have ``clang-format-16`` in your path.
 
 For emacs users, the :file:`.dir-locals.el` file configures emacs
 ``cc-mode`` for an indentation style that is similar to but not


### PR DESCRIPTION
There are minor differences in the output produced by different versions of clang-format. The formatting used at the moment is version 16.

The script is what I am using because the standard script produces formatting that is inconsistent with the code on github.