### PR TITLE
Refactor QPDFParser::parse

### DIFF
--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -156,8 +156,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
             break;
 
         case QPDFTokenizer::tt_integer:
-            object = QPDF_Integer::create(
-                QUtil::string_to_ll(std::string(tokenizer.getValue()).c_str()));
+            object = QPDF_Integer::create(QUtil::string_to_ll(tokenizer.getValue().c_str()));
             break;
 
         case QPDFTokenizer::tt_real:
@@ -166,7 +165,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
 
         case QPDFTokenizer::tt_name:
             {
-                auto name = tokenizer.getValue();
+                auto const& name = tokenizer.getValue();
                 object = QPDF_Name::create(name);
 
                 if (name == "/Contents") {
@@ -179,7 +178,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
 
         case QPDFTokenizer::tt_word:
             {
-                auto value = tokenizer.getValue();
+                auto const& value = tokenizer.getValue();
                 auto size = olist.size();
                 if (content_stream) {
                     object = QPDF_Operator::create(value);
@@ -226,7 +225,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
 
         case QPDFTokenizer::tt_string:
             {
-                auto val = tokenizer.getValue();
+                auto const& val = tokenizer.getValue();
                 if (decrypter) {
                     if (b_contents) {
                         frame.contents_string = val;

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -21,7 +21,6 @@
 
 #include <memory>
 
-
 QPDFObjectHandle
 QPDFParser::parse(bool& empty, bool content_stream)
 {
@@ -30,327 +29,110 @@ QPDFParser::parse(bool& empty, bool content_stream)
     // effect of reading the object and changing the file pointer. If you do this, it will cause a
     // logic error to be thrown from QPDF::inParse().
 
-    const static std::shared_ptr<QPDFObject> null_oh = QPDF_Null::create();
     QPDF::ParseGuard pg(context);
-
     empty = false;
 
     std::shared_ptr<QPDFObject> object;
-    bool set_offset = false;
+    stack.clear();
+    stack.emplace_back(input, st_top);
+    frame = &stack.back();
+    object = nullptr;
 
-//    std::vector<StackFrame> stack{{input, st_top}};
-    stack.clear(); // NEW
-    stack.emplace_back(input, st_top); // NEW
-    bool done = false;
-    bool b_contents = false;
-    bool is_null = false;
-    frame = &stack.back(); // CHANGED
+    if (!tokenizer.nextToken(*input, object_description)) {
+        warn(tokenizer.getErrorMessage());
+    }
 
-    while (!done) {
-        bool indirect_ref = false;
-        is_null = false;
-        object = nullptr;
-        set_offset = false;
-
-        if (!tokenizer.nextToken(*input, object_description)) {
-            warn(tokenizer.getErrorMessage());
+    switch (tokenizer.getType()) {
+    case QPDFTokenizer::tt_eof:
+        if (content_stream) {
+            // In content stream mode, leave object uninitialized to indicate EOF
+            return {};
         }
-        ++good_count; // optimistically
+        QTC::TC("qpdf", "QPDFParser eof in parse");
+        warn("unexpected EOF");
+        return {QPDF_Null::create()};
 
-        switch (tokenizer.getType()) {
-        case QPDFTokenizer::tt_eof:
-            if (stack.size() > 1) {
-                warn("parse error while reading object");
-            }
+    case QPDFTokenizer::tt_bad:
+        QTC::TC("qpdf", "QPDFParser bad token in parse");
+        return {QPDF_Null::create()};
+
+    case QPDFTokenizer::tt_brace_open:
+    case QPDFTokenizer::tt_brace_close:
+        QTC::TC("qpdf", "QPDFParser bad brace");
+        warn("treating unexpected brace token as null");
+        return {QPDF_Null::create()};
+
+    case QPDFTokenizer::tt_array_close:
+        QTC::TC("qpdf", "QPDFParser bad array close");
+        warn("treating unexpected array close token as null");
+        return {QPDF_Null::create()};
+
+    case QPDFTokenizer::tt_dict_close:
+        QTC::TC("qpdf", "QPDFParser bad dictionary close");
+        warn("unexpected dictionary close token");
+        return {QPDF_Null::create()};
+
+    case QPDFTokenizer::tt_array_open:
+    case QPDFTokenizer::tt_dict_open:
+        stack.emplace_back(
+            input,
+            (tokenizer.getType() == QPDFTokenizer::tt_array_open) ? st_array : st_dictionary);
+        return parseRemainder(content_stream);
+
+    case QPDFTokenizer::tt_bool:
+        object = QPDF_Bool::create((tokenizer.getValue() == "true"));
+        break;
+
+    case QPDFTokenizer::tt_null:
+        return {QPDF_Null::create()};
+
+    case QPDFTokenizer::tt_integer:
+        object = QPDF_Integer::create(QUtil::string_to_ll(tokenizer.getValue().c_str()));
+        break;
+
+    case QPDFTokenizer::tt_real:
+        object = QPDF_Real::create(tokenizer.getValue());
+        break;
+
+    case QPDFTokenizer::tt_name:
+        object = QPDF_Name::create(tokenizer.getValue());
+        break;
+
+    case QPDFTokenizer::tt_word:
+        {
+            auto const& value = tokenizer.getValue();
             if (content_stream) {
-                // In content stream mode, leave object uninitialized to indicate EOF
-                return {};
-            }
-//            QTC::TC("qpdf", "QPDFParser eof in parse");
-            warn("unexpected EOF");
-            return {QPDF_Null::create()};
-
-        case QPDFTokenizer::tt_bad:
-//            QTC::TC("qpdf", "QPDFParser bad token in parse");
-            if (tooManyBadTokens()) {
-                return {QPDF_Null::create()};
-            }
-            is_null = true;
-            break;
-
-        case QPDFTokenizer::tt_brace_open:
-        case QPDFTokenizer::tt_brace_close:
-//            QTC::TC("qpdf", "QPDFParser bad brace");
-            warn("treating unexpected brace token as null");
-            if (tooManyBadTokens()) {
-                return {QPDF_Null::create()};
-            }
-            is_null = true;
-            break;
-
-        case QPDFTokenizer::tt_array_close:
-            if (frame->state == st_array) {
-                if (stack.size() < 2) {
-                    throw std::logic_error("QPDFParser::parseInternal: st_stop encountered with "
-                                           "insufficient elements in stack");
-                }
-                object = QPDF_Array::create(std::move(frame->olist), frame->null_count > 100);
-                setDescription(object, frame->offset - 1);
-                // The `offset` points to the next of "[".  Set the rewind offset to point to the
-                // beginning of "[". This has been explicitly tested with whitespace surrounding the
-                // array start delimiter. getLastOffset points to the array end token and therefore
-                // can't be used here.
-                set_offset = true;
-                stack.pop_back();
-                frame = &stack.back();
-            } else {
-//                QTC::TC("qpdf", "QPDFParser bad array close");
-                warn("treating unexpected array close token as null");
-                if (tooManyBadTokens()) {
-                    return {QPDF_Null::create()};
-                }
-                is_null = true;
-            }
-            break;
-
-        case QPDFTokenizer::tt_dict_close:
-            if (frame->state == st_dictionary) {
-                if (stack.size() < 2) {
-                    throw std::logic_error("QPDFParser::parseInternal: st_stop encountered with "
-                                           "insufficient elements in stack");
-                }
-
-                // Convert list to map. Alternating elements are keys.  Attempt to recover more or
-                // less gracefully from invalid dictionaries.
-                std::set<std::string> names;
-                for (auto& obj: frame->olist) {
-                    if (obj) {
-                        if (obj->getTypeCode() == ::ot_name) {
-                            names.insert(obj->getStringValue());
-                        }
-                    }
-                }
-
-                std::map<std::string, QPDFObjectHandle> dict;
-                int next_fake_key = 1;
-                for (auto iter = frame->olist.begin(); iter != frame->olist.end();) {
-                    // Calculate key.
-                    std::string key;
-                    if (*iter && (*iter)->getTypeCode() == ::ot_name) {
-                        key = (*iter)->getStringValue();
-                        ++iter;
-                    } else {
-                        for (bool found_fake = false; !found_fake;) {
-                            key = "/QPDFFake" + std::to_string(next_fake_key++);
-                            found_fake = (names.count(key) == 0);
-//                            QTC::TC("qpdf", "QPDFParser found fake", (found_fake ? 0 : 1));
-                        }
-                        warn(
-                            frame->offset,
-                            "expected dictionary key but found non-name object; inserting key " +
-                                key);
-                    }
-                    if (dict.count(key) > 0) {
-//                        QTC::TC("qpdf", "QPDFParser duplicate dict key");
-                        warn(
-                            frame->offset,
-                            "dictionary has duplicated key " + key +
-                                "; last occurrence overrides earlier ones");
-                    }
-
-                    // Calculate value.
-                    std::shared_ptr<QPDFObject> val;
-                    if (iter != frame->olist.end()) {
-                        val = *iter;
-                        ++iter;
-                    } else {
-//                        QTC::TC("qpdf", "QPDFParser no val for last key");
-                        warn(
-                            frame->offset,
-                            "dictionary ended prematurely; using null as value for last key");
-                        val = QPDF_Null::create();
-                    }
-
-                    dict[std::move(key)] = std::move(val);
-                }
-                if (!frame->contents_string.empty() && dict.count("/Type") &&
-                    dict["/Type"].isNameAndEquals("/Sig") && dict.count("/ByteRange") &&
-                    dict.count("/Contents") && dict["/Contents"].isString()) {
-                    dict["/Contents"] = QPDFObjectHandle::newString(frame->contents_string);
-                    dict["/Contents"].setParsedOffset(frame->contents_offset);
-                }
-                object = QPDF_Dictionary::create(std::move(dict));
-                setDescription(object, frame->offset - 2);
-                // The `offset` points to the next of "<<". Set the rewind offset to point to the
-                // beginning of "<<". This has been explicitly tested with whitespace surrounding
-                // the dictionary start delimiter. getLastOffset points to the dictionary end token
-                // and therefore can't be used here.
-                set_offset = true;
-                stack.pop_back();
-                frame = &stack.back();
-            } else {
-//                QTC::TC("qpdf", "QPDFParser bad dictionary close");
-                warn("unexpected dictionary close token");
-                if (tooManyBadTokens()) {
-                    return {QPDF_Null::create()};
-                }
-                is_null = true;
-            }
-            break;
-
-        case QPDFTokenizer::tt_array_open:
-        case QPDFTokenizer::tt_dict_open:
-            if (stack.size() > 500) {
-//                QTC::TC("qpdf", "QPDFParser too deep");
-                warn("ignoring excessively deeply nested data structure");
+                object = QPDF_Operator::create(value);
+            } else if (value == "endobj") {
+                // We just saw endobj without having read anything.  Treat this as a null and do
+                // not move the input source's offset.
+                input->seek(input->getLastOffset(), SEEK_SET);
+                empty = true;
                 return {QPDF_Null::create()};
             } else {
-                b_contents = false;
-                stack.emplace_back(
-                    input,
-                    (tokenizer.getType() == QPDFTokenizer::tt_array_open) ? st_array
-                                                                          : st_dictionary);
-                frame = &stack.back();
-                return parseRemainder(content_stream); // NEW
-                continue;
+                QTC::TC("qpdf", "QPDFParser treat word as string");
+                warn("unknown token while reading object; treating as string");
+                object = QPDF_String::create(value);
             }
-
-        case QPDFTokenizer::tt_bool:
-            object = QPDF_Bool::create((tokenizer.getValue() == "true"));
-            break;
-
-        case QPDFTokenizer::tt_null:
-            is_null = true;
-            ++frame->null_count;
-
-            break;
-
-        case QPDFTokenizer::tt_integer:
-            object = QPDF_Integer::create(QUtil::string_to_ll(tokenizer.getValue().c_str()));
-            break;
-
-        case QPDFTokenizer::tt_real:
-            object = QPDF_Real::create(tokenizer.getValue());
-            break;
-
-        case QPDFTokenizer::tt_name:
-            {
-                auto const& name = tokenizer.getValue();
-                object = QPDF_Name::create(name);
-
-                if (name == "/Contents") {
-                    b_contents = true;
-                } else {
-                    b_contents = false;
-                }
-            }
-            break;
-
-        case QPDFTokenizer::tt_word:
-            {
-                auto const& value = tokenizer.getValue();
-                auto size = frame->olist.size();
-                if (content_stream) {
-                    object = QPDF_Operator::create(value);
-                } else if (
-                    value == "R" && frame->state != st_top && size >= 2 && frame->olist.back() &&
-                    frame->olist.back()->getTypeCode() == ::ot_integer &&
-                    !frame->olist.back()->getObjGen().isIndirect() && frame->olist.at(size - 2) &&
-                    frame->olist.at(size - 2)->getTypeCode() == ::ot_integer &&
-                    !frame->olist.at(size - 2)->getObjGen().isIndirect()) {
-                    if (context == nullptr) {
-//                        QTC::TC("qpdf", "QPDFParser indirect without context");
-                        throw std::logic_error("QPDFObjectHandle::parse called without context on "
-                                               "an object with indirect references");
-                    }
-                    auto ref_og = QPDFObjGen(
-                        QPDFObjectHandle(frame->olist.at(size - 2)).getIntValueAsInt(),
-                        QPDFObjectHandle(frame->olist.back()).getIntValueAsInt());
-                    if (ref_og.isIndirect()) {
-                        // This action has the desirable side effect of causing dangling references
-                        // (references to indirect objects that don't appear in the PDF) in any
-                        // parsed object to appear in the object cache.
-                        object = context->getObject(ref_og).obj;
-                        indirect_ref = true;
-                    } else {
-//                        QTC::TC("qpdf", "QPDFParser indirect with 0 objid");
-                        is_null = true;
-                    }
-                    frame->olist.pop_back();
-                    frame->olist.pop_back();
-                } else if ((value == "endobj") && (frame->state == st_top)) {
-                    // We just saw endobj without having read anything.  Treat this as a null and do
-                    // not move the input source's offset.
-                    is_null = true;
-                    input->seek(input->getLastOffset(), SEEK_SET);
-                    empty = true;
-                } else {
-//                    QTC::TC("qpdf", "QPDFParser treat word as string");
-                    warn("unknown token while reading object; treating as string");
-                    if (tooManyBadTokens()) {
-                        return {QPDF_Null::create()};
-                    }
-                    object = QPDF_String::create(value);
-                }
-            }
-            break;
-
-        case QPDFTokenizer::tt_string:
-            {
-                auto const& val = tokenizer.getValue();
-                if (decrypter) {
-                    if (b_contents) {
-                        frame->contents_string = val;
-                        frame->contents_offset = input->getLastOffset();
-                        b_contents = false;
-                    }
-                    std::string s{val};
-                    decrypter->decryptString(s);
-                    object = QPDF_String::create(s);
-                } else {
-                    object = QPDF_String::create(val);
-                }
-            }
-            break;
-
-        default:
-            warn("treating unknown token type as null while reading object");
-            if (tooManyBadTokens()) {
-                return {QPDF_Null::create()};
-            }
-            is_null = true;
-            break;
         }
+        break;
 
-        if (object == nullptr && !is_null) {
-            throw std::logic_error("QPDFParser:parseInternal: unexpected uninitialized object");
+    case QPDFTokenizer::tt_string:
+        if (decrypter) {
+            std::string s{tokenizer.getValue()};
+            decrypter->decryptString(s);
+            object = QPDF_String::create(s);
+        } else {
+            object = QPDF_String::create(tokenizer.getValue());
         }
+        break;
 
-        switch (frame->state) {
-        case st_dictionary:
-        case st_array:
-            if (is_null) {
-                object = null_oh;
-                // No need to set description for direct nulls - they probably will become implicit.
-            } else if (!indirect_ref && !set_offset) {
-                setDescription(object, input->getLastOffset());
-            }
-            set_offset = true;
-            frame->olist.push_back(object);
-            break;
-
-        case st_top:
-            done = true;
-            break;
-        }
+    default:
+        warn("treating unknown token type as null while reading object");
+        return {QPDF_Null::create()};
     }
 
-    if (is_null) {
-        object = QPDF_Null::create();
-    }
-    if (!set_offset) {
-        setDescription(object, frame->offset);
-    }
+    setDescription(object, frame->offset);
     return object;
 }
 
@@ -363,18 +145,15 @@ QPDFParser::parseRemainder(bool content_stream)
     // logic error to be thrown from QPDF::inParse().
 
     const static std::shared_ptr<QPDFObject> null_oh = QPDF_Null::create();
-//    QPDF::ParseGuard pg(context);
-
-//    empty = false;
 
     std::shared_ptr<QPDFObject> object;
     bool set_offset = false;
 
-//    std::vector<StackFrame> stack{{input, st_top},};
     bool done = false;
     bool b_contents = false;
     bool is_null = false;
     frame = &stack.back(); // CHANGED
+    bad_count = 0;
 
     while (!done) {
         bool indirect_ref = false;
@@ -389,19 +168,17 @@ QPDFParser::parseRemainder(bool content_stream)
 
         switch (tokenizer.getType()) {
         case QPDFTokenizer::tt_eof:
-            if (stack.size() > 1) {
-                warn("parse error while reading object");
-            }
+            warn("parse error while reading object");
             if (content_stream) {
                 // In content stream mode, leave object uninitialized to indicate EOF
                 return {};
             }
-            QTC::TC("qpdf", "QPDFParser eof in parse");
+            QTC::TC("qpdf", "QPDFParser eof in parseRemainder");
             warn("unexpected EOF");
             return {QPDF_Null::create()};
 
         case QPDFTokenizer::tt_bad:
-            QTC::TC("qpdf", "QPDFParser bad token in parse");
+            QTC::TC("qpdf", "QPDFParser bad token in parseRemainder");
             if (tooManyBadTokens()) {
                 return {QPDF_Null::create()};
             }
@@ -410,7 +187,7 @@ QPDFParser::parseRemainder(bool content_stream)
 
         case QPDFTokenizer::tt_brace_open:
         case QPDFTokenizer::tt_brace_close:
-            QTC::TC("qpdf", "QPDFParser bad brace");
+            QTC::TC("qpdf", "QPDFParser bad brace in parseRemainder");
             warn("treating unexpected brace token as null");
             if (tooManyBadTokens()) {
                 return {QPDF_Null::create()};
@@ -434,7 +211,7 @@ QPDFParser::parseRemainder(bool content_stream)
                 stack.pop_back();
                 frame = &stack.back();
             } else {
-                QTC::TC("qpdf", "QPDFParser bad array close");
+                QTC::TC("qpdf", "QPDFParser bad array close in parseRemainder");
                 warn("treating unexpected array close token as null");
                 if (tooManyBadTokens()) {
                     return {QPDF_Null::create()};
@@ -519,7 +296,7 @@ QPDFParser::parseRemainder(bool content_stream)
                 stack.pop_back();
                 frame = &stack.back();
             } else {
-                QTC::TC("qpdf", "QPDFParser bad dictionary close");
+                QTC::TC("qpdf", "QPDFParser bad dictionary close in parseRemainder");
                 warn("unexpected dictionary close token");
                 if (tooManyBadTokens()) {
                     return {QPDF_Null::create()};
@@ -582,7 +359,7 @@ QPDFParser::parseRemainder(bool content_stream)
                 if (content_stream) {
                     object = QPDF_Operator::create(value);
                 } else if (
-                    value == "R" && frame->state != st_top && size >= 2 && frame->olist.back() &&
+                    value == "R" && size >= 2 && frame->olist.back() &&
                     frame->olist.back()->getTypeCode() == ::ot_integer &&
                     !frame->olist.back()->getObjGen().isIndirect() && frame->olist.at(size - 2) &&
                     frame->olist.at(size - 2)->getTypeCode() == ::ot_integer &&
@@ -607,14 +384,8 @@ QPDFParser::parseRemainder(bool content_stream)
                     }
                     frame->olist.pop_back();
                     frame->olist.pop_back();
-                } else if ((value == "endobj") && (frame->state == st_top)) {
-                    // We just saw endobj without having read anything.  Treat this as a null and do
-                    // not move the input source's offset.
-                    is_null = true;
-                    input->seek(input->getLastOffset(), SEEK_SET);
-//                    empty = true;
                 } else {
-                    QTC::TC("qpdf", "QPDFParser treat word as string");
+                    QTC::TC("qpdf", "QPDFParser treat word as string in parseRemainder");
                     warn("unknown token while reading object; treating as string");
                     if (tooManyBadTokens()) {
                         return {QPDF_Null::create()};

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -227,20 +227,15 @@ QPDFParser::parse(bool& empty, bool content_stream)
             if (stack.size() > 500) {
                 QTC::TC("qpdf", "QPDFParser too deep");
                 warn("ignoring excessively deeply nested data structure");
-                if (tooManyBadTokens()) {
-                    return {QPDF_Null::create()};
-                }
-                is_null = true;
-                state = st_top;
+                return {QPDF_Null::create()};
             } else {
-                state = st_start;
                 state_stack.push_back(
                     (tokenizer.getType() == QPDFTokenizer::tt_array_open) ? st_array
                                                                           : st_dictionary);
                 b_contents = false;
                 stack.emplace_back(input);
+                continue;
             }
-            break;
 
         case QPDFTokenizer::tt_bool:
             object = QPDF_Bool::create((tokenizer.getValue() == "true"));
@@ -349,7 +344,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
             break;
         }
 
-        if (object == nullptr && !is_null && state != st_start) {
+        if (object == nullptr && !is_null) {
             throw std::logic_error("QPDFParser:parseInternal: unexpected uninitialized object");
         }
 
@@ -368,9 +363,6 @@ QPDFParser::parse(bool& empty, bool content_stream)
 
         case st_top:
             done = true;
-            break;
-
-        case st_start:
             break;
         }
     }

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -113,11 +113,11 @@ QPDFParser::parse(bool& empty, bool content_stream)
 
     case QPDFTokenizer::tt_string:
         if (decrypter) {
-                std::string s{tokenizer.getValue()};
-                decrypter->decryptString(s);
-                return withDescription<QPDF_String>(s);
+            std::string s{tokenizer.getValue()};
+            decrypter->decryptString(s);
+            return withDescription<QPDF_String>(s);
         } else {
-                return withDescription<QPDF_String>(tokenizer.getValue());
+            return withDescription<QPDF_String>(tokenizer.getValue());
         }
 
     default:
@@ -134,20 +134,10 @@ QPDFParser::parseRemainder(bool content_stream)
     // effect of reading the object and changing the file pointer. If you do this, it will cause a
     // logic error to be thrown from QPDF::inParse().
 
-    const static ObjectPtr null_oh = QPDF_Null::create();
-
-    ObjectPtr object;
-    bool set_offset = false;
-    bool b_contents = false;
-    bool is_null = false;
     bad_count = 0;
+    bool b_contents = false;
 
     while (true) {
-        bool indirect_ref = false;
-        is_null = false;
-        object = nullptr;
-        set_offset = false;
-
         if (!tokenizer.nextToken(*input, object_description)) {
             warn(tokenizer.getErrorMessage());
         }
@@ -169,8 +159,8 @@ QPDFParser::parseRemainder(bool content_stream)
             if (tooManyBadTokens()) {
                 return {QPDF_Null::create()};
             }
-            is_null = true;
-            break;
+            addNull();
+            continue;
 
         case QPDFTokenizer::tt_brace_open:
         case QPDFTokenizer::tt_brace_close:
@@ -179,32 +169,32 @@ QPDFParser::parseRemainder(bool content_stream)
             if (tooManyBadTokens()) {
                 return {QPDF_Null::create()};
             }
-            is_null = true;
-            break;
+            addNull();
+            continue;
 
         case QPDFTokenizer::tt_array_close:
             if (frame->state == st_array) {
-                object = QPDF_Array::create(std::move(frame->olist), frame->null_count > 100);
+                auto object = QPDF_Array::create(std::move(frame->olist), frame->null_count > 100);
                 setDescription(object, frame->offset - 1);
                 // The `offset` points to the next of "[".  Set the rewind offset to point to the
                 // beginning of "[". This has been explicitly tested with whitespace surrounding the
                 // array start delimiter. getLastOffset points to the array end token and therefore
                 // can't be used here.
-                set_offset = true;
                 if (stack.size() <= 1) {
                     return object;
                 }
                 stack.pop_back();
                 frame = &stack.back();
+                add(std::move(object));
             } else {
                 QTC::TC("qpdf", "QPDFParser bad array close in parseRemainder");
                 warn("treating unexpected array close token as null");
                 if (tooManyBadTokens()) {
                     return {QPDF_Null::create()};
                 }
-                is_null = true;
+                addNull();
             }
-            break;
+            continue;
 
         case QPDFTokenizer::tt_dict_close:
             if (frame->state == st_dictionary) {
@@ -267,7 +257,7 @@ QPDFParser::parseRemainder(bool content_stream)
                     dict["/Contents"] = QPDFObjectHandle::newString(frame->contents_string);
                     dict["/Contents"].setParsedOffset(frame->contents_offset);
                 }
-                object = QPDF_Dictionary::create(std::move(dict));
+                auto object = QPDF_Dictionary::create(std::move(dict));
                 setDescription(object, frame->offset - 2);
                 // The `offset` points to the next of "<<". Set the rewind offset to point to the
                 // beginning of "<<". This has been explicitly tested with whitespace surrounding
@@ -276,18 +266,18 @@ QPDFParser::parseRemainder(bool content_stream)
                 if (stack.size() <= 1) {
                     return object;
                 }
-                set_offset = true;
                 stack.pop_back();
                 frame = &stack.back();
+                add(std::move(object));
             } else {
                 QTC::TC("qpdf", "QPDFParser bad dictionary close in parseRemainder");
                 warn("unexpected dictionary close token");
                 if (tooManyBadTokens()) {
                     return {QPDF_Null::create()};
                 }
-                is_null = true;
+                addNull();
             }
-            break;
+            continue;
 
         case QPDFTokenizer::tt_array_open:
         case QPDFTokenizer::tt_dict_open:
@@ -306,26 +296,25 @@ QPDFParser::parseRemainder(bool content_stream)
             }
 
         case QPDFTokenizer::tt_bool:
-            object = QPDF_Bool::create((tokenizer.getValue() == "true"));
-            break;
+            addScalar<QPDF_Bool>(tokenizer.getValue() == "true");
+            continue;
 
         case QPDFTokenizer::tt_null:
-            is_null = true;
-            ++frame->null_count;
-            break;
+            addNull();
+            continue;
 
         case QPDFTokenizer::tt_integer:
-            object = QPDF_Integer::create(QUtil::string_to_ll(tokenizer.getValue().c_str()));
-            break;
+            addScalar<QPDF_Integer>(QUtil::string_to_ll(tokenizer.getValue().c_str()));
+            continue;
 
         case QPDFTokenizer::tt_real:
-            object = QPDF_Real::create(tokenizer.getValue());
-            break;
+            addScalar<QPDF_Real>(tokenizer.getValue());
+            continue;
 
         case QPDFTokenizer::tt_name:
             {
                 auto const& name = tokenizer.getValue();
-                object = QPDF_Name::create(name);
+                addScalar<QPDF_Name>(name);
 
                 if (name == "/Contents") {
                     b_contents = true;
@@ -333,14 +322,14 @@ QPDFParser::parseRemainder(bool content_stream)
                     b_contents = false;
                 }
             }
-            break;
+            continue;
 
         case QPDFTokenizer::tt_word:
             {
                 auto const& value = tokenizer.getValue();
                 auto size = frame->olist.size();
                 if (content_stream) {
-                    object = QPDF_Operator::create(value);
+                    addScalar<QPDF_Operator>(value);
                 } else if (
                     value == "R" && size >= 2 && frame->olist.back() &&
                     frame->olist.back()->getTypeCode() == ::ot_integer &&
@@ -359,24 +348,25 @@ QPDFParser::parseRemainder(bool content_stream)
                         // This action has the desirable side effect of causing dangling references
                         // (references to indirect objects that don't appear in the PDF) in any
                         // parsed object to appear in the object cache.
-                        object = context->getObject(ref_og).obj;
-                        indirect_ref = true;
+                        frame->olist.pop_back();
+                        frame->olist.pop_back();
+                        add(std::move(context->getObject(ref_og).obj));
                     } else {
                         QTC::TC("qpdf", "QPDFParser indirect with 0 objid");
-                        is_null = true;
+                        frame->olist.pop_back();
+                        frame->olist.pop_back();
+                        addNull();
                     }
-                    frame->olist.pop_back();
-                    frame->olist.pop_back();
                 } else {
                     QTC::TC("qpdf", "QPDFParser treat word as string in parseRemainder");
                     warn("unknown token while reading object; treating as string");
                     if (tooManyBadTokens()) {
                         return {QPDF_Null::create()};
                     }
-                    object = QPDF_String::create(value);
+                    addScalar<QPDF_String>(value);
                 }
             }
-            break;
+            continue;
 
         case QPDFTokenizer::tt_string:
             {
@@ -389,35 +379,46 @@ QPDFParser::parseRemainder(bool content_stream)
                     }
                     std::string s{val};
                     decrypter->decryptString(s);
-                    object = QPDF_String::create(s);
+                    addScalar<QPDF_String>(s);
                 } else {
-                    object = QPDF_String::create(val);
+                    addScalar<QPDF_String>(val);
                 }
             }
-            break;
+            continue;
 
         default:
             warn("treating unknown token type as null while reading object");
             if (tooManyBadTokens()) {
                 return {QPDF_Null::create()};
             }
-            is_null = true;
-            break;
+            addNull();
         }
-
-        if (object == nullptr && !is_null) {
-            throw std::logic_error("QPDFParser:parseInternal: unexpected uninitialized object");
-        }
-
-        if (is_null) {
-            object = null_oh;
-            // No need to set description for direct nulls - they probably will become implicit.
-        } else if (!indirect_ref && !set_offset) {
-            setDescription(object, input->getLastOffset());
-        }
-        frame->olist.push_back(object);
     }
     return {}; // unreachable
+}
+
+void
+QPDFParser::add(std::shared_ptr<QPDFObject>&& obj)
+{
+    frame->olist.emplace_back(std::move(obj));
+}
+
+void
+QPDFParser::addNull()
+{
+    const static ObjectPtr null_obj = QPDF_Null::create();
+
+    frame->olist.emplace_back(null_obj);
+    ++frame->null_count;
+}
+
+template <typename T, typename... Args>
+void
+QPDFParser::addScalar(Args&&... args)
+{
+    auto obj = T::create(args...);
+    obj->setDescription(context, description, input->getLastOffset());
+    add(std::move(obj));
 }
 
 template <typename T, typename... Args>

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -32,7 +32,7 @@ class QPDFParser
 
   private:
     struct StackFrame;
-    enum parser_state_e { st_top, st_dictionary, st_array };
+    enum parser_state_e { st_dictionary, st_array };
 
     struct StackFrame
     {

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -61,6 +61,7 @@ class QPDFParser
     void addScalar(Args&&... args);
     bool tooManyBadTokens();
     void warnDuplicateKey();
+    void fixMissingKeys();
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;
     void warn(QPDFExc const&) const;

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -31,8 +31,9 @@ class QPDFParser
     QPDFObjectHandle parse(bool& empty, bool content_stream);
 
   private:
-    struct StackFrame;
-    enum parser_state_e { st_dictionary, st_array };
+    // Parser state.  Note:
+    // state < st_dictionary_value == (state = st_dictionary_key || state = st_dictionary_value)
+    enum parser_state_e { st_dictionary_key, st_dictionary_value, st_array };
 
     struct StackFrame
     {
@@ -43,7 +44,9 @@ class QPDFParser
         }
 
         std::vector<std::shared_ptr<QPDFObject>> olist;
+        std::map<std::string, QPDFObjectHandle> dict;
         parser_state_e state;
+        std::string key;
         qpdf_offset_t offset;
         std::string contents_string;
         qpdf_offset_t contents_offset{-1};
@@ -57,6 +60,7 @@ class QPDFParser
     template <typename T, typename... Args>
     void addScalar(Args&&... args);
     bool tooManyBadTokens();
+    void warnDuplicateKey();
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;
     void warn(QPDFExc const&) const;
@@ -83,7 +87,6 @@ class QPDFParser
     int int_count = 0;
     long long int_buffer[2]{0, 0};
     qpdf_offset_t last_offset_buffer[2]{0, 0};
-
 };
 
 #endif // QPDFPARSER_HH

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -45,18 +45,20 @@ class QPDFParser
         std::vector<std::shared_ptr<QPDFObject>> olist;
         parser_state_e state;
         qpdf_offset_t offset;
-        std::string contents_string{""};
+        std::string contents_string;
         qpdf_offset_t contents_offset{-1};
         int null_count{0};
     };
 
-
-    QPDFObjectHandle
-    parseRemainder(bool content_stream);
+    QPDFObjectHandle parseRemainder(bool content_stream);
     bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;
     void warn(QPDFExc const&) const;
+    template <typename T, typename... Args>
+    // Create a new scalar object complete with parsed offset and description.
+    // NB the offset includes any leading whitespace.
+    QPDFObjectHandle withDescription(Args&&... args);
     void setDescription(std::shared_ptr<QPDFObject>& obj, qpdf_offset_t parsed_offset);
     std::shared_ptr<InputSource> input;
     std::string const& object_description;
@@ -65,11 +67,14 @@ class QPDFParser
     QPDF* context;
     std::shared_ptr<QPDFValue::Description> description;
     std::vector<StackFrame> stack;
-    StackFrame*  frame;
+    StackFrame* frame;
     // Number of recent bad tokens.
     int bad_count = 0;
     // Number of good tokens since last bad token. Irrelevant if bad_count == 0.
     int good_count = 0;
+    // Start offset including any leading whitespace.
+    qpdf_offset_t start;
+
 };
 
 #endif // QPDFPARSER_HH

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -31,7 +31,7 @@ class QPDFParser
     QPDFObjectHandle parse(bool& empty, bool content_stream);
 
   private:
-    enum parser_state_e { st_top, st_start, st_stop, st_eof, st_dictionary, st_array };
+    enum parser_state_e { st_top, st_start, st_stop, st_dictionary, st_array };
 
     bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -31,7 +31,7 @@ class QPDFParser
     QPDFObjectHandle parse(bool& empty, bool content_stream);
 
   private:
-    enum parser_state_e { st_top, st_start, st_stop, st_dictionary, st_array };
+    enum parser_state_e { st_top, st_start, st_dictionary, st_array };
 
     bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -50,6 +50,9 @@ class QPDFParser
         int null_count{0};
     };
 
+
+    QPDFObjectHandle
+    parseRemainder(bool content_stream);
     bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;
@@ -61,6 +64,8 @@ class QPDFParser
     QPDFObjectHandle::StringDecrypter* decrypter;
     QPDF* context;
     std::shared_ptr<QPDFValue::Description> description;
+    std::vector<StackFrame> stack;
+    StackFrame*  frame;
     // Number of recent bad tokens.
     int bad_count = 0;
     // Number of good tokens since last bad token. Irrelevant if bad_count == 0.

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -31,7 +31,24 @@ class QPDFParser
     QPDFObjectHandle parse(bool& empty, bool content_stream);
 
   private:
+    struct StackFrame;
     enum parser_state_e { st_top, st_dictionary, st_array };
+
+    struct StackFrame
+    {
+        StackFrame(std::shared_ptr<InputSource> const& input, parser_state_e state) :
+            state(state),
+            offset(input->tell())
+        {
+        }
+
+        std::vector<std::shared_ptr<QPDFObject>> olist;
+        parser_state_e state;
+        qpdf_offset_t offset;
+        std::string contents_string{""};
+        qpdf_offset_t contents_offset{-1};
+        int null_count{0};
+    };
 
     bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -31,7 +31,7 @@ class QPDFParser
     QPDFObjectHandle parse(bool& empty, bool content_stream);
 
   private:
-    enum parser_state_e { st_top, st_start, st_dictionary, st_array };
+    enum parser_state_e { st_top, st_dictionary, st_array };
 
     bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -33,6 +33,7 @@ class QPDFParser
   private:
     enum parser_state_e { st_top, st_start, st_stop, st_eof, st_dictionary, st_array };
 
+    bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;
     void warn(QPDFExc const&) const;
@@ -43,6 +44,10 @@ class QPDFParser
     QPDFObjectHandle::StringDecrypter* decrypter;
     QPDF* context;
     std::shared_ptr<QPDFValue::Description> description;
+    // Number of recent bad tokens.
+    int bad_count = 0;
+    // Number of good tokens since last bad token. Irrelevant if bad_count == 0.
+    int good_count = 0;
 };
 
 #endif // QPDFPARSER_HH

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -53,6 +53,7 @@ class QPDFParser
     QPDFObjectHandle parseRemainder(bool content_stream);
     void add(std::shared_ptr<QPDFObject>&& obj);
     void addNull();
+    void addInt(int count);
     template <typename T, typename... Args>
     void addScalar(Args&&... args);
     bool tooManyBadTokens();
@@ -78,6 +79,10 @@ class QPDFParser
     int good_count = 0;
     // Start offset including any leading whitespace.
     qpdf_offset_t start;
+    // Number of successive integer tokens.
+    int int_count = 0;
+    long long int_buffer[2]{0, 0};
+    qpdf_offset_t last_offset_buffer[2]{0, 0};
 
 };
 

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -51,6 +51,10 @@ class QPDFParser
     };
 
     QPDFObjectHandle parseRemainder(bool content_stream);
+    void add(std::shared_ptr<QPDFObject>&& obj);
+    void addNull();
+    template <typename T, typename... Args>
+    void addScalar(Args&&... args);
     bool tooManyBadTokens();
     void warn(qpdf_offset_t offset, std::string const& msg) const;
     void warn(std::string const& msg) const;

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -57,11 +57,14 @@ QPDF trailer lacks size 0
 QPDF trailer size not integer 0
 QPDF trailer prev not integer 0
 QPDFParser bad brace 0
+QPDFParser bad brace in parseRemainder 0
 QPDFParser bad array close 0
+QPDFParser bad array close in parseRemainder 0
 QPDF stream without length 0
 QPDF stream length not integer 0
 QPDF missing endstream 0
 QPDFParser bad dictionary close 0
+QPDFParser bad dictionary close in parseRemainder 0
 QPDF can't find xref 0
 QPDFTokenizer bad ) 0
 QPDFTokenizer bad > 0
@@ -258,6 +261,7 @@ QPDFParser indirect with 0 objid 0
 QPDF object id 0 0
 QPDF recursion loop in resolve 0
 QPDFParser treat word as string 0
+QPDFParser treat word as string in parseRemainder 0
 QPDFParser found fake 1
 QPDFParser no val for last key 0
 QPDF resolve failure to null 0
@@ -289,7 +293,9 @@ QPDFObjectHandle coalesce called on stream 0
 QPDFObjectHandle coalesce provide stream data 0
 QPDF_Stream bad token at end during normalize 0
 QPDFParser bad token in parse 0
+QPDFParser bad token in parseRemainder 0
 QPDFParser eof in parse 0
+QPDFParser eof in parseRemainder 0
 QPDFObjectHandle array bounds 0
 QPDFObjectHandle boolean returning false 0
 QPDFObjectHandle integer returning 0 0

--- a/qpdf/qtest/parsing.test
+++ b/qpdf/qtest/parsing.test
@@ -17,7 +17,7 @@ my $td = new TestDriver('parsing');
 my $n_tests = 17;
 
 $td->runtest("parse objects from string",
-             {$td->COMMAND => "test_driver 31 good1.qdf"},
+             {$td->COMMAND => "test_driver 31 bad39.qdf"},
              {$td->FILE => "parse-object.out", $td->EXIT_STATUS => 0},
              $td->NORMALIZE_NEWLINES);
 $td->runtest("EOF terminating literal tokens",

--- a/qpdf/qtest/qpdf/bad16-recover.out
+++ b/qpdf/qtest/qpdf/bad16-recover.out
@@ -1,14 +1,14 @@
 WARNING: bad16.pdf (trailer, offset 753): unexpected dictionary close token
 WARNING: bad16.pdf (trailer, offset 756): unexpected dictionary close token
 WARNING: bad16.pdf (trailer, offset 759): unknown token while reading object; treating as string
-WARNING: bad16.pdf (trailer, offset 779): unexpected EOF
 WARNING: bad16.pdf (trailer, offset 779): parse error while reading object
+WARNING: bad16.pdf (trailer, offset 779): unexpected EOF
 WARNING: bad16.pdf: file is damaged
 WARNING: bad16.pdf (offset 712): expected trailer dictionary
 WARNING: bad16.pdf: Attempting to reconstruct cross-reference table
 WARNING: bad16.pdf (trailer, offset 753): unexpected dictionary close token
 WARNING: bad16.pdf (trailer, offset 756): unexpected dictionary close token
 WARNING: bad16.pdf (trailer, offset 759): unknown token while reading object; treating as string
-WARNING: bad16.pdf (trailer, offset 779): unexpected EOF
 WARNING: bad16.pdf (trailer, offset 779): parse error while reading object
+WARNING: bad16.pdf (trailer, offset 779): unexpected EOF
 bad16.pdf: unable to find trailer dictionary while recovering damaged file

--- a/qpdf/qtest/qpdf/bad16.out
+++ b/qpdf/qtest/qpdf/bad16.out
@@ -1,6 +1,6 @@
 WARNING: bad16.pdf (trailer, offset 753): unexpected dictionary close token
 WARNING: bad16.pdf (trailer, offset 756): unexpected dictionary close token
 WARNING: bad16.pdf (trailer, offset 759): unknown token while reading object; treating as string
-WARNING: bad16.pdf (trailer, offset 779): unexpected EOF
 WARNING: bad16.pdf (trailer, offset 779): parse error while reading object
+WARNING: bad16.pdf (trailer, offset 779): unexpected EOF
 bad16.pdf (offset 712): expected trailer dictionary

--- a/qpdf/qtest/qpdf/bad36-recover.out
+++ b/qpdf/qtest/qpdf/bad36-recover.out
@@ -1,6 +1,6 @@
 WARNING: bad36.pdf (trailer, offset 764): unknown token while reading object; treating as string
-WARNING: bad36.pdf (trailer, offset 715): expected dictionary key but found non-name object; inserting key /QPDFFake2
 WARNING: bad36.pdf (trailer, offset 715): dictionary ended prematurely; using null as value for last key
+WARNING: bad36.pdf (trailer, offset 715): expected dictionary key but found non-name object; inserting key /QPDFFake2
 /QTest is implicit
 /QTest is direct and has type null (2)
 /QTest is null

--- a/qpdf/qtest/qpdf/bad36.out
+++ b/qpdf/qtest/qpdf/bad36.out
@@ -1,6 +1,6 @@
 WARNING: bad36.pdf (trailer, offset 764): unknown token while reading object; treating as string
-WARNING: bad36.pdf (trailer, offset 715): expected dictionary key but found non-name object; inserting key /QPDFFake2
 WARNING: bad36.pdf (trailer, offset 715): dictionary ended prematurely; using null as value for last key
+WARNING: bad36.pdf (trailer, offset 715): expected dictionary key but found non-name object; inserting key /QPDFFake2
 /QTest is implicit
 /QTest is direct and has type null (2)
 /QTest is null

--- a/qpdf/qtest/qpdf/bad39.qdf
+++ b/qpdf/qtest/qpdf/bad39.qdf
@@ -1,0 +1,102 @@
+%PDF-1.3
+%¿÷¢þ
+%QDF-1.0
+
+%% Original object ID: 1 0
+1 0 obj
+<<
+  /Pages 2 0 R
+  /Type /Catalog
+>>
+endobj
+
+%% Original object ID: 2 0
+2 0 obj
+<<
+  /Count 1
+  /Kids [
+    3 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+%% Page 1
+%% Original object ID: 3 0
+3 0 obj
+<<
+  /Contents 4 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 2 0 R
+  /Resources <<
+    /Font <<
+      /F1 6 0 R
+    >>
+    /ProcSet 7 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Contents for page 1
+%% Original object ID: 4 0
+4 0 obj
+<<
+  /Length 5 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Potato) Tj
+ET
+endstream
+endobj
+
+5 0 obj
+44
+endobj
+
+%% Original object ID: 6 0
+6 0 obj
+<<
+  /BaseFont /Helvetica
+  /Encoding /WinAnsiEncoding
+  /Name /F1
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+%% Original object ID: 5 0
+7 0 obj
+[
+  /PDF
+  /Text
+]
+endobj
+
+xref
+0 8
+0000000000 65535 f 
+0000000052 00000 n 
+0000000133 00000 n 
+0000000242 00000 n 
+0000000484 00000 n 
+0000000583 00000 n 
+0000000629 00000 n 
+0000001113 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 8
+  /ID [<31415926535897932384626433832795><31415926535897932384626433832795>]
+>>
+startxref
+809
+%%EOF
+7 0 obj

--- a/qpdf/qtest/qpdf/issue-335a.out
+++ b/qpdf/qtest/qpdf/issue-335a.out
@@ -51,6 +51,7 @@ WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 600): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 134): dictionary has duplicated key /L
 WARNING: issue-335a.pdf (trailer, offset 601): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 648): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 649): name with stray # will not work with PDF >= 1.2
@@ -74,6 +75,7 @@ WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 600): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 164): dictionary has duplicated key /L
 WARNING: issue-335a.pdf (trailer, offset 601): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 648): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 649): name with stray # will not work with PDF >= 1.2
@@ -97,6 +99,7 @@ WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 600): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 231): dictionary has duplicated key /L
 WARNING: issue-335a.pdf (trailer, offset 601): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 648): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 649): name with stray # will not work with PDF >= 1.2
@@ -448,6 +451,7 @@ WARNING: issue-335a.pdf (trailer, offset 1168): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1332): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 1033): dictionary has duplicated key /L
 WARNING: issue-335a.pdf (trailer, offset 1333): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1344): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1428): unexpected )

--- a/qpdf/qtest/qpdf/parse-object.out
+++ b/qpdf/qtest/qpdf/parse-object.out
@@ -1,5 +1,5 @@
 [ /name 16059 3.14159 false << /key true /other [ (string1) (string2) ] >> null ]
-logic error parsing indirect: QPDFObjectHandle::parse called without context on an object with indirect references
+logic error parsing indirect: QPDFParser::parse called without context on an object with indirect references
 trailing data: parsed object (trailing test): trailing data found parsing object from string
 WARNING: parsed object (offset 9): unknown token while reading object; treating as string
 WARNING: parsed object: treating unexpected brace token as null

--- a/qpdf/qtest/qpdf/parse-object.out
+++ b/qpdf/qtest/qpdf/parse-object.out
@@ -2,4 +2,10 @@
 logic error parsing indirect: QPDFObjectHandle::parse called without context on an object with indirect references
 trailing data: parsed object (trailing test): trailing data found parsing object from string
 WARNING: parsed object (offset 9): unknown token while reading object; treating as string
+WARNING: parsed object: treating unexpected brace token as null
+WARNING: parsed object: treating unexpected brace token as null
+WARNING: parsed object: unexpected dictionary close token
+WARNING: bad39.qdf (object 7 0, offset 1121): unexpected EOF
+WARNING: bad39.qdf (object 7 0, offset 1121): expected endobj
+WARNING: bad39.qdf (object 7 0, offset 1121): EOF after endobj
 test 31 done

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1195,6 +1195,13 @@ test_31(QPDF& pdf, char const* arg2)
     // mistakenly parsed as an indirect object.
     assert(QPDFObjectHandle::parse(&pdf, "[5 0 R 0 R /X]").unparse() == "[ 5 0 R 0 (R) /X ]");
     assert(QPDFObjectHandle::parse(&pdf, "[1 0 R]", "indirect test").unparse() == "[ 1 0 R ]");
+    // TC:QPDFParser bad brace
+    assert(QPDFObjectHandle::parse(&pdf, "}").unparse() == "null");
+    assert(QPDFObjectHandle::parse(&pdf, "{").unparse() == "null");
+    // TC:QPDFParser bad dictionary close
+    assert(QPDFObjectHandle::parse(&pdf, ">>").unparse() == "null");
+    // TC:QPDFParser eof in parse
+    assert(QPDFObjectHandle::parse(&pdf, "[7 0 R]").getArrayItem(0).isNull());
 }
 
 static void


### PR DESCRIPTION
The main changes are:

- combine the state and object stacks. This required the refactoring of some parser states to prevent the two stacks from going out of sync.

- create separate methods for handling the first token and subsequent tokens.

- avoid the creation of temporary QPDF_Integer and QPDF_Name objects by refactoring the parsing of indirect references and dictionary keys.

- create dictionaries on the fly rather than accumulating key and value objects and processing them once the close token has been found. This requires splitting st_dictionary  in st_dictionary_key and st_dictionary_value.