### PR TITLE
Fix previous fix to setting checkbox value (fixes #1056)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2024-02-11  Jay Berkenbilt  <ejb@ql.org>
+
+	* The previous fix to #1056 was incomplete. When setting a check
+	box value, the previous fix allowed any value other than /Off to
+	mean checked. Now we also set the actual value based on the
+	allowable non-/Off value in the normal appearance dictionary.
+	Fixes #1056.
+
 2024-02-03  Jay Berkenbilt  <ejb@ql.org>
 
 	* Add fuzz testing for JSON.

--- a/include/qpdf/QPDFFormFieldObjectHelper.hh
+++ b/include/qpdf/QPDFFormFieldObjectHelper.hh
@@ -166,7 +166,9 @@ class QPDFFormFieldObjectHelper: public QPDFObjectHelper
     // either /Tx (text) or /Ch (choice), set /NeedAppearances to true. You can explicitly tell this
     // method not to set /NeedAppearances if you are going to generate an appearance stream
     // yourself. Starting with qpdf 8.3.0, this method handles fields of type /Btn (checkboxes,
-    // radio buttons, pushbuttons) specially.
+    // radio buttons, pushbuttons) specially. When setting a checkbox value, any value other than
+    // /Off will be treated as on, and the actual value set will be based on the appearance stream's
+    // /N dictionary, so the value that ends up in /V may not exactly match the value you pass in.
     QPDF_DLL
     void setV(QPDFObjectHandle value, bool need_appearances = true);
 

--- a/qpdf/qtest/qpdf/button-set-out.pdf
+++ b/qpdf/qtest/qpdf/button-set-out.pdf
@@ -122,7 +122,7 @@ endobj
   >>
   /P 15 0 R
   /T (checkbox1)
-  /V /Yes
+  /V /Yup
 >>
 endobj
 
@@ -589,10 +589,10 @@ endobj
   /AP <<
     /N <<
       /Off 64 0 R
-      /Yes 66 0 R
+      /Yup 66 0 R
     >>
   >>
-  /AS /Yes
+  /AS /Yup
   /F 4
   /Rect [
     118.649

--- a/qpdf/qtest/qpdf/button-set.pdf
+++ b/qpdf/qtest/qpdf/button-set.pdf
@@ -3481,7 +3481,7 @@ endobj
   /AP <<
     /N <<
       /Off 24 0 R
-      /Yes 26 0 R
+      /Yup 26 0 R
     >>
   >>
   /AS /Off

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -1942,7 +1942,9 @@ test_51(QPDF& pdf, char const* arg2)
         } else if (Tval == "checkbox1") {
             std::cout << "turning checkbox1 on\n";
             QPDFFormFieldObjectHelper foh(field);
-            foh.setV(QPDFObjectHandle::newName("/Yes"));
+            // The value that eventually gets set is based on what's allowed in /N and may not match
+            // this value.
+            foh.setV(QPDFObjectHandle::newName("/Sure"));
         } else if (Tval == "checkbox2") {
             std::cout << "turning checkbox2 off\n";
             QPDFFormFieldObjectHelper foh(field);


### PR DESCRIPTION
The code accepted values other than /Yes but still used /Yes as the checked value instead of obeying the normal appearance dictionary.