### PR TITLE
Add new method QPDFObjectHandle::force

### DIFF
--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -308,6 +308,17 @@ class QPDFObjectHandle
     QPDF_DLL
     bool isSameObjectAs(QPDFObjectHandle const&) const;
 
+    // Indicate that the object handle is about to be used in a way that violates the PDF
+    // specification. For example, use:
+    //   qpdf.getRoot().replaceKey("/Pages", "<< /Type /Pages /Kids [] /Count 0>>\n"_qpdf.force());
+    // to indicate that you are deliberately using a direct object where the specification requires
+    // an indirect object. For future compatibility with qpdf 12.x.
+    QPDFObjectHandle
+    force() const noexcept
+    {
+        return *this;
+    }
+
     // Return type code and type name of underlying object.  These are useful for doing rapid type
     // tests (like switch statements) or for testing and debugging.
     QPDF_DLL

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -11,6 +11,14 @@ changes that are under consideration, you can build qpdf locally and
 enable the ``FUTURE`` build option (see :ref:`build-options`).
 
 Planned changes for future 12.x (subject to change):
+  - It will become illegal to create ``QPDF`` objects that do not comply
+    with the PDF specification, unless it is intentional. See the entry
+    for ``QPDFObjectHandle::force()`` below for further detail. The result
+    of creating an invalid ``QPDF`` object, unless documented, will be
+    undefined and may change over time. For example, an error may be
+    ignored, be quietly fixed, or generate a warning or error. There
+    will be a build option to disable this behaviour.
+
   - ``QPDFObjectHandle`` will support move construction/assignment.
     This change will be invisible to most developers but may break
     your code if you rely on specific behavior around how many
@@ -37,6 +45,13 @@ Planned changes for future 12.x (subject to change):
     to ``subtract``. (Not enabled with ``FUTURE`` option.)
 
 .. x.y.z: not yet released
+
+  - Library Enhancements
+
+    - Add new method ``QPDFObjectHandle::force`` to indicate that the
+      object handle is about to be used in a way that does not comply
+      with the PDF specification. The method currently does nothing
+      and is provided to help with transition to future qpdf 12.x.
 
 11.6.3: October 15, 2023
   - Bug fixes:


### PR DESCRIPTION
Proposed change for qpdf 12.

Requiring that non-compliant operations are explicitly flagged has two benefits:

- it helps with the transparent transition to a more strongly type object handle.

- it helps with avoiding the need to repeatedly check the same structures.