### PR TITLE
Refactor Pl_TIFFPredictor 

### DIFF
--- a/libqpdf/Pl_TIFFPredictor.cc
+++ b/libqpdf/Pl_TIFFPredictor.cc
@@ -35,8 +35,7 @@ Pl_TIFFPredictor::Pl_TIFFPredictor(
         throw std::runtime_error("TIFFPredictor created with invalid columns value");
     }
     this->bytes_per_row = bpr & UINT_MAX;
-    this->cur_row = QUtil::make_shared_array<unsigned char>(this->bytes_per_row);
-    memset(this->cur_row.get(), 0, this->bytes_per_row);
+    this->cur_row.assign(this->bytes_per_row, 0);
 }
 
 void
@@ -46,19 +45,19 @@ Pl_TIFFPredictor::write(unsigned char const* data, size_t len)
     size_t offset = 0;
     while (len >= left) {
         // finish off current row
-        memcpy(this->cur_row.get() + this->pos, data + offset, left);
+        memcpy(this->cur_row.data() + this->pos, data + offset, left);
         offset += left;
         len -= left;
 
         processRow();
 
         // Prepare for next row
-        memset(this->cur_row.get(), 0, this->bytes_per_row);
+        this->cur_row.assign(this->bytes_per_row, 0);
         left = this->bytes_per_row;
         this->pos = 0;
     }
     if (len) {
-        memcpy(this->cur_row.get() + this->pos, data + offset, len);
+        memcpy(this->cur_row.data() + this->pos, data + offset, len);
     }
     this->pos += len;
 }
@@ -68,7 +67,7 @@ Pl_TIFFPredictor::processRow()
 {
     QTC::TC("libtests", "Pl_TIFFPredictor processRow", (action == a_decode ? 0 : 1));
     BitWriter bw(this->getNext());
-    BitStream in(this->cur_row.get(), this->bytes_per_row);
+    BitStream in(this->cur_row.data(), this->bytes_per_row);
     std::vector<long long> prev;
     for (unsigned int i = 0; i < this->samples_per_pixel; ++i) {
         long long sample = in.getBitsSigned(this->bits_per_sample);
@@ -100,6 +99,6 @@ Pl_TIFFPredictor::finish()
         processRow();
     }
     this->pos = 0;
-    memset(this->cur_row.get(), 0, this->bytes_per_row);
+    this->cur_row.assign(this->bytes_per_row, 0);
     getNext()->finish();
 }

--- a/libqpdf/Pl_TIFFPredictor.cc
+++ b/libqpdf/Pl_TIFFPredictor.cc
@@ -19,7 +19,8 @@ Pl_TIFFPredictor::Pl_TIFFPredictor(
     action(action),
     columns(columns),
     samples_per_pixel(samples_per_pixel),
-    bits_per_sample(bits_per_sample)
+    bits_per_sample(bits_per_sample),
+    p_next(getNext())
 {
     if (samples_per_pixel < 1) {
         throw std::runtime_error("TIFFPredictor created with invalid samples_per_pixel");
@@ -58,7 +59,7 @@ void
 Pl_TIFFPredictor::processRow()
 {
     QTC::TC("libtests", "Pl_TIFFPredictor processRow", (action == a_decode ? 0 : 1));
-    BitWriter bw(this->getNext());
+    BitWriter bw(p_next);
     BitStream in(this->cur_row.data(), this->bytes_per_row);
     std::vector<long long> prev;
     for (unsigned int i = 0; i < this->samples_per_pixel; ++i) {
@@ -92,5 +93,5 @@ Pl_TIFFPredictor::finish()
         processRow();
     }
     cur_row.clear();
-    getNext()->finish();
+    p_next->finish();
 }

--- a/libqpdf/Pl_TIFFPredictor.cc
+++ b/libqpdf/Pl_TIFFPredictor.cc
@@ -6,8 +6,6 @@
 
 #include <climits>
 #include <stdexcept>
-#include <vector>
-#include <iostream>
 
 Pl_TIFFPredictor::Pl_TIFFPredictor(
     char const* identifier,
@@ -62,14 +60,9 @@ Pl_TIFFPredictor::processRow()
     QTC::TC("libtests", "Pl_TIFFPredictor processRow", (action == a_decode ? 0 : 1));
     BitWriter bw(p_next);
     BitStream in(cur_row.data(), cur_row.size());
-    previous.clear();
-    for (unsigned int i = 0; i < this->samples_per_pixel; ++i) {
-        long long sample = in.getBitsSigned(this->bits_per_sample);
-        bw.writeBitsSigned(sample, this->bits_per_sample);
-        previous.push_back(sample);
-    }
-    for (unsigned int col = 1; col < this->columns; ++col) {
-        for (auto& prev : previous) {
+    previous.assign(samples_per_pixel, 0);
+    for (unsigned int col = 0; col < this->columns; ++col) {
+        for (auto& prev: previous) {
             long long sample = in.getBitsSigned(this->bits_per_sample);
             long long new_sample = sample;
             if (action == a_encode) {

--- a/libqpdf/Pl_TIFFPredictor.cc
+++ b/libqpdf/Pl_TIFFPredictor.cc
@@ -78,6 +78,7 @@ Pl_TIFFPredictor::processRow()
         }
         bw.flush();
     } else {
+        out.clear();
         auto next = cur_row.begin();
         auto cr_end = cur_row.end();
         auto pr_end = previous.end();
@@ -93,10 +94,10 @@ Pl_TIFFPredictor::processRow()
                     new_sample += *prev;
                     *prev = new_sample;
                 }
-                auto out = static_cast<unsigned char>(255U & new_sample);
-                p_next->write(&out, 1);
+                out.push_back(static_cast<unsigned char>(255U & new_sample));
             }
         }
+        p_next->write(out.data(), out.size());
     }
 }
 

--- a/libqpdf/Pl_TIFFPredictor.cc
+++ b/libqpdf/Pl_TIFFPredictor.cc
@@ -37,23 +37,21 @@ Pl_TIFFPredictor::Pl_TIFFPredictor(
 void
 Pl_TIFFPredictor::write(unsigned char const* data, size_t len)
 {
-    size_t left = this->bytes_per_row - cur_row.size();
-    size_t offset = 0;
-    while (len >= left) {
+    auto end = data + len;
+    auto row_end = data + (bytes_per_row - cur_row.size());
+    while (row_end <= end) {
         // finish off current row
-        cur_row.insert(cur_row.end(), data + offset, data + offset + left);
-        offset += left;
-        len -= left;
+        cur_row.insert(cur_row.end(), data, row_end);
+        data = row_end;
+        row_end += bytes_per_row;
 
         processRow();
 
         // Prepare for next row
-        this->cur_row.clear();
-        left = this->bytes_per_row;
+        cur_row.clear();
     }
-    if (len) {
-        cur_row.insert(cur_row.end(), data + offset, data + offset + len);
-    }
+
+    cur_row.insert(cur_row.end(), data, end);
 }
 
 void

--- a/libqpdf/qpdf/Pl_TIFFPredictor.hh
+++ b/libqpdf/qpdf/Pl_TIFFPredictor.hh
@@ -35,6 +35,7 @@ class Pl_TIFFPredictor: public Pipeline
     unsigned int bits_per_sample;
     std::vector<unsigned char> cur_row;
     std::vector<long long> previous;
+    std::vector<unsigned char> out;
     Pipeline* p_next;
 };
 

--- a/libqpdf/qpdf/Pl_TIFFPredictor.hh
+++ b/libqpdf/qpdf/Pl_TIFFPredictor.hh
@@ -34,6 +34,7 @@ class Pl_TIFFPredictor: public Pipeline
     unsigned int samples_per_pixel;
     unsigned int bits_per_sample;
     std::vector<unsigned char> cur_row;
+    Pipeline* p_next;
 };
 
 #endif // PL_TIFFPREDICTOR_HH

--- a/libqpdf/qpdf/Pl_TIFFPredictor.hh
+++ b/libqpdf/qpdf/Pl_TIFFPredictor.hh
@@ -6,6 +6,8 @@
 
 #include <qpdf/Pipeline.hh>
 
+#include<vector>
+
 class Pl_TIFFPredictor: public Pipeline
 {
   public:
@@ -31,7 +33,7 @@ class Pl_TIFFPredictor: public Pipeline
     unsigned int bytes_per_row;
     unsigned int samples_per_pixel;
     unsigned int bits_per_sample;
-    std::shared_ptr<unsigned char> cur_row;
+    std::vector<unsigned char> cur_row;
     size_t pos;
 };
 

--- a/libqpdf/qpdf/Pl_TIFFPredictor.hh
+++ b/libqpdf/qpdf/Pl_TIFFPredictor.hh
@@ -34,7 +34,6 @@ class Pl_TIFFPredictor: public Pipeline
     unsigned int samples_per_pixel;
     unsigned int bits_per_sample;
     std::vector<unsigned char> cur_row;
-    size_t pos;
 };
 
 #endif // PL_TIFFPREDICTOR_HH

--- a/libqpdf/qpdf/Pl_TIFFPredictor.hh
+++ b/libqpdf/qpdf/Pl_TIFFPredictor.hh
@@ -34,6 +34,7 @@ class Pl_TIFFPredictor: public Pipeline
     unsigned int samples_per_pixel;
     unsigned int bits_per_sample;
     std::vector<unsigned char> cur_row;
+    std::vector<long long> previous;
     Pipeline* p_next;
 };
 


### PR DESCRIPTION
Use standard library instead of memcpy and raw pointers.

For the last 7 days crashes have been running at over 500 per day. Probably worth seeing whether this makes a difference 