### PR TITLE
Refactor QPDF object cache and xref table

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -985,14 +985,8 @@ class QPDF
     QPDFObjectHandle reserveObjectIfNotExists(QPDFObjGen const& og);
     QPDFObjectHandle reserveStream(QPDFObjGen const& og);
     QPDFObjGen nextObjGen();
-    QPDFObjectHandle newIndirect(QPDFObjGen const&, std::shared_ptr<QPDFObject> const&);
-    QPDFObjectHandle makeIndirectFromQPDFObject(std::shared_ptr<QPDFObject> const& obj);
+    QPDFObjectHandle makeIndirectFromQPDFObject(std::shared_ptr<QPDFObject>&& obj);
     void removeObject(QPDFObjGen og);
-    void updateCache(
-        QPDFObjGen const& og,
-        std::shared_ptr<QPDFObject> const& object,
-        qpdf_offset_t end_before_space,
-        qpdf_offset_t end_after_space);
     static QPDFExc damagedPDF(
         std::shared_ptr<InputSource> const& input,
         std::string const& object,

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -839,18 +839,7 @@ class QPDF
     };
 
     // JobSetter class is restricted to QPDFJob.
-    class JobSetter
-    {
-        friend class QPDFJob;
-
-      private:
-        // Enable enhanced warnings for pdf file checking.
-        static void
-        setCheckMode(QPDF& qpdf, bool val)
-        {
-            qpdf.m->check_mode = val;
-        }
-    };
+    class JobSetter;
 
     // For testing only -- do not add to DLL
     static bool test_json_validators();
@@ -865,28 +854,7 @@ class QPDF
 
     static std::string const qpdf_version;
 
-    class ObjCache
-    {
-      public:
-        ObjCache() :
-            end_before_space(0),
-            end_after_space(0)
-        {
-        }
-        ObjCache(
-            std::shared_ptr<QPDFObject> object,
-            qpdf_offset_t end_before_space,
-            qpdf_offset_t end_after_space) :
-            object(object),
-            end_before_space(end_before_space),
-            end_after_space(end_after_space)
-        {
-        }
-
-        std::shared_ptr<QPDFObject> object;
-        qpdf_offset_t end_before_space;
-        qpdf_offset_t end_after_space;
-    };
+    class ObjTable;
 
     class ObjCopier
     {
@@ -977,24 +945,7 @@ class QPDF
         QPDFObjGen og;
     };
 
-    class ResolveRecorder
-    {
-      public:
-        ResolveRecorder(QPDF* qpdf, QPDFObjGen const& og) :
-            qpdf(qpdf),
-            iter(qpdf->m->resolving.insert(og).first)
-        {
-        }
-        virtual ~ResolveRecorder()
-        {
-            this->qpdf->m->resolving.erase(iter);
-        }
-
-      private:
-        QPDF* qpdf;
-        std::set<QPDFObjGen>::const_iterator iter;
-    };
-
+    class ResolveRecorder;
     class JSONReactor;
 
     void parse(char const* password);
@@ -1036,8 +987,6 @@ class QPDF
     QPDFObjGen nextObjGen();
     QPDFObjectHandle newIndirect(QPDFObjGen const&, std::shared_ptr<QPDFObject> const&);
     QPDFObjectHandle makeIndirectFromQPDFObject(std::shared_ptr<QPDFObject> const& obj);
-    bool isCached(QPDFObjGen const& og);
-    bool isUnresolved(QPDFObjGen const& og);
     void removeObject(QPDFObjGen og);
     void updateCache(
         QPDFObjGen const& og,
@@ -1450,85 +1399,7 @@ class QPDF
         return QIntC::to_ulonglong(i);
     }
 
-    class Members
-    {
-        friend class QPDF;
-        friend class ResolveRecorder;
-
-      public:
-        QPDF_DLL
-        ~Members() = default;
-
-      private:
-        Members();
-        Members(Members const&) = delete;
-
-        std::shared_ptr<QPDFLogger> log;
-        unsigned long long unique_id{0};
-        QPDFTokenizer tokenizer;
-        std::shared_ptr<InputSource> file;
-        std::string last_object_description;
-        bool provided_password_is_hex_key{false};
-        bool ignore_xref_streams{false};
-        bool suppress_warnings{false};
-        bool attempt_recovery{true};
-        bool check_mode{false};
-        std::shared_ptr<EncryptionParameters> encp;
-        std::string pdf_version;
-        std::map<QPDFObjGen, QPDFXRefEntry> xref_table;
-        std::set<int> deleted_objects;
-        std::map<QPDFObjGen, ObjCache> obj_cache;
-        std::set<QPDFObjGen> resolving;
-        QPDFObjectHandle trailer;
-        std::vector<QPDFObjectHandle> all_pages;
-        std::map<QPDFObjGen, int> pageobj_to_pages_pos;
-        bool pushed_inherited_attributes_to_pages{false};
-        bool ever_pushed_inherited_attributes_to_pages{false};
-        bool ever_called_get_all_pages{false};
-        std::vector<QPDFExc> warnings;
-        std::map<unsigned long long, ObjCopier> object_copiers;
-        std::shared_ptr<QPDFObjectHandle::StreamDataProvider> copied_streams;
-        // copied_stream_data_provider is owned by copied_streams
-        CopiedStreamDataProvider* copied_stream_data_provider{nullptr};
-        bool reconstructed_xref{false};
-        bool fixed_dangling_refs{false};
-        bool immediate_copy_from{false};
-        bool in_parse{false};
-        bool parsed{false};
-        std::set<int> resolved_object_streams;
-
-        // Linearization data
-        qpdf_offset_t first_xref_item_offset{0}; // actual value from file
-        bool uncompressed_after_compressed{false};
-        bool linearization_warnings{false};
-
-        // Linearization parameter dictionary and hint table data: may be read from file or computed
-        // prior to writing a linearized file
-        QPDFObjectHandle lindict;
-        LinParameters linp;
-        HPageOffset page_offset_hints;
-        HSharedObject shared_object_hints;
-        HGeneric outline_hints;
-
-        // Computed linearization data: used to populate above tables during writing and to compare
-        // with them during validation. c_ means computed.
-        LinParameters c_linp;
-        CHPageOffset c_page_offset_data;
-        CHSharedObject c_shared_object_data;
-        HGeneric c_outline_data;
-
-        // Object ordering data for linearized files: initialized by calculateLinearizationData().
-        // Part numbers refer to the PDF 1.4 specification.
-        std::vector<QPDFObjectHandle> part4;
-        std::vector<QPDFObjectHandle> part6;
-        std::vector<QPDFObjectHandle> part7;
-        std::vector<QPDFObjectHandle> part8;
-        std::vector<QPDFObjectHandle> part9;
-
-        // Optimization data
-        std::map<ObjUser, std::set<QPDFObjGen>> obj_user_to_objects;
-        std::map<QPDFObjGen, std::set<ObjUser>> object_to_obj_users;
-    };
+    class Members;
 
     // Keep all member variables inside the Members object, which we dynamically allocate. This
     // makes it possible to add new private members without breaking binary compatibility.

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -583,7 +583,7 @@ QPDF::reconstruct_xref(QPDFExc& e)
             if (entry.getType() != 1) {
                 continue;
             }
-            auto oh = getObjectByObjGen(iter.first);
+            QPDFObjectHandle oh = m->obj_cache.getObject(iter.first);
             try {
                 if (!oh.isStreamOfType("/XRef")) {
                     continue;
@@ -1909,7 +1909,7 @@ QPDF::reserveObjectIfNotExists(QPDFObjGen const& og)
     if (m->xref_table.count(og) == 0) {
         return m->obj_cache.insert({og, QPDF_Reserved::create()})->second.object;
     } else {
-        return getObject(og);
+        return m->obj_cache.getObject(og);
     }
 }
 
@@ -1923,25 +1923,25 @@ QPDFObjectHandle
 QPDF::getObject(QPDFObjGen const& og)
 {
     // This method is called by the parser and therefore must not resolve any objects.
-    return m->obj_cache.insert({og, {QPDF_Unresolved::create(this, og)}})->second.object;
+    return {m->obj_cache.getObject(og.getObj(), og.getGen())};
 }
 
 QPDFObjectHandle
 QPDF::getObject(int objid, int generation)
 {
-    return getObject(QPDFObjGen(objid, generation));
+    return {m->obj_cache.getObject(objid, generation)};
 }
 
 QPDFObjectHandle
 QPDF::getObjectByObjGen(QPDFObjGen const& og)
 {
-    return getObject(og);
+    return {m->obj_cache.getObject(og.getObj(), og.getGen())};
 }
 
 QPDFObjectHandle
 QPDF::getObjectByID(int objid, int generation)
 {
-    return getObject(QPDFObjGen(objid, generation));
+    return {m->obj_cache.getObject(objid, generation)};
 }
 
 void

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1761,9 +1761,9 @@ QPDF::resolveObjectsInStream(int obj_stream_number)
 
     // For linearization data in the object, use the data from the object stream for the objects in
     // the stream.
-    QPDFObjGen stream_og(obj_stream_number, 0);
-    qpdf_offset_t end_before_space = m->obj_cache.entries[stream_og].end_before_space;
-    qpdf_offset_t end_after_space = m->obj_cache.entries[stream_og].end_after_space;
+    auto it = m->obj_cache.find(QPDFObjGen(obj_stream_number, 0));
+    qpdf_offset_t end_before_space = it->second.end_before_space;
+    qpdf_offset_t end_after_space = it->second.end_after_space;
 
     QPDFObjectHandle dict = obj_stream.getDict();
     if (!dict.isDictionaryOfType("/ObjStm")) {
@@ -2250,7 +2250,7 @@ QPDF::swapObjects(QPDFObjGen const& og1, QPDFObjGen const& og2)
     // Force objects to be read from the input source if needed, then swap them in the cache.
     resolve(og1);
     resolve(og2);
-    m->obj_cache.entries[og1].object->swapWith(m->obj_cache.entries[og2].object);
+    m->obj_cache.find(og1)->second.object->swapWith(m->obj_cache.find(og2)->second.object);
 }
 
 unsigned long long

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -13,7 +13,7 @@
 #include <qpdf/Pl_StdioFile.hh>
 #include <qpdf/Pl_String.hh>
 #include <qpdf/QIntC.hh>
-#include <qpdf/QPDF.hh>
+#include <qpdf/QPDF_private.hh>
 #include <qpdf/QPDFAcroFormDocumentHelper.hh>
 #include <qpdf/QPDFCryptoProvider.hh>
 #include <qpdf/QPDFEmbeddedFileDocumentHelper.hh>

--- a/libqpdf/QPDF_encryption.cc
+++ b/libqpdf/QPDF_encryption.cc
@@ -3,7 +3,7 @@
 
 #include <qpdf/assert_debug.h>
 
-#include <qpdf/QPDF.hh>
+#include <qpdf/QPDF_private.hh>
 
 #include <qpdf/QPDFExc.hh>
 

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -1,4 +1,4 @@
-#include <qpdf/QPDF.hh>
+#include <qpdf/QPDF_private.hh>
 
 #include <qpdf/FileInputSource.hh>
 #include <qpdf/Pl_Base64.hh>

--- a/libqpdf/QPDF_json.cc
+++ b/libqpdf/QPDF_json.cc
@@ -425,7 +425,7 @@ QPDF::JSONReactor::containerEnd(JSON const& value)
         for (auto& oc: pdf.m->obj_cache) {
             if (oc.second.object->getTypeCode() == ::ot_reserved && reserved.count(oc.first) == 0) {
                 QTC::TC("qpdf", "QPDF_json non-trivial null reserved");
-                pdf.updateCache(oc.first, QPDF_Null::create(), -1, -1);
+                pdf.m->obj_cache.insert_or_assign(oc.first, QPDF_Null::create());
             }
         }
     }

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -582,7 +582,7 @@ QPDF::getUncompressedObject(QPDFObjectHandle& obj, std::map<int, int> const& obj
         return obj;
     } else {
         int repl = (*(object_stream_data.find(obj.getObjectID()))).second;
-        return getObject(repl, 0);
+        return m->obj_cache.getObject(repl, 0);
     }
 }
 
@@ -1178,9 +1178,9 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
         stopOnError("found other than one root while"
                     " calculating linearization data");
     }
-    m->part4.push_back(getObject(*(lc_root.begin())));
+    m->part4.push_back(m->obj_cache.getObject(*(lc_root.begin())));
     for (auto const& og: lc_open_document) {
-        m->part4.push_back(getObject(og));
+        m->part4.push_back(m->obj_cache.getObject(og));
     }
 
     // Part 6: first page objects.  Note: implementation note 124 states that Acrobat always treats
@@ -1205,11 +1205,11 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
     // of hint tables.
 
     for (auto const& og: lc_first_page_private) {
-        m->part6.push_back(getObject(og));
+        m->part6.push_back(m->obj_cache.getObject(og));
     }
 
     for (auto const& og: lc_first_page_shared) {
-        m->part6.push_back(getObject(og));
+        m->part6.push_back(m->obj_cache.getObject(og));
     }
 
     // Place the outline dictionary if it goes in the first page section.
@@ -1252,7 +1252,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
         for (auto const& og: m->obj_user_to_objects[ou]) {
             if (lc_other_page_private.count(og)) {
                 lc_other_page_private.erase(og);
-                m->part7.push_back(getObject(og));
+                m->part7.push_back(m->obj_cache.getObject(og));
                 ++m->c_page_offset_data.entries.at(i).nobjects;
             }
         }
@@ -1268,7 +1268,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
 
     // Order is unimportant.
     for (auto const& og: lc_other_page_shared) {
-        m->part8.push_back(getObject(og));
+        m->part8.push_back(m->obj_cache.getObject(og));
     }
 
     // Part 9: other objects
@@ -1288,7 +1288,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
     for (auto const& og: pages_ogs) {
         if (lc_other.count(og)) {
             lc_other.erase(og);
-            m->part9.push_back(getObject(og));
+            m->part9.push_back(m->obj_cache.getObject(og));
         }
     }
 
@@ -1313,7 +1313,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
             for (auto const& og: ogs) {
                 if (lc_thumbnail_private.count(og)) {
                     lc_thumbnail_private.erase(og);
-                    m->part9.push_back(getObject(og));
+                    m->part9.push_back(m->obj_cache.getObject(og));
                 }
             }
         }
@@ -1325,7 +1325,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
 
     // Place shared thumbnail objects
     for (auto const& og: lc_thumbnail_shared) {
-        m->part9.push_back(getObject(og));
+        m->part9.push_back(m->obj_cache.getObject(og));
     }
 
     // Place outlines unless in first page
@@ -1335,7 +1335,7 @@ QPDF::calculateLinearizationData(std::map<int, int> const& object_stream_data)
 
     // Place all remaining objects
     for (auto const& og: lc_other) {
-        m->part9.push_back(getObject(og));
+        m->part9.push_back(m->obj_cache.getObject(og));
     }
 
     // Make sure we got everything exactly once.
@@ -1428,7 +1428,7 @@ QPDF::pushOutlinesToPart(
     lc_outlines.erase(outlines_og);
     part.push_back(outlines);
     for (auto const& og: lc_outlines) {
-        part.push_back(getObject(og));
+        part.push_back(m->obj_cache.getObject(og));
         ++m->c_outline_data.nobjects;
     }
 }

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -1,6 +1,6 @@
 // See doc/linearization.
 
-#include <qpdf/QPDF.hh>
+#include <qpdf/QPDF_private.hh>
 
 #include <qpdf/BitStream.hh>
 #include <qpdf/BitWriter.hh>
@@ -286,7 +286,7 @@ QPDF::readHintStream(Pipeline& pl, qpdf_offset_t offset, size_t length)
     QPDFObjGen og;
     QPDFObjectHandle H =
         readObjectAtOffset(false, offset, "linearization hint stream", QPDFObjGen(0, 0), og, false);
-    ObjCache& oc = m->obj_cache[og];
+    auto& oc = m->obj_cache.entries[og];
     qpdf_offset_t min_end_offset = oc.end_before_space;
     qpdf_offset_t max_end_offset = oc.end_after_space;
     if (!H.isStream()) {
@@ -304,7 +304,7 @@ QPDF::readHintStream(Pipeline& pl, qpdf_offset_t offset, size_t length)
         QTC::TC("qpdf", "QPDF hint table length indirect");
         // Force resolution
         (void)length_obj.getIntValue();
-        ObjCache& oc2 = m->obj_cache[length_obj.getObjGen()];
+        auto& oc2 = m->obj_cache.entries[length_obj.getObjGen()];
         min_end_offset = oc2.end_before_space;
         max_end_offset = oc2.end_after_space;
     } else {
@@ -511,11 +511,11 @@ QPDF::checkLinearizationInternal()
     qpdf_offset_t max_E = -1;
     for (auto const& oh: m->part6) {
         QPDFObjGen og(oh.getObjGen());
-        if (m->obj_cache.count(og) == 0) {
+        if (!m->obj_cache.contains(og)) {
             // All objects have to have been dereferenced to be classified.
             throw std::logic_error("linearization part6 object not in cache");
         }
-        ObjCache const& oc = m->obj_cache[og];
+        auto const& oc = m->obj_cache.entries[og];
         min_E = std::max(min_E, oc.end_before_space);
         max_E = std::max(max_E, oc.end_after_space);
     }
@@ -544,10 +544,10 @@ QPDF::maxEnd(ObjUser const& ou)
     }
     qpdf_offset_t end = 0;
     for (auto const& og: m->obj_user_to_objects[ou]) {
-        if (m->obj_cache.count(og) == 0) {
+        if (!m->obj_cache.contains(og)) {
             stopOnError("unknown object referenced in object user table");
         }
-        end = std::max(end, m->obj_cache[og].end_after_space);
+        end = std::max(end, m->obj_cache.entries[og].end_after_space);
     }
     return end;
 }
@@ -595,10 +595,10 @@ QPDF::lengthNextN(int first_object, int n)
             linearizationWarning(
                 "no xref table entry for " + std::to_string(first_object + i) + " 0");
         } else {
-            if (m->obj_cache.count(og) == 0) {
+            if (!m->obj_cache.contains(og)) {
                 stopOnError("found unknown object while calculating length for linearization data");
             }
-            length += toI(m->obj_cache[og].end_after_space - getLinearizationOffset(og));
+            length += toI(m->obj_cache.entries[og].end_after_space - getLinearizationOffset(og));
         }
     }
     return length;

--- a/libqpdf/QPDF_optimization.cc
+++ b/libqpdf/QPDF_optimization.cc
@@ -2,7 +2,7 @@
 
 #include <qpdf/assert_debug.h>
 
-#include <qpdf/QPDF.hh>
+#include <qpdf/QPDF_private.hh>
 
 #include <qpdf/QPDFExc.hh>
 #include <qpdf/QPDF_Array.hh>

--- a/libqpdf/QPDF_pages.cc
+++ b/libqpdf/QPDF_pages.cc
@@ -1,4 +1,4 @@
-#include <qpdf/QPDF.hh>
+#include <qpdf/QPDF_private.hh>
 
 #include <qpdf/QPDFExc.hh>
 #include <qpdf/QTC.hh>

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -130,12 +130,6 @@ class QPDFObject
     }
 
     void
-    setDefaultDescription(QPDF* qpdf, QPDFObjGen const& og)
-    {
-        // Intended for use by the QPDF class
-        value->setDefaultDescription(qpdf, og);
-    }
-    void
     setObjGen(QPDF* qpdf, QPDFObjGen const& og)
     {
         value->qpdf = qpdf;

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -65,12 +65,6 @@ class QPDFValue: public std::enable_shared_from_this<QPDFValue>
         setParsedOffset(offset);
     }
     void
-    setDefaultDescription(QPDF* a_qpdf, QPDFObjGen const& a_og)
-    {
-        qpdf = a_qpdf;
-        og = a_og;
-    }
-    void
     setChildDescription(
         QPDF* a_qpdf,
         std::shared_ptr<QPDFValue> parent,

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -21,7 +21,7 @@ class QPDF::ObjTable
         Entry() = default;
 
         Entry(
-            std::shared_ptr<QPDFObject> const& object,
+            std::shared_ptr<QPDFObject>&& object,
             qpdf_offset_t end_before_space = -1,
             qpdf_offset_t end_after_space = -1) :
             object(object),
@@ -112,6 +112,7 @@ class QPDF::ObjTable
         return entries.upper_bound(og);
     }
 
+  private:
     std::map<QPDFObjGen, Entry> entries;
     QPDF& qpdf;
 };

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -104,6 +104,8 @@ class QPDF::ObjTable
         return entries.insert(std::move(pair)).first;
     }
 
+    iterator insert_or_assign(QPDFObjGen oh, Entry&& obj);
+
     iterator
     upper_bound(QPDFObjGen og)
     {

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -5,6 +5,7 @@
 
 #include <qpdf/QPDFObject_private.hh>
 #include <qpdf/QPDF_Null.hh>
+#include <qpdf/QPDF_Unresolved.hh>
 
 // The object table is a combination of the previous object cache and (, in future,) the xref_table
 // (, as well as possibly other existing structures). It is a hybrid of a map and a vector indexed
@@ -95,6 +96,23 @@ class QPDF::ObjTable
     find(QPDFObjGen og)
     {
         return entries.find(og);
+    }
+
+    std::shared_ptr<QPDFObject>
+    getObject(int id, int gen = 0)
+    {
+        // This method is called by the parser and therefore must not resolve any objects.
+        return getObject(QPDFObjGen(id, gen));
+    }
+
+    std::shared_ptr<QPDFObject>
+    getObject(QPDFObjGen og)
+    {
+        // This method is called by the parser and therefore must not resolve any objects.
+        if (auto it = entries.find(og); it != entries.end()) {
+            return it->second.object;
+        }
+        return entries.insert({og, {QPDF_Unresolved::create(&qpdf, og)}}).first->second.object;
     }
 
     iterator

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -1,0 +1,229 @@
+#ifndef QPDF_PRIVATE_HH
+#define QPDF_PRIVATE_HH
+
+#include <qpdf/QPDF.hh>
+
+#include <qpdf/QPDFObject_private.hh>
+#include <qpdf/QPDF_Null.hh>
+
+// The object table is a combination of the previous object cache and (, in future,) the xref_table
+// (, as well as possibly other existing structures). It is a hybrid of a map and a vector indexed
+// (currently by objgen but in future) by object id, in that it allows random non-contiguous
+// insertion/ access as well as appending. The interface is modelled on std::map and std::vector as
+// appropriate. Return types are simplified where this reduces code. For validity of references and
+// iterators the worst case of std::map and std::vector should be assumed.
+class QPDF::ObjTable
+{
+  public:
+    class Entry
+    {
+      public:
+        Entry() = default;
+
+        Entry(
+            std::shared_ptr<QPDFObject> const& object,
+            qpdf_offset_t end_before_space = -1,
+            qpdf_offset_t end_after_space = -1) :
+            object(object),
+            end_before_space(end_before_space),
+            end_after_space(end_after_space)
+        {
+        }
+
+        std::shared_ptr<QPDFObject> object;
+        qpdf_offset_t end_before_space{0};
+        qpdf_offset_t end_after_space{0};
+    };
+
+    using iterator = std::map<QPDFObjGen, Entry>::iterator;
+    using const_reverse_iterator = std::map<QPDFObjGen, Entry>::const_reverse_iterator;
+
+    ObjTable(QPDF& qpdf) :
+        qpdf(qpdf)
+    {
+    }
+
+    iterator
+    begin() noexcept
+    {
+        return entries.begin();
+    }
+
+    iterator
+    end() noexcept
+    {
+        return entries.end();
+    }
+
+    const_reverse_iterator
+    crbegin() const noexcept
+    {
+        return entries.crbegin();
+    }
+
+    bool
+    contains(QPDFObjGen og)
+    {
+        return entries.count(og) != 0;
+    }
+
+    bool
+    containsResolved(QPDFObjGen og)
+    {
+        auto it = entries.find(og);
+        return it != entries.end() && it->second.object->getTypeCode() != ::ot_unresolved;
+    }
+
+    bool
+    empty()
+    {
+        return entries.empty();
+    }
+
+    void
+    erase(QPDFObjGen og)
+    {
+        static std::shared_ptr<QPDFObject> null = QPDF_Null::create();
+        if (auto cached = entries.find(og); cached != entries.end()) {
+            // Take care of any object handles that may be floating around.
+            cached->second.object->assign(null);
+            entries.erase(cached);
+        }
+    }
+
+    iterator
+    find(QPDFObjGen og)
+    {
+        return entries.find(og);
+    }
+
+    iterator
+    insert(std::pair<QPDFObjGen const, Entry>&& pair)
+    {
+        pair.second.object->setObjGen(&qpdf, pair.first);
+        return entries.insert(std::move(pair)).first;
+    }
+
+    iterator
+    upper_bound(QPDFObjGen og)
+    {
+        return entries.upper_bound(og);
+    }
+
+    std::map<QPDFObjGen, Entry> entries;
+    QPDF& qpdf;
+};
+
+class QPDF::Members
+{
+    friend class QPDF;
+    friend class ResolveRecorder;
+
+  public:
+    QPDF_DLL
+    ~Members() = default;
+
+  private:
+    Members(QPDF& qpdf);
+    Members(Members const&) = delete;
+
+    std::shared_ptr<QPDFLogger> log;
+    unsigned long long unique_id{0};
+    QPDFTokenizer tokenizer;
+    std::shared_ptr<InputSource> file;
+    std::string last_object_description;
+    bool provided_password_is_hex_key{false};
+    bool ignore_xref_streams{false};
+    bool suppress_warnings{false};
+    bool attempt_recovery{true};
+    bool check_mode{false};
+    std::shared_ptr<EncryptionParameters> encp;
+    std::string pdf_version;
+    std::map<QPDFObjGen, QPDFXRefEntry> xref_table;
+    std::set<int> deleted_objects;
+    ObjTable obj_cache;
+    std::set<QPDFObjGen> resolving;
+    QPDFObjectHandle trailer;
+    std::vector<QPDFObjectHandle> all_pages;
+    std::map<QPDFObjGen, int> pageobj_to_pages_pos;
+    bool pushed_inherited_attributes_to_pages{false};
+    bool ever_pushed_inherited_attributes_to_pages{false};
+    bool ever_called_get_all_pages{false};
+    std::vector<QPDFExc> warnings;
+    std::map<unsigned long long, ObjCopier> object_copiers;
+    std::shared_ptr<QPDFObjectHandle::StreamDataProvider> copied_streams;
+    // copied_stream_data_provider is owned by copied_streams
+    CopiedStreamDataProvider* copied_stream_data_provider{nullptr};
+    bool reconstructed_xref{false};
+    bool fixed_dangling_refs{false};
+    bool immediate_copy_from{false};
+    bool in_parse{false};
+    bool parsed{false};
+    std::set<int> resolved_object_streams;
+
+    // Linearization data
+    qpdf_offset_t first_xref_item_offset{0}; // actual value from file
+    bool uncompressed_after_compressed{false};
+    bool linearization_warnings{false};
+
+    // Linearization parameter dictionary and hint table data: may be read from file or computed
+    // prior to writing a linearized file
+    QPDFObjectHandle lindict;
+    LinParameters linp;
+    HPageOffset page_offset_hints;
+    HSharedObject shared_object_hints;
+    HGeneric outline_hints;
+
+    // Computed linearization data: used to populate above tables during writing and to compare
+    // with them during validation. c_ means computed.
+    LinParameters c_linp;
+    CHPageOffset c_page_offset_data;
+    CHSharedObject c_shared_object_data;
+    HGeneric c_outline_data;
+
+    // Object ordering data for linearized files: initialized by calculateLinearizationData().
+    // Part numbers refer to the PDF 1.4 specification.
+    std::vector<QPDFObjectHandle> part4;
+    std::vector<QPDFObjectHandle> part6;
+    std::vector<QPDFObjectHandle> part7;
+    std::vector<QPDFObjectHandle> part8;
+    std::vector<QPDFObjectHandle> part9;
+
+    // Optimization data
+    std::map<ObjUser, std::set<QPDFObjGen>> obj_user_to_objects;
+    std::map<QPDFObjGen, std::set<ObjUser>> object_to_obj_users;
+};
+
+// JobSetter class is restricted to QPDFJob.
+class QPDF::JobSetter
+{
+    friend class QPDFJob;
+
+  private:
+    // Enable enhanced warnings for pdf file checking.
+    static void
+    setCheckMode(QPDF& qpdf, bool val)
+    {
+        qpdf.m->check_mode = val;
+    }
+};
+
+class QPDF::ResolveRecorder
+{
+  public:
+    ResolveRecorder(QPDF* qpdf, QPDFObjGen const& og) :
+        qpdf(qpdf),
+        iter(qpdf->m->resolving.insert(og).first)
+    {
+    }
+    virtual ~ResolveRecorder()
+    {
+        this->qpdf->m->resolving.erase(iter);
+    }
+
+  private:
+    QPDF* qpdf;
+    std::set<QPDFObjGen>::const_iterator iter;
+};
+
+#endif // QPDF_PRIVATE_HH


### PR DESCRIPTION
This PR contains some preparatory work for ensuring that the object cache only contains null entries for deleted objects.

As the approach taken may be controversial some early feedback would be useful.

(This is a very early draft with obvious omissions, eg deleting constructors, controlling access, etc)