### PR TITLE
Fix option reference in cli.rst

### DIFF
--- a/manual/cli.rst
+++ b/manual/cli.rst
@@ -749,7 +749,7 @@ Related Options
       signature but leaves its visual appearance intact.
 
    Remove security restrictions associated with digitally signed PDF
-   files. This may be combined with :qpdf:option:--decrypt: to allow
+   files. This may be combined with :qpdf:ref:--decrypt: to allow
    free editing of previously signed/encrypted files. This option
    invalidates the signature but leaves its visual appearance intact.
 


### PR DESCRIPTION
To reference another command line option description, `:qpdf:ref:` is needed instead of `:qpdf:option:` which is not resolved properly in the HTML documentation.