### PR TITLE
Tighten checks for invalid indirect references  during xref reconstru…

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1195,6 +1195,10 @@ QPDF::insertFreeXrefEntry(QPDFObjGen og)
 void
 QPDF::insertReconstructedXrefEntry(int obj, qpdf_offset_t f1, int f2)
 {
+    if (!(obj > 0 && 0 <= f2 && f2 < 65535)) {
+        QTC::TC("qpdf", "QPDF xref overwrite invalid objgen");
+        return;
+    }
     QPDFObjGen og(obj, f2);
     if (!m->deleted_objects.count(obj)) {
         // deleted_objects stores the uncompressed objects removed from the xref table at the start

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -105,6 +105,7 @@ QPDF_encryption xref stream from encrypted file 0
 QPDFJob unable to filter 0
 QUtil non-trivial UTF-16 0
 QPDF xref overwrite object 0
+QPDF xref overwrite invalid objgen 0
 QPDF decoding error warning 0
 qpdf-c called qpdf_init 0
 qpdf-c called qpdf_cleanup 0

--- a/qpdf/qtest/qpdf/obj0-check.out
+++ b/qpdf/qtest/qpdf/obj0-check.out
@@ -5,5 +5,4 @@ checking obj0.pdf
 PDF Version: 1.3
 File is not encrypted
 File is not linearized
-WARNING: obj0.pdf (offset 15): object with ID 0
 qpdf: operation succeeded with warnings


### PR DESCRIPTION
…ction

I don't think having a specific warning here is useful - we already know that the file is damaged. I think a message here would just the flood of spurious messages for severely damaged files.

Do we need any specific test cases?