### PR TITLE
Bump minimum clang-format version to 16

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 # -*- yaml -*-
-# This configuration works with clang-format-15.
+# This configuration requires at least clang-format 15.
+# See ./format-code for comments about the minimum version.
 # See https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 ---
 Language: Cpp

--- a/format-code
+++ b/format-code
@@ -19,6 +19,19 @@
 
 # Please see "Code Formatting" in the manual for additional notes.
 
+# If a newer version of clang-format causes changes to the output that
+# are improvements, bump the minimum required version of clang-format
+# here, and update manual/contributing.rst. There's a comment there
+# that refers to this comment. See also .clang-format.
+min_version=16
+
+clang_version=$(clang-format --version | \
+    awk '{for (i=1; i<=NF; i++) if ($i == "version") {print int($(i+1)); exit}}')
+if [ "$clang_version" -lt "$min_version" ]; then
+    echo "clang-format version >= $min_version is required"
+    exit 2
+fi
+
 cd $(dirname $0)
 for i in $(find . -name 'build*' -prune -o '(' \
 		-name '*.hh' -o -name '*.h' -o -name '*.cc' -o -name '*.c' \

--- a/manual/contributing.rst
+++ b/manual/contributing.rst
@@ -20,11 +20,14 @@ https://github.com/qpdf/qpdf/discussions.
 Code Formatting
 ---------------
 
-The qpdf source code is formatting using clang-format ≥ version 15
-with a :file:`.clang-format` file at the top of the source tree. The
+.. The minimum clang-format version is also in format-code. There is a
+   comment there that references this file.
+
+The qpdf source code is formatted using clang-format with a
+:file:`.clang-format` file at the top of the source tree. The
 :file:`format-code` script reformats all the source code in the
-repository. You must have ``clang-format`` in your path, and it must be
-at least version 15.
+repository. You must have ``clang-format`` in your path, and it must
+be at least version 16.
 
 For emacs users, the :file:`.dir-locals.el` file configures emacs
 ``cc-mode`` for an indentation style that is similar to but not


### PR DESCRIPTION
Also enforce in format-code.

@m-holger Does this work for you? If so, I'll merge this and close #986 .