### PR TITLE
Simplify QPDFObjectHandle::isPageObject

### DIFF
--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -2299,22 +2299,7 @@ QPDFObjectHandle::isPageObject()
     }
     // getAllPages repairs /Type when traversing the page tree.
     getOwningQPDF()->getAllPages();
-    if (!this->isDictionary()) {
-        return false;
-    }
-    if (this->hasKey("/Type")) {
-        QPDFObjectHandle type = this->getKey("/Type");
-        if (type.isNameAndEquals("/Page")) {
-            return true;
-        }
-        // Files have been seen in the wild that have /Type (Page)
-        else if (type.isString() && (type.getStringValue() == "Page")) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-    return false;
+    return isDictionaryOfType("/Page");
 }
 
 bool


### PR DESCRIPTION
The removed code is redundant for pages that are part of the page tree due to the repairs carried out by getAllPages.

If the intention is to identify page objects that are not part of the pages tree a comment explaining that use would be helpful, including the reasoning for accepting a damaged page object without warning/repair. 