### PR TITLE
Remove use of non-standard `char_traits<unsigned char>` from Pl_Buffer

### DIFF
--- a/include/qpdf/Pl_Buffer.hh
+++ b/include/qpdf/Pl_Buffer.hh
@@ -33,6 +33,7 @@
 #include <qpdf/PointerHolder.hh> // unused -- remove in qpdf 12 (see #785)
 
 #include <memory>
+#include <vector>
 
 class QPDF_DLL_CLASS Pl_Buffer: public Pipeline
 {
@@ -77,7 +78,7 @@ class QPDF_DLL_CLASS Pl_Buffer: public Pipeline
         Members(Members const&) = delete;
 
         bool ready{true};
-        std::basic_string<unsigned char> data;
+        std::vector<unsigned char> data;
     };
 
     std::shared_ptr<Members> m;

--- a/libqpdf/Pl_Buffer.cc
+++ b/libqpdf/Pl_Buffer.cc
@@ -19,7 +19,7 @@ Pl_Buffer::~Pl_Buffer() // NOLINT (modernize-use-equals-default)
 void
 Pl_Buffer::write(unsigned char const* buf, size_t len)
 {
-    m->data.append(buf, len);
+    m->data.insert(m->data.end(), buf, buf + len);
     m->ready = false;
 
     if (getNext(true)) {
@@ -43,7 +43,7 @@ Pl_Buffer::getBuffer()
         throw std::logic_error("Pl_Buffer::getBuffer() called when not ready");
     }
 
-    auto size = m->data.length();
+    auto size = m->data.size();
     auto* b = new Buffer(size);
     if (size > 0) {
         unsigned char* p = b->getBuffer();
@@ -65,7 +65,7 @@ Pl_Buffer::getMallocBuffer(unsigned char** buf, size_t* len)
     if (!m->ready) {
         throw std::logic_error("Pl_Buffer::getMallocBuffer() called when not ready");
     }
-    auto size = m->data.length();
+    auto size = m->data.size();
     *len = size;
     if (size > 0) {
         *buf = reinterpret_cast<unsigned char*>(malloc(size));


### PR DESCRIPTION
`basic_string<unsigned char>` implies use of
`char_traits<unsigned char>`.

This char_traits specialization is not standard C++, and will be removed from LibC++ as of LLVM 18. To ensure continued LibC++ compatibility it needs to be removed.

There are two possible replacements here: `std::string` (e.g. `std::basic_string<char>`), or `std::vector<unsigned char>`.

I have opted for vector since this code is dealing with a binary buffer; though probably either way is fine (why does C++ even have strings anyway??).

https://github.com/qpdf/qpdf/issues/1024