### PR TITLE
Add new method QPDFObjectHandle::dItems

### DIFF
--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -759,6 +759,10 @@ class QPDFObjectHandle
     QPDF_DLL
     QPDFDictItems ditems();
 
+    class DictItems;
+    QPDF_DLL
+    DictItems dItems();
+
     // Return true if key is present.  Keys with null values are treated as if they are not present.
     // This is as per the PDF spec.
     QPDF_DLL
@@ -1408,6 +1412,41 @@ QPDFObjectHandle operator ""_qpdf(char const* v, size_t len);
 /* clang-format on */
 
 #endif // QPDF_NO_QPDF_STRING
+
+class QPDFObjectHandle::DictItems
+{
+    friend class QPDFObjectHandle;
+
+  public:
+    class iterator: public std::map<std::string, QPDFObjectHandle>::iterator
+    {
+      public:
+        iterator(std::map<std::string, QPDFObjectHandle>::iterator it) :
+            std::map<std::string, QPDFObjectHandle>::iterator(it)
+        {
+        }
+    };
+
+    iterator begin()
+    {
+        return dict.begin();
+    }
+
+    iterator end()
+    {
+        return dict.end();
+    }
+
+  private:
+    DictItems(QPDFObjectHandle& oh, std::map<std::string, QPDFObjectHandle>& dict) :
+        oh(oh),
+        dict(dict)
+    {
+    }
+
+    QPDFObjectHandle oh;
+    std::map<std::string, QPDFObjectHandle>& dict;
+};
 
 class QPDFObjectHandle::QPDFDictItems
 {

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -961,6 +961,19 @@ QPDFObjectHandle::ditems()
     return {*this};
 }
 
+QPDFObjectHandle::DictItems
+QPDFObjectHandle::dItems()
+{
+    static std::map<std::string, QPDFObjectHandle> empty;
+    if (auto dict = asDictionary()) {
+        return {*this, dict->getAsMap()};
+    } else {
+        typeWarning("dictionary", "treating as empty");
+        //        QTC::TC("qpdf", "QPDFObjectHandle dictionary empty map for dItems");
+        return {*this, empty};
+    }
+}
+
 bool
 QPDFObjectHandle::hasKey(std::string const& key)
 {

--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -1129,7 +1129,7 @@ QPDFWriter::enqueueObject(QPDFObjectHandle object)
                 enqueueObject(item);
             }
         } else if (object.isDictionary()) {
-            for (auto& item: object.getDictAsMap()) {
+            for (auto& item: object.dItems()) {
                 if (!item.second.isNull()) {
                     enqueueObject(item.second);
                 }
@@ -1487,7 +1487,7 @@ QPDFWriter::unparseObject(
 
         writeString("<<");
 
-        for (auto& item: object.getDictAsMap()) {
+        for (auto& item: object.dItems()) {
             if (!item.second.isNull()) {
                 auto const& key = item.first;
                 writeString(indent);

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -112,8 +112,8 @@ QPDF_Dictionary::getKeys()
     return result;
 }
 
-std::map<std::string, QPDFObjectHandle> const&
-QPDF_Dictionary::getAsMap() const
+std::map<std::string, QPDFObjectHandle>&
+QPDF_Dictionary::getAsMap()
 {
     return this->items;
 }
@@ -138,3 +138,5 @@ QPDF_Dictionary::removeKey(std::string const& key)
     // no-op if key does not exist
     this->items.erase(key);
 }
+
+

--- a/libqpdf/qpdf/QPDF_Dictionary.hh
+++ b/libqpdf/qpdf/QPDF_Dictionary.hh
@@ -24,8 +24,7 @@ class QPDF_Dictionary: public QPDFValue
     bool hasKey(std::string const&);
     QPDFObjectHandle getKey(std::string const&);
     std::set<std::string> getKeys();
-    std::map<std::string, QPDFObjectHandle> const& getAsMap() const;
-
+    std::map<std::string, QPDFObjectHandle>& getAsMap();
     // If value is null, remove key; otherwise, replace the value of key, adding it if it does not
     // exist.
     void replaceKey(std::string const& key, QPDFObjectHandle value);


### PR DESCRIPTION
Inspired by #1087, provide a more efficient alternative to getDictAsMap.

Using dItems in QPDFWriter saves a good 2% on both clang-15 and gcc-12.

I haven't added any documentation or tests yet.
