### PR TITLE
Try overriding branch name in CodeCov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,10 +130,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: 'Code Coverage'
         run: build-scripts/test-coverage
+      - id: set_branch
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "override_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+          else
+            echo "override_branch=" >> $GITHUB_OUTPUT
+          fi
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          override_branch: ${{ steps.set_branch.outputs.override_branch }}
   QuickJobs:
     runs-on: ubuntu-latest
     needs: Prebuild


### PR DESCRIPTION
As of this moment, if a specific commit's coverage data is uploaded to CodeCov via a pull request, when that exact same commit builds in main, the branch is not associated with the commit. I'm hoping this might work around that.