### PR TITLE
Remove non-standard string_view<unsigned char> from QPDF_Name

### DIFF
--- a/libqpdf/QPDF_Name.cc
+++ b/libqpdf/QPDF_Name.cc
@@ -3,8 +3,6 @@
 #include <qpdf/JSON_writer.hh>
 #include <qpdf/QUtil.hh>
 
-#include <string_view>
-
 QPDF_Name::QPDF_Name(std::string const& name) :
     QPDFValue(::ot_name, "name"),
     name(name)
@@ -57,14 +55,12 @@ QPDF_Name::unparse()
 std::pair<bool, bool>
 QPDF_Name::analyzeJSONEncoding(const std::string& name)
 {
-    std::basic_string_view<unsigned char> view{
-        reinterpret_cast<const unsigned char*>(name.data()), name.size()};
-
     int tail = 0;       // Number of continuation characters expected.
     bool tail2 = false; // Potential overlong 3 octet utf-8.
     bool tail3 = false; // potential overlong 4 octet
     bool needs_escaping = false;
-    for (auto const& c: view) {
+    for (auto it = name.begin(); it != name.end(); ++it) {
+        unsigned char c = static_cast<unsigned char>(*it);
         if (tail) {
             if ((c & 0xc0) != 0x80) {
                 return {false, false};


### PR DESCRIPTION
string_view<unsigned char> leads to char_traits<unsigned char> which is not standard C++ (background in https://github.com/qpdf/qpdf/issues/1024).

This triggers compilation failures with certain C++20 compiler configurations.

To avoid this I moved the cast to the loop's range declaration. This should work (for 8-bit characters) despite switching from an explicit cast to an integral conversion, per the following C++17 standards text:

> For each value i of type unsigned char in the range 0 to 255 inclusive, there exists a value j of type char such that the result of an integral conversion from i to char is j, and the result of an integral conversion from j to unsigned char is i.

But if you want me to be more explicit and keep the reinterpret_cast at the cost of an extra line or two I'd be happy to.

https://github.com/qpdf/qpdf/issues/1024
