### PR TITLE
Move random number device check to runtime (fixes #1022)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-09-03  Jay Berkenbilt  <ejb@ql.org>
+
+        * Move check for random number device to runtime instead of
+        compile time. Since, by default, the crypto provider provides
+        random numbers, runtime determinination of a random number device
+        is usually not needed. Fixes #1022.
+
 2023-09-02  Jay Berkenbilt  <ejb@ql.org>
 
         * Bug fix from M. Holger: allow fix-qdf to read from pipe. Fixes #1010.

--- a/libqpdf/CMakeLists.txt
+++ b/libqpdf/CMakeLists.txt
@@ -320,8 +320,6 @@ check_symbol_exists(fseeko "stdio.h" HAVE_FSEEKO)
 check_symbol_exists(fseeko64 "stdio.h" HAVE_FSEEKO64)
 check_symbol_exists(localtime_r "time.h" HAVE_LOCALTIME_R)
 check_symbol_exists(random "stdlib.h" HAVE_RANDOM)
-find_file(RANDOM_DEVICE
-  "urandom" "arandom" "arandom" PATHS "/dev" NO_DEFAULT_PATH)
 
 check_c_source_compiles(
 "#include <time.h>

--- a/libqpdf/qpdf/qpdf-config.h.in
+++ b/libqpdf/qpdf/qpdf-config.h.in
@@ -24,8 +24,5 @@
 #cmakedefine HAVE_MALLOC_INFO 1
 #cmakedefine HAVE_OPEN_MEMSTREAM 1
 
-/* system random device (e.g. /dev/random) if any */
-#cmakedefine RANDOM_DEVICE "${RANDOM_DEVICE}"
-
 /* bytes in the size_t type */
 #cmakedefine SIZEOF_SIZE_T ${SIZEOF_SIZE_T}


### PR DESCRIPTION
Having it at compile time breaks cross-compilation and isn't really right anyway.