### PR TITLE
Add copy annotation test

### DIFF
--- a/qpdf/qtest/copy-annotations.test
+++ b/qpdf/qtest/copy-annotations.test
@@ -14,7 +14,7 @@ cleanup();
 
 my $td = new TestDriver('copy-annotations');
 
-my $n_tests = 46;
+my $n_tests = 48;
 
 $td->runtest("complex copy annotations",
              {$td->COMMAND =>
@@ -60,6 +60,19 @@ $td->runtest("get json no acroform",
 $td->runtest("check output",
              {$td->FILE => "a.pdf"},
              {$td->FILE => "annotations-same-file.out.pdf"});
+
+# PDF:Table 164:P
+$td->runtest("copy annotations with /P entry",
+             {$td->COMMAND =>
+                  "qpdf --qdf --static-id --no-original-object-ids" .
+                   " annotations-no-acroform-with-p.pdf --pages . 1,1 -- a.pdf"},
+             {$td->STRING => "", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
+
+$td->runtest("check output",
+             {$td->FILE => "a.pdf"},
+             {$td->FILE => "annotations-no-acroform-with-p.out.pdf"},
+             $td->EXPECT_FAILURE);
 
 $td->runtest("copy annotations no acroform from foreign file",
              {$td->COMMAND =>

--- a/qpdf/qtest/qpdf/annotations-no-acroform-with-p.out.pdf
+++ b/qpdf/qtest/qpdf/annotations-no-acroform-with-p.out.pdf
@@ -1,0 +1,1651 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+1 0 obj
+<<
+  /Names <<
+    /EmbeddedFiles 2 0 R
+  >>
+  /Pages 3 0 R
+  /Type /Catalog
+>>
+endobj
+
+2 0 obj
+<<
+  /Names [
+    (attachment1.txt)
+    4 0 R
+  ]
+>>
+endobj
+
+3 0 obj
+<<
+  /Count 2
+  /Kids [
+    5 0 R
+    6 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+4 0 obj
+<<
+  /EF <<
+    /F 7 0 R
+    /UF 7 0 R
+  >>
+  /F (attachment1.txt)
+  /Type /Filespec
+  /UF (attachment1.txt)
+>>
+endobj
+
+%% Page 1
+5 0 obj
+<<
+  /Annots [
+    9 0 R
+    10 0 R
+    11 0 R
+    12 0 R
+    13 0 R
+    14 0 R
+    15 0 R
+    16 0 R
+    17 0 R
+    18 0 R
+    19 0 R
+  ]
+  /Contents 20 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources 22 0 R
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+6 0 obj
+<<
+  /Annots [
+    23 0 R
+    24 0 R
+    25 0 R
+    26 0 R
+    27 0 R
+    28 0 R
+    29 0 R
+    30 0 R
+    31 0 R
+    32 0 R
+    33 0 R
+  ]
+  /Contents 20 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources 22 0 R
+  /Type /Page
+>>
+endobj
+
+7 0 obj
+<<
+  /Params <<
+    /CheckSum <80a33fc110b5a7b8b4d58b8d57e814bc>
+    /Size 22
+    /Subtype /text#2fplain
+  >>
+  /Type /EmbeddedFile
+  /Length 8 0 R
+>>
+stream
+content of attachment
+endstream
+endobj
+
+8 0 obj
+22
+endobj
+
+9 0 obj
+<<
+  /A <<
+    /S /URI
+    /URI (https://www.qbilt.org/)
+  >>
+  /Border [
+    0
+    0
+    .4
+  ]
+  /C [
+    .8
+    .6
+    .6
+  ]
+  /H /I
+  /Rect [
+    72
+    501.832
+    374.4
+    520.696
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+10 0 obj
+<<
+  /AP <<
+    /N 34 0 R
+  >>
+  /DA (0 0.4 0 rg /F1 18 Tf)
+  /DR 22 0 R
+  /DV ()
+  /FT /Tx
+  /Ff 0
+  /P 5 0 R
+  /Rect [
+    72
+    470.774
+    190.8
+    484.922
+  ]
+  /Subtype /Widget
+  /T (Text Box 1)
+  /Type /Annot
+  /V (Formy field)
+>>
+endobj
+
+11 0 obj
+<<
+  /AP <<
+    /N 36 0 R
+  >>
+  /Contents (attachment1.txt)
+  /FS 4 0 R
+  /NM (attachment1.txt)
+  /Rect [
+    72
+    400
+    92
+    420
+  ]
+  /Subtype /FileAttachment
+  /Type /Annot
+>>
+endobj
+
+12 0 obj
+<<
+  /AP <<
+    /N 38 0 R
+  >>
+  /DA (0 0.4 0 rg /F1 18 Tf)
+  /DR 22 0 R
+  /DV ()
+  /FT /Tx
+  /Ff 0
+  /Rect [
+    372
+    330.774
+    386.148
+    470.374
+  ]
+  /Subtype /Widget
+  /T (Text Box 2)
+  /Type /Annot
+  /V (Rot-ccw field)
+>>
+endobj
+
+13 0 obj
+<<
+  /AP <<
+    /N 40 0 R
+  >>
+  /DA ()
+  /Rect [
+    72
+    350
+    92
+    360
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+14 0 obj
+<<
+  /AP <<
+    /N 42 0 R
+  >>
+  /DA ()
+  /Rect [
+    102
+    350
+    112
+    370
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+15 0 obj
+<<
+  /AP <<
+    /N 44 0 R
+  >>
+  /DA ()
+  /Rect [
+    122
+    350
+    142
+    360
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+16 0 obj
+<<
+  /AP <<
+    /N 46 0 R
+  >>
+  /DA ()
+  /Rect [
+    152
+    350
+    162
+    370
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+17 0 obj
+<<
+  /AP <<
+    /N <<
+      /1 48 0 R
+      /Off 50 0 R
+    >>
+  >>
+  /AS /1
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 52 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 53 0 R
+  /Rect [
+    152.749
+    648.501
+    164.801
+    660.549
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+18 0 obj
+<<
+  /AP <<
+    /N <<
+      /2 54 0 R
+      /Off 56 0 R
+    >>
+  >>
+  /AS /2
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 52 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 53 0 R
+  /Rect [
+    152.749
+    627.301
+    164.801
+    639.349
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+19 0 obj
+<<
+  /AP <<
+    /N <<
+      /3 58 0 R
+      /Off 60 0 R
+    >>
+  >>
+  /AS /3
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 52 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 53 0 R
+  /Rect [
+    151.399
+    606.501
+    163.451
+    618.549
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 2
+20 0 obj
+<<
+  /Length 21 0 R
+>>
+stream
+q
+1 1 .7 rg
+.5 .5 0 RG
+72 470.77 118.8 14.15 re
+B
+Q
+q
+0 .5 .5 RG
+0 1 1 rg
+372 330.77 14.15 139.4 re
+B
+Q
+q
+1 0 0 RG
+72 310 20 10 re
+72 310 5 10 re
+S
+0 1 0 RG
+102 310 10 20 re
+102 310 10 5 re
+S
+0 0 1 RG
+122 310 20 10 re
+137 310 5 10 re
+S
+0.5 0 1 RG
+152 310 10 20 re
+152 325 10 5 re
+S
+10 w
+0.14 .33 .18 RG
+5 5 602 782 re
+S
+Q
+BT
+  /F1 16 Tf
+  20.6 TL
+  170 650 Td
+  (radio button 1) Tj
+  (radio button 2) '
+  (radio button 3) '
+  1 0 0 1 72 546 Tm
+  /F1 20 Tf
+  (Thick green border surrounds page.) Tj
+  0 -40 Td
+  /F1 24 Tf
+  0 0 1 rg
+  (https://www.qbilt.org) Tj
+  /F1 12 Tf
+  1 0 0 1 202 474 Tm
+  (<- Formy field in yellow) Tj
+  1 0 0 1 392 410 Tm
+  14.4 TL
+  (<- Rot-ccw field) Tj
+  (with "Rot" at bottom) '
+  (and text going up) '
+  0 g
+  1 0 0 1 102 405 Tm
+  (Arrow to the left points down.) Tj
+  1 0 0 1 182 310 Tm
+  (<- Drawn rectangles appear below annotations.) Tj
+ET
+endstream
+endobj
+
+21 0 obj
+874
+endobj
+
+22 0 obj
+<<
+  /Font <<
+    /F1 62 0 R
+  >>
+>>
+endobj
+
+23 0 obj
+<<
+  /A <<
+    /S /URI
+    /URI (https://www.qbilt.org/)
+  >>
+  /Border [
+    0
+    0
+    .4
+  ]
+  /C [
+    .8
+    .6
+    .6
+  ]
+  /H /I
+  /Rect [
+    72
+    501.832
+    374.4
+    520.696
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+24 0 obj
+<<
+  /AP <<
+    /N 63 0 R
+  >>
+  /DA (0 0.4 0 rg /F1 18 Tf)
+  /DR 22 0 R
+  /DV ()
+  /FT /Tx
+  /Ff 0
+  /P 6 0 R
+  /Rect [
+    72
+    470.774
+    190.8
+    484.922
+  ]
+  /Subtype /Widget
+  /T (Text Box 1)
+  /Type /Annot
+  /V (Formy field)
+>>
+endobj
+
+25 0 obj
+<<
+  /AP <<
+    /N 65 0 R
+  >>
+  /Contents (attachment1.txt)
+  /FS 4 0 R
+  /NM (attachment1.txt)
+  /Rect [
+    72
+    400
+    92
+    420
+  ]
+  /Subtype /FileAttachment
+  /Type /Annot
+>>
+endobj
+
+26 0 obj
+<<
+  /AP <<
+    /N 67 0 R
+  >>
+  /DA (0 0.4 0 rg /F1 18 Tf)
+  /DR 22 0 R
+  /DV ()
+  /FT /Tx
+  /Ff 0
+  /Rect [
+    372
+    330.774
+    386.148
+    470.374
+  ]
+  /Subtype /Widget
+  /T (Text Box 2)
+  /Type /Annot
+  /V (Rot-ccw field)
+>>
+endobj
+
+27 0 obj
+<<
+  /AP <<
+    /N 69 0 R
+  >>
+  /DA ()
+  /Rect [
+    72
+    350
+    92
+    360
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+28 0 obj
+<<
+  /AP <<
+    /N 71 0 R
+  >>
+  /DA ()
+  /Rect [
+    102
+    350
+    112
+    370
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+29 0 obj
+<<
+  /AP <<
+    /N 73 0 R
+  >>
+  /DA ()
+  /Rect [
+    122
+    350
+    142
+    360
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+30 0 obj
+<<
+  /AP <<
+    /N 75 0 R
+  >>
+  /DA ()
+  /Rect [
+    152
+    350
+    162
+    370
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+31 0 obj
+<<
+  /AP <<
+    /N <<
+      /1 77 0 R
+      /Off 79 0 R
+    >>
+  >>
+  /AS /1
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 52 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 53 0 R
+  /Rect [
+    152.749
+    648.501
+    164.801
+    660.549
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+32 0 obj
+<<
+  /AP <<
+    /N <<
+      /2 81 0 R
+      /Off 83 0 R
+    >>
+  >>
+  /AS /2
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 52 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 53 0 R
+  /Rect [
+    152.749
+    627.301
+    164.801
+    639.349
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+33 0 obj
+<<
+  /AP <<
+    /N <<
+      /3 85 0 R
+      /Off 87 0 R
+    >>
+  >>
+  /AS /3
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 52 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 53 0 R
+  /Rect [
+    151.399
+    606.501
+    163.451
+    618.549
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+34 0 obj
+<<
+  /BBox [
+    0
+    -2.826
+    118.8
+    11.322
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 35 0 R
+>>
+stream
+/Tx BMC
+q
+BT
+  /F1 18 Tf
+  (Formy field) Tj
+ET
+Q
+EMC
+endstream
+endobj
+
+35 0 obj
+53
+endobj
+
+36 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    20
+  ]
+  /Resources <<
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 37 0 R
+>>
+stream
+0 10 m
+10 0 l
+20 10 l
+10 0 m
+10 20 l
+0 0 20 20 re
+S
+endstream
+endobj
+
+37 0 obj
+52
+endobj
+
+38 0 obj
+<<
+  /BBox [
+    0
+    -2.826
+    140.4
+    11.322
+  ]
+  /Matrix [
+    0
+    1
+    -1
+    0
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 39 0 R
+>>
+stream
+/Tx BMC
+q
+BT
+  /F1 18 Tf
+  (Rot-ccw field) Tj
+ET
+Q
+EMC
+endstream
+endobj
+
+39 0 obj
+55
+endobj
+
+40 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 41 0 R
+>>
+stream
+1 0 0 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+41 0 obj
+36
+endobj
+
+42 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    0
+    1
+    -1
+    0
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 43 0 R
+>>
+stream
+0 1 0 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+43 0 obj
+36
+endobj
+
+44 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    -1
+    0
+    0
+    -1
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 45 0 R
+>>
+stream
+0 0 1 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+45 0 obj
+36
+endobj
+
+46 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    0
+    -1
+    1
+    0
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 47 0 R
+>>
+stream
+0.5 0 1 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+47 0 obj
+38
+endobj
+
+48 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 49 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+1 0 0 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+49 0 obj
+202
+endobj
+
+50 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 51 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+51 0 obj
+12
+endobj
+
+52 0 obj
+<<
+  /BaseFont /ZapfDingbats
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+53 0 obj
+<<
+  /DV /1
+  /FT /Btn
+  /Ff 49152
+  /Kids [
+    17 0 R
+    18 0 R
+    19 0 R
+  ]
+  /T (r1)
+  /V /2
+>>
+endobj
+
+54 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 55 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+0 1 0 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+55 0 obj
+202
+endobj
+
+56 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 57 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+57 0 obj
+12
+endobj
+
+58 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 59 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+0 0 1 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+59 0 obj
+202
+endobj
+
+60 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 61 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+61 0 obj
+12
+endobj
+
+62 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+63 0 obj
+<<
+  /BBox [
+    0
+    -2.826
+    118.8
+    11.322
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 64 0 R
+>>
+stream
+/Tx BMC
+q
+BT
+  /F1 18 Tf
+  (Formy field) Tj
+ET
+Q
+EMC
+endstream
+endobj
+
+64 0 obj
+53
+endobj
+
+65 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    20
+  ]
+  /Resources <<
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 66 0 R
+>>
+stream
+0 10 m
+10 0 l
+20 10 l
+10 0 m
+10 20 l
+0 0 20 20 re
+S
+endstream
+endobj
+
+66 0 obj
+52
+endobj
+
+67 0 obj
+<<
+  /BBox [
+    0
+    -2.826
+    140.4
+    11.322
+  ]
+  /Matrix [
+    0
+    1
+    -1
+    0
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 68 0 R
+>>
+stream
+/Tx BMC
+q
+BT
+  /F1 18 Tf
+  (Rot-ccw field) Tj
+ET
+Q
+EMC
+endstream
+endobj
+
+68 0 obj
+55
+endobj
+
+69 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 70 0 R
+>>
+stream
+1 0 0 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+70 0 obj
+36
+endobj
+
+71 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    0
+    1
+    -1
+    0
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 72 0 R
+>>
+stream
+0 1 0 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+72 0 obj
+36
+endobj
+
+73 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    -1
+    0
+    0
+    -1
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 74 0 R
+>>
+stream
+0 0 1 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+74 0 obj
+36
+endobj
+
+75 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    0
+    -1
+    1
+    0
+    0
+    0
+  ]
+  /Resources 22 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 76 0 R
+>>
+stream
+0.5 0 1 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+76 0 obj
+38
+endobj
+
+77 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 78 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+1 0 0 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+78 0 obj
+202
+endobj
+
+79 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 80 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+80 0 obj
+12
+endobj
+
+81 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 82 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+0 1 0 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+82 0 obj
+202
+endobj
+
+83 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 84 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+84 0 obj
+12
+endobj
+
+85 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 86 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+0 0 1 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+86 0 obj
+202
+endobj
+
+87 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 89 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 88 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+88 0 obj
+12
+endobj
+
+89 0 obj
+<<
+  /Font 90 0 R
+  /ProcSet [
+    /PDF
+    /Text
+  ]
+>>
+endobj
+
+90 0 obj
+<<
+  /ZaDi 52 0 R
+>>
+endobj
+
+xref
+0 91
+0000000000 65535 f 
+0000000025 00000 n 
+0000000121 00000 n 
+0000000190 00000 n 
+0000000272 00000 n 
+0000000410 00000 n 
+0000000693 00000 n 
+0000000967 00000 n 
+0000001173 00000 n 
+0000001192 00000 n 
+0000001435 00000 n 
+0000001692 00000 n 
+0000001895 00000 n 
+0000002146 00000 n 
+0000002286 00000 n 
+0000002428 00000 n 
+0000002570 00000 n 
+0000002712 00000 n 
+0000003065 00000 n 
+0000003418 00000 n 
+0000003794 00000 n 
+0000004725 00000 n 
+0000004746 00000 n 
+0000004800 00000 n 
+0000005044 00000 n 
+0000005301 00000 n 
+0000005504 00000 n 
+0000005755 00000 n 
+0000005895 00000 n 
+0000006037 00000 n 
+0000006179 00000 n 
+0000006321 00000 n 
+0000006674 00000 n 
+0000007027 00000 n 
+0000007380 00000 n 
+0000007596 00000 n 
+0000007616 00000 n 
+0000007820 00000 n 
+0000007840 00000 n 
+0000008111 00000 n 
+0000008131 00000 n 
+0000008318 00000 n 
+0000008338 00000 n 
+0000008578 00000 n 
+0000008598 00000 n 
+0000008839 00000 n 
+0000008859 00000 n 
+0000009101 00000 n 
+0000009121 00000 n 
+0000009480 00000 n 
+0000009501 00000 n 
+0000009670 00000 n 
+0000009690 00000 n 
+0000009771 00000 n 
+0000009891 00000 n 
+0000010250 00000 n 
+0000010271 00000 n 
+0000010440 00000 n 
+0000010460 00000 n 
+0000010819 00000 n 
+0000010840 00000 n 
+0000011009 00000 n 
+0000011029 00000 n 
+0000011134 00000 n 
+0000011350 00000 n 
+0000011370 00000 n 
+0000011574 00000 n 
+0000011594 00000 n 
+0000011865 00000 n 
+0000011885 00000 n 
+0000012072 00000 n 
+0000012092 00000 n 
+0000012332 00000 n 
+0000012352 00000 n 
+0000012593 00000 n 
+0000012613 00000 n 
+0000012855 00000 n 
+0000012875 00000 n 
+0000013234 00000 n 
+0000013255 00000 n 
+0000013424 00000 n 
+0000013444 00000 n 
+0000013803 00000 n 
+0000013824 00000 n 
+0000013993 00000 n 
+0000014013 00000 n 
+0000014372 00000 n 
+0000014393 00000 n 
+0000014562 00000 n 
+0000014582 00000 n 
+0000014656 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 91
+  /ID [<a2f146daeb6d814a742556489dab9882><31415926535897932384626433832795>]
+>>
+startxref
+14694
+%%EOF

--- a/qpdf/qtest/qpdf/annotations-no-acroform-with-p.pdf
+++ b/qpdf/qtest/qpdf/annotations-no-acroform-with-p.pdf
@@ -1,0 +1,936 @@
+%PDF-1.6
+%¿÷¢þ
+%QDF-1.0
+
+1 0 obj
+<<
+
+  /Names <<
+    /EmbeddedFiles 6 0 R
+  >>
+  /Pages 7 0 R
+  /Type /Catalog
+>>
+endobj
+
+2 0 obj
+<<
+  /Font <<
+    /F1 8 0 R
+  >>
+>>
+endobj
+
+3 0 obj
+<<
+  /AP <<
+    /N 9 0 R
+  >>
+  /DA (0 0.4 0 rg /F1 18 Tf)
+  /DR 2 0 R
+  /DV ()
+  /FT /Tx
+  /Ff 0
+  /P 17 0 R
+  /Rect [
+    72
+    470.774
+    190.8
+    484.922
+  ]
+  /Subtype /Widget
+  /T (Text Box 1)
+  /Type /Annot
+  /V (Formy field)
+>>
+endobj
+
+4 0 obj
+<<
+  /AP <<
+    /N 11 0 R
+  >>
+  /DA (0 0.4 0 rg /F1 18 Tf)
+  /DR 2 0 R
+  /DV ()
+  /FT /Tx
+  /Ff 0
+  /Rect [
+    372
+    330.774
+    386.148
+    470.374
+  ]
+  /Subtype /Widget
+  /T (Text Box 2)
+  /Type /Annot
+  /V (Rot-ccw field)
+>>
+endobj
+
+5 0 obj
+<<
+  /DV /1
+  /FT /Btn
+  /Ff 49152
+  /Kids [
+    13 0 R
+    14 0 R
+    15 0 R
+  ]
+  /T (r1)
+  /V /2
+>>
+endobj
+
+6 0 obj
+<<
+  /Names [
+    (attachment1.txt)
+    16 0 R
+  ]
+>>
+endobj
+
+7 0 obj
+<<
+  /Count 1
+  /Kids [
+    17 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+8 0 obj
+<<
+  /BaseFont /Courier
+  /Encoding /WinAnsiEncoding
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+9 0 obj
+<<
+  /BBox [
+    0
+    -2.826
+    118.8
+    11.322
+  ]
+  /Resources 2 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 10 0 R
+>>
+stream
+/Tx BMC
+q
+BT
+  /F1 18 Tf
+  (Formy field) Tj
+ET
+Q
+EMC
+endstream
+endobj
+
+10 0 obj
+53
+endobj
+
+11 0 obj
+<<
+  /BBox [
+    0
+    -2.826
+    140.4
+    11.322
+  ]
+  /Matrix [
+    0
+    1
+    -1
+    0
+    0
+    0
+  ]
+  /Resources 2 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 12 0 R
+>>
+stream
+/Tx BMC
+q
+BT
+  /F1 18 Tf
+  (Rot-ccw field) Tj
+ET
+Q
+EMC
+endstream
+endobj
+
+12 0 obj
+55
+endobj
+
+13 0 obj
+<<
+  /AP <<
+    /N <<
+      /1 18 0 R
+      /Off 20 0 R
+    >>
+  >>
+  /AS /1
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 22 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 5 0 R
+  /Rect [
+    152.749
+    648.501
+    164.801
+    660.549
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+14 0 obj
+<<
+  /AP <<
+    /N <<
+      /2 23 0 R
+      /Off 25 0 R
+    >>
+  >>
+  /AS /2
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 22 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 5 0 R
+  /Rect [
+    152.749
+    627.301
+    164.801
+    639.349
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+15 0 obj
+<<
+  /AP <<
+    /N <<
+      /3 27 0 R
+      /Off 29 0 R
+    >>
+  >>
+  /AS /3
+  /DA (0.18039 0.20392 0.21176 rg /ZaDi 0 Tf)
+  /DR <<
+    /Font <<
+      /ZaDi 22 0 R
+    >>
+  >>
+  /F 4
+  /FT /Btn
+  /MK <<
+    /CA (l)
+  >>
+  /Parent 5 0 R
+  /Rect [
+    151.399
+    606.501
+    163.451
+    618.549
+  ]
+  /Subtype /Widget
+  /Type /Annot
+>>
+endobj
+
+16 0 obj
+<<
+  /EF <<
+    /F 31 0 R
+    /UF 31 0 R
+  >>
+  /F (attachment1.txt)
+  /Type /Filespec
+  /UF (attachment1.txt)
+>>
+endobj
+
+%% Page 1
+17 0 obj
+<<
+  /Annots [
+    33 0 R
+    3 0 R
+    34 0 R
+    4 0 R
+    35 0 R
+    36 0 R
+    37 0 R
+    38 0 R
+    13 0 R
+    14 0 R
+    15 0 R
+  ]
+  /Contents 39 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 7 0 R
+  /Resources 2 0 R
+  /Type /Page
+>>
+endobj
+
+18 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 41 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 19 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+1 0 0 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+19 0 obj
+202
+endobj
+
+20 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 41 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 21 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+21 0 obj
+12
+endobj
+
+22 0 obj
+<<
+  /BaseFont /ZapfDingbats
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+23 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 41 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 24 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+0 1 0 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+24 0 obj
+202
+endobj
+
+25 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 41 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 26 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+26 0 obj
+12
+endobj
+
+27 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 41 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 28 0 R
+>>
+stream
+/Tx BMC
+q BT
+0.18039 0.20392 0.21176 rg /ZaDi 12.05 Tf
+0 0 Td
+ET
+Q
+0 0 1 rg
+6 8.4 m 7.35 8.4 8.45 7.35 8.45 6 c
+8.45 4.65 7.35 3.55 6 3.55 c
+4.65 3.55 3.6 4.65 3.6 6 c
+3.6 7.35 4.65 8.4 6 8.4 c f*
+
+EMC
+endstream
+endobj
+
+28 0 obj
+202
+endobj
+
+29 0 obj
+<<
+  /BBox [
+    0
+    0
+    12.05
+    12.05
+  ]
+  /Resources 41 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 30 0 R
+>>
+stream
+/Tx BMC
+EMC
+endstream
+endobj
+
+30 0 obj
+12
+endobj
+
+31 0 obj
+<<
+  /Params <<
+    /CheckSum <80a33fc110b5a7b8b4d58b8d57e814bc>
+    /Size 22
+    /Subtype /text#2fplain
+  >>
+  /Type /EmbeddedFile
+  /Length 32 0 R
+>>
+stream
+content of attachment
+endstream
+endobj
+
+32 0 obj
+22
+endobj
+
+33 0 obj
+<<
+  /A <<
+    /S /URI
+    /URI (https://www.qbilt.org/)
+  >>
+  /Border [
+    0
+    0
+    .4
+  ]
+  /C [
+    .8
+    .6
+    .6
+  ]
+  /H /I
+  /Rect [
+    72
+    501.832
+    374.4
+    520.696
+  ]
+  /Subtype /Link
+  /Type /Annot
+>>
+endobj
+
+34 0 obj
+<<
+  /AP <<
+    /N 42 0 R
+  >>
+  /Contents (attachment1.txt)
+  /FS 16 0 R
+  /NM (attachment1.txt)
+  /Rect [
+    72
+    400
+    92
+    420
+  ]
+  /Subtype /FileAttachment
+  /Type /Annot
+>>
+endobj
+
+35 0 obj
+<<
+  /AP <<
+    /N 44 0 R
+  >>
+  /DA ()
+  /Rect [
+    72
+    350
+    92
+    360
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+36 0 obj
+<<
+  /AP <<
+    /N 46 0 R
+  >>
+  /DA ()
+  /Rect [
+    102
+    350
+    112
+    370
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+37 0 obj
+<<
+  /AP <<
+    /N 48 0 R
+  >>
+  /DA ()
+  /Rect [
+    122
+    350
+    142
+    360
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+38 0 obj
+<<
+  /AP <<
+    /N 50 0 R
+  >>
+  /DA ()
+  /Rect [
+    152
+    350
+    162
+    370
+  ]
+  /Subtype /FreeText
+  /Type /Annot
+>>
+endobj
+
+%% Contents for page 1
+39 0 obj
+<<
+  /Length 40 0 R
+>>
+stream
+q
+1 1 .7 rg
+.5 .5 0 RG
+72 470.77 118.8 14.15 re
+B
+Q
+q
+0 .5 .5 RG
+0 1 1 rg
+372 330.77 14.15 139.4 re
+B
+Q
+q
+1 0 0 RG
+72 310 20 10 re
+72 310 5 10 re
+S
+0 1 0 RG
+102 310 10 20 re
+102 310 10 5 re
+S
+0 0 1 RG
+122 310 20 10 re
+137 310 5 10 re
+S
+0.5 0 1 RG
+152 310 10 20 re
+152 325 10 5 re
+S
+10 w
+0.14 .33 .18 RG
+5 5 602 782 re
+S
+Q
+BT
+  /F1 16 Tf
+  20.6 TL
+  170 650 Td
+  (radio button 1) Tj
+  (radio button 2) '
+  (radio button 3) '
+  1 0 0 1 72 546 Tm
+  /F1 20 Tf
+  (Thick green border surrounds page.) Tj
+  0 -40 Td
+  /F1 24 Tf
+  0 0 1 rg
+  (https://www.qbilt.org) Tj
+  /F1 12 Tf
+  1 0 0 1 202 474 Tm
+  (<- Formy field in yellow) Tj
+  1 0 0 1 392 410 Tm
+  14.4 TL
+  (<- Rot-ccw field) Tj
+  (with "Rot" at bottom) '
+  (and text going up) '
+  0 g
+  1 0 0 1 102 405 Tm
+  (Arrow to the left points down.) Tj
+  1 0 0 1 182 310 Tm
+  (<- Drawn rectangles appear below annotations.) Tj
+ET
+endstream
+endobj
+
+40 0 obj
+874
+endobj
+
+41 0 obj
+<<
+  /Font 52 0 R
+  /ProcSet [
+    /PDF
+    /Text
+  ]
+>>
+endobj
+
+42 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    20
+  ]
+  /Resources <<
+  >>
+  /Subtype /Form
+  /Type /XObject
+  /Length 43 0 R
+>>
+stream
+0 10 m
+10 0 l
+20 10 l
+10 0 m
+10 20 l
+0 0 20 20 re
+S
+endstream
+endobj
+
+43 0 obj
+52
+endobj
+
+44 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Resources 2 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 45 0 R
+>>
+stream
+1 0 0 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+45 0 obj
+36
+endobj
+
+46 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    0
+    1
+    -1
+    0
+    0
+    0
+  ]
+  /Resources 2 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 47 0 R
+>>
+stream
+0 1 0 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+47 0 obj
+36
+endobj
+
+48 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    -1
+    0
+    0
+    -1
+    0
+    0
+  ]
+  /Resources 2 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 49 0 R
+>>
+stream
+0 0 1 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+49 0 obj
+36
+endobj
+
+50 0 obj
+<<
+  /BBox [
+    0
+    0
+    20
+    10
+  ]
+  /Matrix [
+    0
+    -1
+    1
+    0
+    0
+    0
+  ]
+  /Resources 2 0 R
+  /Subtype /Form
+  /Type /XObject
+  /Length 51 0 R
+>>
+stream
+0.5 0 1 RG
+0 0 20 10 re
+0 0 5 10 re
+S
+endstream
+endobj
+
+51 0 obj
+38
+endobj
+
+52 0 obj
+<<
+  /ZaDi 22 0 R
+>>
+endobj
+
+xref
+0 53
+0000000000 65535 f 
+0000000025 00000 n 
+0000000122 00000 n 
+0000000174 00000 n 
+0000000429 00000 n 
+0000000678 00000 n 
+0000000797 00000 n 
+0000000867 00000 n 
+0000000940 00000 n 
+0000001044 00000 n 
+0000001258 00000 n 
+0000001278 00000 n 
+0000001548 00000 n 
+0000001568 00000 n 
+0000001920 00000 n 
+0000002272 00000 n 
+0000002624 00000 n 
+0000002765 00000 n 
+0000003037 00000 n 
+0000003396 00000 n 
+0000003417 00000 n 
+0000003586 00000 n 
+0000003606 00000 n 
+0000003687 00000 n 
+0000004046 00000 n 
+0000004067 00000 n 
+0000004236 00000 n 
+0000004256 00000 n 
+0000004615 00000 n 
+0000004636 00000 n 
+0000004805 00000 n 
+0000004825 00000 n 
+0000005033 00000 n 
+0000005053 00000 n 
+0000005297 00000 n 
+0000005501 00000 n 
+0000005641 00000 n 
+0000005783 00000 n 
+0000005925 00000 n 
+0000006090 00000 n 
+0000007021 00000 n 
+0000007042 00000 n 
+0000007116 00000 n 
+0000007320 00000 n 
+0000007340 00000 n 
+0000007526 00000 n 
+0000007546 00000 n 
+0000007785 00000 n 
+0000007805 00000 n 
+0000008045 00000 n 
+0000008065 00000 n 
+0000008306 00000 n 
+0000008326 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 53
+  /ID [<a2f146daeb6d814a742556489dab9882><7b639c67bfc16b5e891fa5468aac3a14>]
+>>
+startxref
+8364
+%%EOF


### PR DESCRIPTION
I am not sure #1048 is fully implemented, at three different levels:

- I am not sure the code to copy an individual annotation is complete, e.g. the /P key is not fixed on copying. I think it would be worthwhile to check the existing code against the PDF spec.

- There is no high-level code (that I am aware of) to copy all annotations (or all annotations from a region) of one page to another page.

- There is no way to specify in the qpdf CLI  when selecting pages whether annotations should be included or not.