### PR TITLE
Tighten checks for invalid indirect references in QPDFParser

### DIFF
--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -163,16 +163,15 @@ QPDFParser::parseRemainder(bool content_stream)
                     throw std::logic_error("QPDFParser::parse called without context on an object "
                                            "with indirect references");
                 }
-                auto ref_og = QPDFObjGen(
-                    QIntC::to_int(int_buffer[(int_count - 1) % 2]),
-                    QIntC::to_int(int_buffer[(int_count) % 2]));
-                if (ref_og.isIndirect()) {
+                auto id = QIntC::to_int(int_buffer[(int_count - 1) % 2]);
+                auto gen = QIntC::to_int(int_buffer[(int_count) % 2]);
+                if (!(id < 1 || gen < 0 || gen >= 65535)) {
                     // This action has the desirable side effect of causing dangling references
                     // (references to indirect objects that don't appear in the PDF) in any parsed
                     // object to appear in the object cache.
-                    add(std::move(context->getObject(ref_og).obj));
+                    add(std::move(context->getObject(id, gen).obj));
                 } else {
-                    QTC::TC("qpdf", "QPDFParser indirect with 0 objid");
+                    QTC::TC("qpdf", "QPDFParser invalid objgen");
                     addNull();
                 }
                 int_count = 0;

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -256,7 +256,7 @@ QPDFWriter standard deterministic ID 1
 QPDFWriter linearized deterministic ID 1
 QPDFWriter deterministic with no data 0
 qpdf-c called qpdf_set_deterministic_ID 0
-QPDFParser indirect with 0 objid 0
+QPDFParser invalid objgen 0
 QPDF object id 0 0
 QPDF recursion loop in resolve 0
 QPDFParser treat word as string 0

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1202,6 +1202,10 @@ test_31(QPDF& pdf, char const* arg2)
     assert(QPDFObjectHandle::parse(&pdf, ">>").unparse() == "null");
     // TC:QPDFParser eof in parse
     assert(QPDFObjectHandle::parse(&pdf, "[7 0 R]").getArrayItem(0).isNull());
+    // TC:QPDFParser invalid objgen
+    assert(
+        QPDFObjectHandle::parse(&pdf, "[0 0 R -1 0 R 1 65535 R 1 100000 R 1 -1 R]").unparse() ==
+        "[ null null null null null ]");
 }
 
 static void


### PR DESCRIPTION
I have extended the practice of silently replacing 0 0 R with null to all invalid references. While I don't think that the detail of these repairs is of interest to most users, I am not sure that qpdf should report that it succeeded without errors in this case. 