### PR TITLE
Change QPDF::copyForeignObject to return a null object when called wi…

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2034,13 +2034,13 @@ QPDF::copyForeignObject(QPDFObjectHandle foreign)
     }
     obj_copier.to_copy.clear();
 
-    auto& result = obj_copier.object_map[foreign.getObjGen()];
-    if (!result.isInitialized()) {
-        result = QPDFObjectHandle::newNull();
-        warn(damagedPDF("Unexpected reference to /Pages object while copying foreign object. "
-                        "Replacing with Null object."));
+    auto og = foreign.getObjGen();
+    if (!obj_copier.object_map.count(og)) {
+        warn(damagedPDF("unexpected reference to /Pages object while copying foreign object; "
+                        "replacing with null"));
+        return QPDFObjectHandle::newNull();
     }
-    return result;
+    return obj_copier.object_map[foreign.getObjGen()];
 }
 
 void

--- a/qpdf/qtest/qpdf/copy-foreign-objects-25.out
+++ b/qpdf/qtest/qpdf/copy-foreign-objects-25.out
@@ -1,1 +1,2 @@
+WARNING: minimal.pdf (object 6 0, offset 556): Unexpected reference to /Pages object while copying foreign object. Replacing with Null object.
 test 25 done

--- a/qpdf/qtest/qpdf/copy-foreign-objects-25.out
+++ b/qpdf/qtest/qpdf/copy-foreign-objects-25.out
@@ -1,2 +1,2 @@
-WARNING: minimal.pdf (object 6 0, offset 556): Unexpected reference to /Pages object while copying foreign object. Replacing with Null object.
+WARNING: minimal.pdf (object 6 0, offset 556): unexpected reference to /Pages object while copying foreign object; replacing with null
 test 25 done

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -954,6 +954,8 @@ test_25(QPDF& pdf, char const* arg2)
     // Copy qtest without crossing page boundaries.  Should get O1
     // and O2 and their streams but not O3 or any other pages.
 
+    // Also verify that attempts to copy /Pages objects return null.
+
     assert(arg2 != nullptr);
     {
         // Make sure original PDF is out of scope when we write.
@@ -961,6 +963,8 @@ test_25(QPDF& pdf, char const* arg2)
         oldpdf.processFile(arg2);
         QPDFObjectHandle qtest = oldpdf.getTrailer().getKey("/QTest");
         pdf.getTrailer().replaceKey("/QTest", pdf.copyForeignObject(qtest));
+
+        assert(pdf.copyForeignObject(oldpdf.getRoot().getKey("/Pages")).isNull());
     }
 
     QPDFWriter w(pdf, "a.pdf");


### PR DESCRIPTION
…th a /Pages object (fixes #1011)

If copyForeignObject is called with a pages object, the object will not be inserted into the obj_copier.obj_map during normal processing. In the return statement the missing entry is default constructed, with the consequence that an uninitialized object handle is returned. All future references to the object are also replaced with an uninitialized object rather than a null object.
