### PR TITLE
Tune handling of sparse arrays in QPDF_Array

### DIFF
--- a/libqpdf/qpdf/QPDF_Array.hh
+++ b/libqpdf/qpdf/QPDF_Array.hh
@@ -8,6 +8,13 @@
 
 class QPDF_Array: public QPDFValue
 {
+  private:
+    struct Sparse
+    {
+        int size{0};
+        std::map<int, std::shared_ptr<QPDFObject>> elements;
+    };
+
   public:
     ~QPDF_Array() override = default;
     static std::shared_ptr<QPDFObject> create(std::vector<QPDFObjectHandle> const& items);
@@ -21,7 +28,7 @@ class QPDF_Array: public QPDFValue
     int
     size() const noexcept
     {
-        return sparse ? sp_size : int(elements.size());
+        return sp ? sp->size : int(elements.size());
     }
     QPDFObjectHandle at(int n) const noexcept;
     bool setAt(int n, QPDFObjectHandle const& oh);
@@ -39,9 +46,7 @@ class QPDF_Array: public QPDFValue
 
     void checkOwnership(QPDFObjectHandle const& item) const;
 
-    bool sparse{false};
-    int sp_size{0};
-    std::map<int, std::shared_ptr<QPDFObject>> sp_elements;
+    std::unique_ptr<Sparse> sp;
     std::vector<std::shared_ptr<QPDFObject>> elements;
 };
 


### PR DESCRIPTION
Sparse arrays are rare. Dynamically create the variables needed to manage them only when needed.

The change allows additional variables to be added to sparse arrays (e.g. to facilitate the efficient iteration over arrays) without affecting the performance and footprint of normal arrays.

As a side benefit, the change provides a slight improvement in run time and footprint (slightly less than 0.5%). This improvement also applies to the  305 test file. There is no noticeable impact on the 'many-nulls' tests.