### PR TITLE
Build AppImage and linux binary using Ubuntu 18.04 (fixes #1068)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-11-20  Jay Berkenbilt  <ejb@ql.org>
+
+	* Build AppImage with an older Linux distribution to support AWS
+	Lambda. Fixes #1086.
+
 2023-10-15  Jay Berkenbilt  <ejb@ql.org>
 
         * 11.6.3: release

--- a/appimage/Dockerfile
+++ b/appimage/Dockerfile
@@ -1,13 +1,19 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get -y install screen git sudo \
-    build-essential pkg-config cmake \
+    build-essential pkg-config \
     zlib1g-dev libjpeg-dev libgnutls28-dev \
     python3-pip texlive-latex-extra latexmk \
     inkscape imagemagick busybox-static wget fuse && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN pip3 install sphinx sphinx_rtd_theme
+# Get cmake from pypi. We need to keep Ubuntu 18.04 for a while longer
+# since the glibc in Ubuntu 20.04 is too new (as of late 2023) for
+# Amazon Linux 2 in Lambda and for some supported CentOS versions.
+# When we are ready to update to 20.04 or newer, remove the version
+# constraint on sphinx, and install the OS package for cmake.
+RUN pip3 install --upgrade pip
+RUN pip3 install sphinx==4 sphinx_rtd_theme cmake
 COPY entrypoint /entrypoint
 RUN chmod +x /entrypoint
 ENTRYPOINT [ "/entrypoint" ]

--- a/appimage/build-appimage
+++ b/appimage/build-appimage
@@ -47,14 +47,14 @@ fi
 _osversion=$(cat /etc/os-release | grep PRETTY_NAME | awk -F'=' '{print $2}' | sed 's#"##g')
 
 # Warn users building the AppImage locally:
-if [[ ! $_osversion =~ Ubuntu\ 20.04.*\ LTS ]]; then
+if [[ ! $_osversion =~ Ubuntu\ 18.04.*\ LTS ]]; then
 set +x
     echo ""
     #    0         1         2         3         4         5         6         7
     #    01234567890123456789012345678901234567890123456789012345678901234567890123456789
     echo "+===========================================================================+"
     echo "|| WARNING: You are about to build a QPDF AppImage on a system which is    ||"
-    echo "|| NOT Ubuntu 20.04 LTS.                                                   ||"
+    echo "|| NOT Ubuntu 18.04 LTS.                                                   ||"
     echo "||                                                                         ||"
     echo "||    It is recommended that you use a distribution that is at least a     ||"
     echo "||    few years old to maximize the number of Linux distributions the      ||"


### PR DESCRIPTION
This is needed to get an old enough version of glibc to run the Linux binary as an AWS Lambda layer and to support some versions of CentOS.