### PR TITLE
Maintain links to foreign pages when copying foreign objects (fixes #1003)

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -351,6 +351,8 @@ class QPDF
     // QPDF with QPDFWriter if it has any reserved objects in it.
     QPDF_DLL
     QPDFObjectHandle newReserved();
+    QPDF_DLL
+    QPDFObjectHandle newIndirectNull();
 
     // Install this object handle as an indirect object and return an indirect reference to it.
     QPDF_DLL

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -391,8 +391,8 @@ class QPDF
     void swapObjects(int objid1, int generation1, int objid2, int generation2);
 
     // Replace a reserved object.  This is a wrapper around replaceObject but it guarantees that the
-    // underlying object is a reserved object.  After this call, reserved will be a reference to
-    // replacement.
+    // underlying object is a reserved object or a null object.  After this call, reserved will
+    // be a reference to replacement.
     QPDF_DLL
     void replaceReserved(QPDFObjectHandle reserved, QPDFObjectHandle replacement);
 

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1948,7 +1948,10 @@ void
 QPDF::replaceReserved(QPDFObjectHandle reserved, QPDFObjectHandle replacement)
 {
     QTC::TC("qpdf", "QPDF replaceReserved");
-    reserved.assertReserved();
+    auto tc = reserved.getTypeCode();
+    if (!(tc == ::ot_reserved || tc == ::ot_null)) {
+        throw std::logic_error("replaceReserved called with non-reserverd object");
+    }
     replaceObject(reserved.getObjGen(), replacement);
 }
 

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2026,7 +2026,13 @@ QPDF::copyForeignObject(QPDFObjectHandle foreign)
     }
     obj_copier.to_copy.clear();
 
-    return obj_copier.object_map[foreign.getObjGen()];
+    auto& result = obj_copier.object_map[foreign.getObjGen()];
+    if (!result.isInitialized()) {
+        result = QPDFObjectHandle::newNull();
+        warn(damagedPDF("Unexpected reference to /Pages object while copying foreign object. "
+                        "Replacing with Null object."));
+    }
+    return result;
 }
 
 void

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1861,6 +1861,12 @@ QPDF::newReserved()
 }
 
 QPDFObjectHandle
+QPDF::newIndirectNull()
+{
+    return makeIndirectFromQPDFObject(QPDF_Null::create());
+}
+
+QPDFObjectHandle
 QPDF::newStream()
 {
     return makeIndirectFromQPDFObject(
@@ -2015,8 +2021,7 @@ QPDF::copyForeignObject(QPDFObjectHandle foreign)
     reserveObjects(foreign, obj_copier, true);
 
     if (!obj_copier.visiting.empty()) {
-        throw std::logic_error("obj_copier.visiting is not empty"
-                               " after reserving objects");
+        throw std::logic_error("obj_copier.visiting is not empty after reserving objects");
     }
 
     // Copy any new objects and replace the reservations.
@@ -2071,7 +2076,8 @@ QPDF::reserveObjects(QPDFObjectHandle foreign, ObjCopier& obj_copier, bool top)
         QTC::TC("qpdf", "QPDF copy indirect");
         if (obj_copier.object_map.count(foreign_og) == 0) {
             obj_copier.to_copy.push_back(foreign);
-            obj_copier.object_map[foreign_og] = foreign.isStream() ? newStream() : newReserved();
+            obj_copier.object_map[foreign_og] =
+                foreign.isStream() ? newStream() : newIndirectNull();
         }
     }
 

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -121,7 +121,7 @@ QPDF_Dictionary::getAsMap() const
 void
 QPDF_Dictionary::replaceKey(std::string const& key, QPDFObjectHandle value)
 {
-    if (value.isNull()) {
+    if (value.isNull() && !value.isIndirect()) {
         // The PDF spec doesn't distinguish between keys with null values and missing keys.
         removeKey(key);
     } else {

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -122,7 +122,9 @@ void
 QPDF_Dictionary::replaceKey(std::string const& key, QPDFObjectHandle value)
 {
     if (value.isNull() && !value.isIndirect()) {
-        // The PDF spec doesn't distinguish between keys with null values and missing keys.
+        // The PDF spec doesn't distinguish between keys with null values and missing keys. Allow
+        // indirect nulls which are equivalent to a dangling reference, which is permitted by the
+        // spec.
         removeKey(key);
     } else {
         // add or replace value

--- a/qpdf/qtest/qpdf/test80b1.pdf
+++ b/qpdf/qtest/qpdf/test80b1.pdf
@@ -11,7 +11,7 @@
 >>
 endobj
 
-%% Original object ID: 30 0
+%% Original object ID: 31 0
 2 0 obj
 <<
   /DR 4 0 R
@@ -53,7 +53,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 31 0
+%% Original object ID: 32 0
 4 0 obj
 <<
   /Font <<
@@ -70,7 +70,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 29 0
+%% Original object ID: 30 0
 5 0 obj
 <<
   /AP <<
@@ -94,7 +94,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 49 0
+%% Original object ID: 50 0
 6 0 obj
 <<
   /DV /1
@@ -110,7 +110,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 64 0
+%% Original object ID: 65 0
 7 0 obj
 <<
   /AP <<
@@ -141,7 +141,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 72 0
+%% Original object ID: 73 0
 8 0 obj
 <<
   /AP <<
@@ -172,7 +172,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 80 0
+%% Original object ID: 81 0
 9 0 obj
 <<
   /AP <<
@@ -203,7 +203,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 99 0
+%% Original object ID: 100 0
 10 0 obj
 <<
   /DV /2
@@ -219,7 +219,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 112 0
+%% Original object ID: 113 0
 11 0 obj
 <<
   /AP <<
@@ -243,7 +243,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 117 0
+%% Original object ID: 118 0
 12 0 obj
 <<
   /AP <<
@@ -274,7 +274,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 122 0
+%% Original object ID: 123 0
 13 0 obj
 <<
   /AP <<
@@ -312,7 +312,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 127 0
+%% Original object ID: 128 0
 14 0 obj
 <<
   /AP <<
@@ -343,7 +343,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 132 0
+%% Original object ID: 133 0
 15 0 obj
 <<
   /AP <<
@@ -374,7 +374,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 143 0
+%% Original object ID: 144 0
 16 0 obj
 <<
   /AP <<
@@ -398,7 +398,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 155 0
+%% Original object ID: 156 0
 17 0 obj
 <<
   /DV /1
@@ -414,7 +414,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 168 0
+%% Original object ID: 169 0
 18 0 obj
 <<
   /AP <<
@@ -445,7 +445,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 174 0
+%% Original object ID: 175 0
 19 0 obj
 <<
   /AP <<
@@ -476,7 +476,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 180 0
+%% Original object ID: 181 0
 20 0 obj
 <<
   /AP <<
@@ -507,7 +507,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 193 0
+%% Original object ID: 194 0
 21 0 obj
 <<
   /DV /2
@@ -523,7 +523,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 205 0
+%% Original object ID: 206 0
 22 0 obj
 <<
   /AP <<
@@ -547,7 +547,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 209 0
+%% Original object ID: 210 0
 23 0 obj
 <<
   /AP <<
@@ -578,7 +578,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 213 0
+%% Original object ID: 214 0
 24 0 obj
 <<
   /AP <<
@@ -616,7 +616,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 217 0
+%% Original object ID: 218 0
 25 0 obj
 <<
   /AP <<
@@ -647,7 +647,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 221 0
+%% Original object ID: 222 0
 26 0 obj
 <<
   /AP <<
@@ -1309,7 +1309,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 32 0
+%% Original object ID: 33 0
 33 0 obj
 <<
   /BBox [
@@ -1348,7 +1348,7 @@ endobj
 77
 endobj
 
-%% Original object ID: 50 0
+%% Original object ID: 51 0
 35 0 obj
 <<
   /AP <<
@@ -1377,7 +1377,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 51 0
+%% Original object ID: 52 0
 36 0 obj
 <<
   /AP <<
@@ -1406,7 +1406,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 52 0
+%% Original object ID: 53 0
 37 0 obj
 <<
   /AP <<
@@ -1435,7 +1435,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 65 0
+%% Original object ID: 66 0
 38 0 obj
 <<
   /BBox [
@@ -1467,7 +1467,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 66 0
+%% Original object ID: 67 0
 40 0 obj
 <<
   /BBox [
@@ -1504,7 +1504,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 73 0
+%% Original object ID: 74 0
 42 0 obj
 <<
   /BBox [
@@ -1536,7 +1536,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 74 0
+%% Original object ID: 75 0
 44 0 obj
 <<
   /BBox [
@@ -1573,7 +1573,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 81 0
+%% Original object ID: 82 0
 46 0 obj
 <<
   /BBox [
@@ -1605,7 +1605,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 82 0
+%% Original object ID: 83 0
 48 0 obj
 <<
   /BBox [
@@ -1642,7 +1642,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 100 0
+%% Original object ID: 101 0
 50 0 obj
 <<
   /AP <<
@@ -1671,7 +1671,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 101 0
+%% Original object ID: 102 0
 51 0 obj
 <<
   /AP <<
@@ -1700,7 +1700,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 102 0
+%% Original object ID: 103 0
 52 0 obj
 <<
   /AP <<
@@ -1729,7 +1729,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 113 0
+%% Original object ID: 114 0
 53 0 obj
 <<
   /BBox [
@@ -1768,7 +1768,7 @@ endobj
 85
 endobj
 
-%% Original object ID: 118 0
+%% Original object ID: 119 0
 55 0 obj
 <<
   /BBox [
@@ -1809,7 +1809,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 123 0
+%% Original object ID: 124 0
 57 0 obj
 <<
   /BBox [
@@ -1864,7 +1864,7 @@ endobj
 238
 endobj
 
-%% Original object ID: 128 0
+%% Original object ID: 129 0
 59 0 obj
 <<
   /BBox [
@@ -1905,7 +1905,7 @@ endobj
 117
 endobj
 
-%% Original object ID: 133 0
+%% Original object ID: 134 0
 61 0 obj
 <<
   /BBox [
@@ -1946,7 +1946,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 144 0
+%% Original object ID: 145 0
 63 0 obj
 <<
   /BBox [
@@ -1985,7 +1985,7 @@ endobj
 77
 endobj
 
-%% Original object ID: 156 0
+%% Original object ID: 157 0
 65 0 obj
 <<
   /AP <<
@@ -2014,7 +2014,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 157 0
+%% Original object ID: 158 0
 66 0 obj
 <<
   /AP <<
@@ -2043,7 +2043,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 158 0
+%% Original object ID: 159 0
 67 0 obj
 <<
   /AP <<
@@ -2072,7 +2072,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 169 0
+%% Original object ID: 170 0
 68 0 obj
 <<
   /BBox [
@@ -2104,7 +2104,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 170 0
+%% Original object ID: 171 0
 70 0 obj
 <<
   /BBox [
@@ -2141,7 +2141,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 175 0
+%% Original object ID: 176 0
 72 0 obj
 <<
   /BBox [
@@ -2173,7 +2173,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 176 0
+%% Original object ID: 177 0
 74 0 obj
 <<
   /BBox [
@@ -2210,7 +2210,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 181 0
+%% Original object ID: 182 0
 76 0 obj
 <<
   /BBox [
@@ -2242,7 +2242,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 182 0
+%% Original object ID: 183 0
 78 0 obj
 <<
   /BBox [
@@ -2279,7 +2279,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 194 0
+%% Original object ID: 195 0
 80 0 obj
 <<
   /AP <<
@@ -2308,7 +2308,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 195 0
+%% Original object ID: 196 0
 81 0 obj
 <<
   /AP <<
@@ -2337,7 +2337,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 196 0
+%% Original object ID: 197 0
 82 0 obj
 <<
   /AP <<
@@ -2366,7 +2366,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 206 0
+%% Original object ID: 207 0
 83 0 obj
 <<
   /BBox [
@@ -2405,7 +2405,7 @@ endobj
 85
 endobj
 
-%% Original object ID: 210 0
+%% Original object ID: 211 0
 85 0 obj
 <<
   /BBox [
@@ -2446,7 +2446,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 214 0
+%% Original object ID: 215 0
 87 0 obj
 <<
   /BBox [
@@ -2501,7 +2501,7 @@ endobj
 238
 endobj
 
-%% Original object ID: 218 0
+%% Original object ID: 219 0
 89 0 obj
 <<
   /BBox [
@@ -2542,7 +2542,7 @@ endobj
 117
 endobj
 
-%% Original object ID: 222 0
+%% Original object ID: 223 0
 91 0 obj
 <<
   /BBox [
@@ -2583,7 +2583,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 138 0
+%% Original object ID: 139 0
 93 0 obj
 <<
   /AP <<
@@ -2613,7 +2613,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 140 0
+%% Original object ID: 141 0
 94 0 obj
 <<
   /F 28
@@ -2630,7 +2630,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 225 0
+%% Original object ID: 226 0
 95 0 obj
 <<
   /AP <<
@@ -2660,7 +2660,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 228 0
+%% Original object ID: 229 0
 96 0 obj
 <<
   /F 28
@@ -2926,7 +2926,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 53 0
+%% Original object ID: 54 0
 110 0 obj
 <<
   /BBox [
@@ -2969,7 +2969,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 54 0
+%% Original object ID: 55 0
 112 0 obj
 <<
   /BBox [
@@ -3001,7 +3001,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 55 0
+%% Original object ID: 56 0
 114 0 obj
 <<
   /BBox [
@@ -3044,7 +3044,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 56 0
+%% Original object ID: 57 0
 116 0 obj
 <<
   /BBox [
@@ -3076,7 +3076,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 57 0
+%% Original object ID: 58 0
 118 0 obj
 <<
   /BBox [
@@ -3119,7 +3119,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 58 0
+%% Original object ID: 59 0
 120 0 obj
 <<
   /BBox [
@@ -3151,7 +3151,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 103 0
+%% Original object ID: 104 0
 122 0 obj
 <<
   /BBox [
@@ -3194,7 +3194,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 104 0
+%% Original object ID: 105 0
 124 0 obj
 <<
   /BBox [
@@ -3226,7 +3226,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 105 0
+%% Original object ID: 106 0
 126 0 obj
 <<
   /BBox [
@@ -3269,7 +3269,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 106 0
+%% Original object ID: 107 0
 128 0 obj
 <<
   /BBox [
@@ -3301,7 +3301,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 107 0
+%% Original object ID: 108 0
 130 0 obj
 <<
   /BBox [
@@ -3344,7 +3344,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 108 0
+%% Original object ID: 109 0
 132 0 obj
 <<
   /BBox [
@@ -3376,7 +3376,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 159 0
+%% Original object ID: 160 0
 134 0 obj
 <<
   /BBox [
@@ -3419,7 +3419,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 160 0
+%% Original object ID: 161 0
 136 0 obj
 <<
   /BBox [
@@ -3451,7 +3451,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 161 0
+%% Original object ID: 162 0
 138 0 obj
 <<
   /BBox [
@@ -3494,7 +3494,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 162 0
+%% Original object ID: 163 0
 140 0 obj
 <<
   /BBox [
@@ -3526,7 +3526,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 163 0
+%% Original object ID: 164 0
 142 0 obj
 <<
   /BBox [
@@ -3569,7 +3569,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 164 0
+%% Original object ID: 165 0
 144 0 obj
 <<
   /BBox [
@@ -3601,7 +3601,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 197 0
+%% Original object ID: 198 0
 146 0 obj
 <<
   /BBox [
@@ -3644,7 +3644,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 198 0
+%% Original object ID: 199 0
 148 0 obj
 <<
   /BBox [
@@ -3676,7 +3676,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 199 0
+%% Original object ID: 200 0
 150 0 obj
 <<
   /BBox [
@@ -3719,7 +3719,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 200 0
+%% Original object ID: 201 0
 152 0 obj
 <<
   /BBox [
@@ -3751,7 +3751,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 201 0
+%% Original object ID: 202 0
 154 0 obj
 <<
   /BBox [
@@ -3794,7 +3794,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 202 0
+%% Original object ID: 203 0
 156 0 obj
 <<
   /BBox [
@@ -3826,7 +3826,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 139 0
+%% Original object ID: 140 0
 158 0 obj
 <<
   /BBox [
@@ -3867,7 +3867,7 @@ endobj
 929
 endobj
 
-%% Original object ID: 137 0
+%% Original object ID: 138 0
 160 0 obj
 <<
   /F 28
@@ -3884,7 +3884,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 134 0
+%% Original object ID: 135 0
 161 0 obj
 <<
   /AP <<
@@ -3914,7 +3914,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 226 0
+%% Original object ID: 227 0
 162 0 obj
 <<
   /BBox [
@@ -4082,7 +4082,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 135 0
+%% Original object ID: 136 0
 169 0 obj
 <<
   /BBox [
@@ -4127,172 +4127,172 @@ xref
 0000001190 00000 n 
 0000001554 00000 n 
 0000001918 00000 n 
-0000002282 00000 n 
-0000002431 00000 n 
-0000002787 00000 n 
-0000003206 00000 n 
-0000003752 00000 n 
-0000004226 00000 n 
-0000004685 00000 n 
-0000004990 00000 n 
-0000005141 00000 n 
-0000005513 00000 n 
-0000005885 00000 n 
-0000006257 00000 n 
-0000006408 00000 n 
-0000006770 00000 n 
-0000007195 00000 n 
-0000007747 00000 n 
-0000008227 00000 n 
-0000008700 00000 n 
-0000009310 00000 n 
-0000009789 00000 n 
-0000011734 00000 n 
-0000012132 00000 n 
-0000014074 00000 n 
-0000014183 00000 n 
-0000014472 00000 n 
-0000014520 00000 n 
-0000014863 00000 n 
-0000015204 00000 n 
-0000015547 00000 n 
-0000015772 00000 n 
-0000015820 00000 n 
-0000016115 00000 n 
-0000016163 00000 n 
-0000016388 00000 n 
-0000016436 00000 n 
-0000016731 00000 n 
-0000016779 00000 n 
-0000017004 00000 n 
-0000017052 00000 n 
-0000017347 00000 n 
-0000017396 00000 n 
-0000017741 00000 n 
-0000018084 00000 n 
-0000018429 00000 n 
-0000018728 00000 n 
-0000018777 00000 n 
-0000019104 00000 n 
-0000019154 00000 n 
-0000019604 00000 n 
-0000019654 00000 n 
-0000019983 00000 n 
-0000020033 00000 n 
-0000020358 00000 n 
-0000020408 00000 n 
-0000020705 00000 n 
-0000020754 00000 n 
-0000021103 00000 n 
-0000021450 00000 n 
-0000021799 00000 n 
-0000022032 00000 n 
-0000022081 00000 n 
-0000022384 00000 n 
-0000022433 00000 n 
-0000022666 00000 n 
-0000022715 00000 n 
-0000023018 00000 n 
-0000023067 00000 n 
-0000023300 00000 n 
-0000023349 00000 n 
-0000023652 00000 n 
-0000023701 00000 n 
-0000024050 00000 n 
-0000024397 00000 n 
-0000024746 00000 n 
-0000025053 00000 n 
-0000025102 00000 n 
-0000025437 00000 n 
-0000025487 00000 n 
-0000025945 00000 n 
-0000025995 00000 n 
-0000026332 00000 n 
-0000026382 00000 n 
-0000026715 00000 n 
-0000026765 00000 n 
-0000027116 00000 n 
-0000027286 00000 n 
-0000027643 00000 n 
-0000027842 00000 n 
-0000027943 00000 n 
-0000027990 00000 n 
-0000028136 00000 n 
-0000028201 00000 n 
-0000028474 00000 n 
-0000029235 00000 n 
-0000029285 00000 n 
-0000029529 00000 n 
-0000029801 00000 n 
-0000030442 00000 n 
-0000030492 00000 n 
-0000030734 00000 n 
-0000030838 00000 n 
-0000031273 00000 n 
-0000031323 00000 n 
-0000031550 00000 n 
-0000031599 00000 n 
-0000032034 00000 n 
-0000032084 00000 n 
-0000032311 00000 n 
-0000032360 00000 n 
-0000032795 00000 n 
-0000032845 00000 n 
-0000033072 00000 n 
-0000033122 00000 n 
-0000033557 00000 n 
-0000033608 00000 n 
-0000033835 00000 n 
-0000033885 00000 n 
-0000034320 00000 n 
-0000034371 00000 n 
-0000034598 00000 n 
-0000034648 00000 n 
-0000035083 00000 n 
-0000035134 00000 n 
-0000035361 00000 n 
-0000035411 00000 n 
-0000035854 00000 n 
-0000035905 00000 n 
-0000036140 00000 n 
-0000036190 00000 n 
-0000036633 00000 n 
-0000036684 00000 n 
-0000036919 00000 n 
-0000036969 00000 n 
-0000037412 00000 n 
-0000037463 00000 n 
-0000037698 00000 n 
-0000037748 00000 n 
-0000038191 00000 n 
-0000038242 00000 n 
-0000038477 00000 n 
-0000038527 00000 n 
-0000038970 00000 n 
-0000039021 00000 n 
-0000039256 00000 n 
-0000039306 00000 n 
-0000039749 00000 n 
-0000039800 00000 n 
-0000040035 00000 n 
-0000040085 00000 n 
-0000041365 00000 n 
-0000041416 00000 n 
-0000041588 00000 n 
-0000041940 00000 n 
-0000043228 00000 n 
-0000043278 00000 n 
-0000059560 00000 n 
-0000059612 00000 n 
-0000070798 00000 n 
-0000070849 00000 n 
-0000070969 00000 n 
-0000072194 00000 n 
+0000002283 00000 n 
+0000002432 00000 n 
+0000002788 00000 n 
+0000003207 00000 n 
+0000003753 00000 n 
+0000004227 00000 n 
+0000004686 00000 n 
+0000004991 00000 n 
+0000005142 00000 n 
+0000005514 00000 n 
+0000005886 00000 n 
+0000006258 00000 n 
+0000006409 00000 n 
+0000006771 00000 n 
+0000007196 00000 n 
+0000007748 00000 n 
+0000008228 00000 n 
+0000008701 00000 n 
+0000009311 00000 n 
+0000009790 00000 n 
+0000011735 00000 n 
+0000012133 00000 n 
+0000014075 00000 n 
+0000014184 00000 n 
+0000014473 00000 n 
+0000014521 00000 n 
+0000014864 00000 n 
+0000015205 00000 n 
+0000015548 00000 n 
+0000015773 00000 n 
+0000015821 00000 n 
+0000016116 00000 n 
+0000016164 00000 n 
+0000016389 00000 n 
+0000016437 00000 n 
+0000016732 00000 n 
+0000016780 00000 n 
+0000017005 00000 n 
+0000017053 00000 n 
+0000017348 00000 n 
+0000017397 00000 n 
+0000017742 00000 n 
+0000018085 00000 n 
+0000018430 00000 n 
+0000018729 00000 n 
+0000018778 00000 n 
+0000019105 00000 n 
+0000019155 00000 n 
+0000019605 00000 n 
+0000019655 00000 n 
+0000019984 00000 n 
+0000020034 00000 n 
+0000020359 00000 n 
+0000020409 00000 n 
+0000020706 00000 n 
+0000020755 00000 n 
+0000021104 00000 n 
+0000021451 00000 n 
+0000021800 00000 n 
+0000022033 00000 n 
+0000022082 00000 n 
+0000022385 00000 n 
+0000022434 00000 n 
+0000022667 00000 n 
+0000022716 00000 n 
+0000023019 00000 n 
+0000023068 00000 n 
+0000023301 00000 n 
+0000023350 00000 n 
+0000023653 00000 n 
+0000023702 00000 n 
+0000024051 00000 n 
+0000024398 00000 n 
+0000024747 00000 n 
+0000025054 00000 n 
+0000025103 00000 n 
+0000025438 00000 n 
+0000025488 00000 n 
+0000025946 00000 n 
+0000025996 00000 n 
+0000026333 00000 n 
+0000026383 00000 n 
+0000026716 00000 n 
+0000026766 00000 n 
+0000027117 00000 n 
+0000027287 00000 n 
+0000027644 00000 n 
+0000027843 00000 n 
+0000027944 00000 n 
+0000027991 00000 n 
+0000028137 00000 n 
+0000028202 00000 n 
+0000028475 00000 n 
+0000029236 00000 n 
+0000029286 00000 n 
+0000029530 00000 n 
+0000029802 00000 n 
+0000030443 00000 n 
+0000030493 00000 n 
+0000030735 00000 n 
+0000030839 00000 n 
+0000031274 00000 n 
+0000031324 00000 n 
+0000031551 00000 n 
+0000031600 00000 n 
+0000032035 00000 n 
+0000032085 00000 n 
+0000032312 00000 n 
+0000032361 00000 n 
+0000032796 00000 n 
+0000032846 00000 n 
+0000033073 00000 n 
+0000033123 00000 n 
+0000033558 00000 n 
+0000033609 00000 n 
+0000033836 00000 n 
+0000033886 00000 n 
+0000034321 00000 n 
+0000034372 00000 n 
+0000034599 00000 n 
+0000034649 00000 n 
+0000035084 00000 n 
+0000035135 00000 n 
+0000035362 00000 n 
+0000035412 00000 n 
+0000035855 00000 n 
+0000035906 00000 n 
+0000036141 00000 n 
+0000036191 00000 n 
+0000036634 00000 n 
+0000036685 00000 n 
+0000036920 00000 n 
+0000036970 00000 n 
+0000037413 00000 n 
+0000037464 00000 n 
+0000037699 00000 n 
+0000037749 00000 n 
+0000038192 00000 n 
+0000038243 00000 n 
+0000038478 00000 n 
+0000038528 00000 n 
+0000038971 00000 n 
+0000039022 00000 n 
+0000039257 00000 n 
+0000039307 00000 n 
+0000039750 00000 n 
+0000039801 00000 n 
+0000040036 00000 n 
+0000040086 00000 n 
+0000041366 00000 n 
+0000041417 00000 n 
+0000041589 00000 n 
+0000041941 00000 n 
+0000043229 00000 n 
+0000043279 00000 n 
+0000059561 00000 n 
+0000059613 00000 n 
+0000070799 00000 n 
+0000070850 00000 n 
+0000070970 00000 n 
+0000072195 00000 n 
 trailer <<
   /Root 1 0 R
   /Size 171
   /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
 >>
 startxref
-72216
+72217
 %%EOF

--- a/qpdf/qtest/qpdf/test80b2.pdf
+++ b/qpdf/qtest/qpdf/test80b2.pdf
@@ -11,7 +11,7 @@
 >>
 endobj
 
-%% Original object ID: 25 0
+%% Original object ID: 26 0
 2 0 obj
 <<
   /DR 4 0 R
@@ -53,7 +53,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 26 0
+%% Original object ID: 27 0
 4 0 obj
 <<
   /Font <<
@@ -70,7 +70,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 24 0
+%% Original object ID: 25 0
 5 0 obj
 <<
   /AP <<
@@ -94,7 +94,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 38 0
+%% Original object ID: 39 0
 6 0 obj
 <<
   /DV /1
@@ -110,7 +110,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 51 0
+%% Original object ID: 52 0
 7 0 obj
 <<
   /AP <<
@@ -141,7 +141,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 57 0
+%% Original object ID: 58 0
 8 0 obj
 <<
   /AP <<
@@ -172,7 +172,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 63 0
+%% Original object ID: 64 0
 9 0 obj
 <<
   /AP <<
@@ -203,7 +203,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 76 0
+%% Original object ID: 77 0
 10 0 obj
 <<
   /DV /2
@@ -219,7 +219,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 88 0
+%% Original object ID: 89 0
 11 0 obj
 <<
   /AP <<
@@ -243,7 +243,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 92 0
+%% Original object ID: 93 0
 12 0 obj
 <<
   /AP <<
@@ -274,7 +274,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 96 0
+%% Original object ID: 97 0
 13 0 obj
 <<
   /AP <<
@@ -312,7 +312,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 100 0
+%% Original object ID: 101 0
 14 0 obj
 <<
   /AP <<
@@ -343,7 +343,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 104 0
+%% Original object ID: 105 0
 15 0 obj
 <<
   /AP <<
@@ -374,7 +374,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 117 0
+%% Original object ID: 118 0
 16 0 obj
 <<
   /AP <<
@@ -398,7 +398,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 129 0
+%% Original object ID: 130 0
 17 0 obj
 <<
   /DV /1
@@ -414,7 +414,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 142 0
+%% Original object ID: 143 0
 18 0 obj
 <<
   /AP <<
@@ -445,7 +445,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 148 0
+%% Original object ID: 149 0
 19 0 obj
 <<
   /AP <<
@@ -476,7 +476,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 154 0
+%% Original object ID: 155 0
 20 0 obj
 <<
   /AP <<
@@ -507,7 +507,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 167 0
+%% Original object ID: 168 0
 21 0 obj
 <<
   /DV /2
@@ -523,7 +523,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 179 0
+%% Original object ID: 180 0
 22 0 obj
 <<
   /AP <<
@@ -547,7 +547,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 183 0
+%% Original object ID: 184 0
 23 0 obj
 <<
   /AP <<
@@ -578,7 +578,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 187 0
+%% Original object ID: 188 0
 24 0 obj
 <<
   /AP <<
@@ -616,7 +616,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 191 0
+%% Original object ID: 192 0
 25 0 obj
 <<
   /AP <<
@@ -647,7 +647,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 195 0
+%% Original object ID: 196 0
 26 0 obj
 <<
   /AP <<
@@ -1309,7 +1309,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 27 0
+%% Original object ID: 28 0
 33 0 obj
 <<
   /BBox [
@@ -1348,7 +1348,7 @@ endobj
 77
 endobj
 
-%% Original object ID: 39 0
+%% Original object ID: 40 0
 35 0 obj
 <<
   /AP <<
@@ -1377,7 +1377,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 40 0
+%% Original object ID: 41 0
 36 0 obj
 <<
   /AP <<
@@ -1406,7 +1406,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 41 0
+%% Original object ID: 42 0
 37 0 obj
 <<
   /AP <<
@@ -1435,7 +1435,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 52 0
+%% Original object ID: 53 0
 38 0 obj
 <<
   /BBox [
@@ -1467,7 +1467,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 53 0
+%% Original object ID: 54 0
 40 0 obj
 <<
   /BBox [
@@ -1504,7 +1504,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 58 0
+%% Original object ID: 59 0
 42 0 obj
 <<
   /BBox [
@@ -1536,7 +1536,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 59 0
+%% Original object ID: 60 0
 44 0 obj
 <<
   /BBox [
@@ -1573,7 +1573,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 64 0
+%% Original object ID: 65 0
 46 0 obj
 <<
   /BBox [
@@ -1605,7 +1605,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 65 0
+%% Original object ID: 66 0
 48 0 obj
 <<
   /BBox [
@@ -1642,7 +1642,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 77 0
+%% Original object ID: 78 0
 50 0 obj
 <<
   /AP <<
@@ -1671,7 +1671,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 78 0
+%% Original object ID: 79 0
 51 0 obj
 <<
   /AP <<
@@ -1700,7 +1700,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 79 0
+%% Original object ID: 80 0
 52 0 obj
 <<
   /AP <<
@@ -1729,7 +1729,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 89 0
+%% Original object ID: 90 0
 53 0 obj
 <<
   /BBox [
@@ -1768,7 +1768,7 @@ endobj
 85
 endobj
 
-%% Original object ID: 93 0
+%% Original object ID: 94 0
 55 0 obj
 <<
   /BBox [
@@ -1809,7 +1809,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 97 0
+%% Original object ID: 98 0
 57 0 obj
 <<
   /BBox [
@@ -1864,7 +1864,7 @@ endobj
 238
 endobj
 
-%% Original object ID: 101 0
+%% Original object ID: 102 0
 59 0 obj
 <<
   /BBox [
@@ -1905,7 +1905,7 @@ endobj
 117
 endobj
 
-%% Original object ID: 105 0
+%% Original object ID: 106 0
 61 0 obj
 <<
   /BBox [
@@ -1946,7 +1946,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 118 0
+%% Original object ID: 119 0
 63 0 obj
 <<
   /BBox [
@@ -1985,7 +1985,7 @@ endobj
 77
 endobj
 
-%% Original object ID: 130 0
+%% Original object ID: 131 0
 65 0 obj
 <<
   /AP <<
@@ -2014,7 +2014,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 131 0
+%% Original object ID: 132 0
 66 0 obj
 <<
   /AP <<
@@ -2043,7 +2043,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 132 0
+%% Original object ID: 133 0
 67 0 obj
 <<
   /AP <<
@@ -2072,7 +2072,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 143 0
+%% Original object ID: 144 0
 68 0 obj
 <<
   /BBox [
@@ -2104,7 +2104,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 144 0
+%% Original object ID: 145 0
 70 0 obj
 <<
   /BBox [
@@ -2141,7 +2141,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 149 0
+%% Original object ID: 150 0
 72 0 obj
 <<
   /BBox [
@@ -2173,7 +2173,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 150 0
+%% Original object ID: 151 0
 74 0 obj
 <<
   /BBox [
@@ -2210,7 +2210,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 155 0
+%% Original object ID: 156 0
 76 0 obj
 <<
   /BBox [
@@ -2242,7 +2242,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 156 0
+%% Original object ID: 157 0
 78 0 obj
 <<
   /BBox [
@@ -2279,7 +2279,7 @@ endobj
 82
 endobj
 
-%% Original object ID: 168 0
+%% Original object ID: 169 0
 80 0 obj
 <<
   /AP <<
@@ -2308,7 +2308,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 169 0
+%% Original object ID: 170 0
 81 0 obj
 <<
   /AP <<
@@ -2337,7 +2337,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 170 0
+%% Original object ID: 171 0
 82 0 obj
 <<
   /AP <<
@@ -2366,7 +2366,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 180 0
+%% Original object ID: 181 0
 83 0 obj
 <<
   /BBox [
@@ -2405,7 +2405,7 @@ endobj
 85
 endobj
 
-%% Original object ID: 184 0
+%% Original object ID: 185 0
 85 0 obj
 <<
   /BBox [
@@ -2446,7 +2446,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 188 0
+%% Original object ID: 189 0
 87 0 obj
 <<
   /BBox [
@@ -2501,7 +2501,7 @@ endobj
 238
 endobj
 
-%% Original object ID: 192 0
+%% Original object ID: 193 0
 89 0 obj
 <<
   /BBox [
@@ -2542,7 +2542,7 @@ endobj
 117
 endobj
 
-%% Original object ID: 196 0
+%% Original object ID: 197 0
 91 0 obj
 <<
   /BBox [
@@ -2583,7 +2583,7 @@ endobj
 114
 endobj
 
-%% Original object ID: 111 0
+%% Original object ID: 112 0
 93 0 obj
 <<
   /AP <<
@@ -2613,7 +2613,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 114 0
+%% Original object ID: 115 0
 94 0 obj
 <<
   /F 28
@@ -2630,7 +2630,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 199 0
+%% Original object ID: 200 0
 95 0 obj
 <<
   /AP <<
@@ -2660,7 +2660,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 202 0
+%% Original object ID: 203 0
 96 0 obj
 <<
   /F 28
@@ -2926,7 +2926,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 42 0
+%% Original object ID: 43 0
 110 0 obj
 <<
   /BBox [
@@ -2969,7 +2969,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 43 0
+%% Original object ID: 44 0
 112 0 obj
 <<
   /BBox [
@@ -3001,7 +3001,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 44 0
+%% Original object ID: 45 0
 114 0 obj
 <<
   /BBox [
@@ -3044,7 +3044,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 45 0
+%% Original object ID: 46 0
 116 0 obj
 <<
   /BBox [
@@ -3076,7 +3076,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 46 0
+%% Original object ID: 47 0
 118 0 obj
 <<
   /BBox [
@@ -3119,7 +3119,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 47 0
+%% Original object ID: 48 0
 120 0 obj
 <<
   /BBox [
@@ -3151,7 +3151,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 80 0
+%% Original object ID: 81 0
 122 0 obj
 <<
   /BBox [
@@ -3194,7 +3194,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 81 0
+%% Original object ID: 82 0
 124 0 obj
 <<
   /BBox [
@@ -3226,7 +3226,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 82 0
+%% Original object ID: 83 0
 126 0 obj
 <<
   /BBox [
@@ -3269,7 +3269,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 83 0
+%% Original object ID: 84 0
 128 0 obj
 <<
   /BBox [
@@ -3301,7 +3301,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 84 0
+%% Original object ID: 85 0
 130 0 obj
 <<
   /BBox [
@@ -3344,7 +3344,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 85 0
+%% Original object ID: 86 0
 132 0 obj
 <<
   /BBox [
@@ -3376,7 +3376,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 133 0
+%% Original object ID: 134 0
 134 0 obj
 <<
   /BBox [
@@ -3419,7 +3419,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 134 0
+%% Original object ID: 135 0
 136 0 obj
 <<
   /BBox [
@@ -3451,7 +3451,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 135 0
+%% Original object ID: 136 0
 138 0 obj
 <<
   /BBox [
@@ -3494,7 +3494,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 136 0
+%% Original object ID: 137 0
 140 0 obj
 <<
   /BBox [
@@ -3526,7 +3526,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 137 0
+%% Original object ID: 138 0
 142 0 obj
 <<
   /BBox [
@@ -3569,7 +3569,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 138 0
+%% Original object ID: 139 0
 144 0 obj
 <<
   /BBox [
@@ -3601,7 +3601,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 171 0
+%% Original object ID: 172 0
 146 0 obj
 <<
   /BBox [
@@ -3644,7 +3644,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 172 0
+%% Original object ID: 173 0
 148 0 obj
 <<
   /BBox [
@@ -3676,7 +3676,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 173 0
+%% Original object ID: 174 0
 150 0 obj
 <<
   /BBox [
@@ -3719,7 +3719,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 174 0
+%% Original object ID: 175 0
 152 0 obj
 <<
   /BBox [
@@ -3751,7 +3751,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 175 0
+%% Original object ID: 176 0
 154 0 obj
 <<
   /BBox [
@@ -3794,7 +3794,7 @@ endobj
 220
 endobj
 
-%% Original object ID: 176 0
+%% Original object ID: 177 0
 156 0 obj
 <<
   /BBox [
@@ -3826,7 +3826,7 @@ endobj
 12
 endobj
 
-%% Original object ID: 112 0
+%% Original object ID: 113 0
 158 0 obj
 <<
   /BBox [
@@ -3867,7 +3867,7 @@ endobj
 929
 endobj
 
-%% Original object ID: 108 0
+%% Original object ID: 109 0
 160 0 obj
 <<
   /F 28
@@ -3884,7 +3884,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 109 0
+%% Original object ID: 110 0
 161 0 obj
 <<
   /AP <<
@@ -3914,7 +3914,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 200 0
+%% Original object ID: 201 0
 162 0 obj
 <<
   /BBox [
@@ -4082,7 +4082,7 @@ endobj
 >>
 endobj
 
-%% Original object ID: 110 0
+%% Original object ID: 111 0
 169 0 obj
 <<
   /BBox [


### PR DESCRIPTION
Use indirect nulls (dangling references) to reserve foreign objects.

Reserve foreign page objects when references to them are encountered so that links are not broken if the page is subsequently copied.

Comments and tests will need to be updated if this approach is accepted. 