### PR TITLE
Remove unneeded workaround

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2398,7 +2398,6 @@ QPDF::getCompressibleObjGens()
 
     const size_t max_obj = getObjectCount();
     std::vector<bool> visited(max_obj, false);
-    QPDFObjGen::set visited_gen; // for objects with generation > 0
     std::vector<QPDFObjectHandle> queue;
     queue.reserve(512);
     queue.push_back(m->trailer);
@@ -2409,19 +2408,14 @@ QPDF::getCompressibleObjGens()
         if (obj.isIndirect()) {
             QPDFObjGen og = obj.getObjGen();
             const size_t id = toS(og.getObj() - 1);
-            const int gen = og.getGen();
             if (id >= max_obj)
                 throw std::logic_error(
                     "unexpected object id encountered in getCompressibleObjGens");
-            if ((gen == 0 && visited[id]) || visited_gen.count(og)) {
+            if (visited[id]) {
                 QTC::TC("qpdf", "QPDF loop detected traversing objects");
                 continue;
             }
-            if (gen == 0) {
-                visited[id] = true;
-            } else {
-                visited_gen.insert(og);
-            }
+            visited[id] = true;
             if (og == encryption_dict_og) {
                 QTC::TC("qpdf", "QPDF exclude encryption dictionary");
             } else if (!(obj.isStream() ||


### PR DESCRIPTION
After the last fix, a previous workaround is no longer needed.
@m-holger thoughts? I haven't thought it through carefully enough. I may not be handling dangling references correctly, though it passes the test suite. e.g. if a null dangling comes first, will it block traversal through the live one? I have to run for an appointment. Maybe we need a null check before adding to visited -- out of time to test. I'll be back in about 2 hours.