### PR TITLE
Add bad xref table test

### DIFF
--- a/qpdf/qtest/qpdf/bad-xref.pdf
+++ b/qpdf/qtest/qpdf/bad-xref.pdf
@@ -1,0 +1,104 @@
+%PDF-1.3
+1 0 obj
+<<
+  /Type /Catalog
+  /Pages 2 0 R
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Pages
+  /Kids [
+    3 0 R
+  ]
+  /Count 1
+>>
+endobj
+
+3 0 obj
+<<
+  /Type /Page
+  /Parent 2 0 R
+  /MediaBox [0 0 612 792]
+  /Contents 4 0 R
+  /Resources <<
+    /ProcSet 5 0 R
+    /Font <<
+      /F1 6 0 R
+    >>
+  >>
+>>
+endobj
+
+4 0 obj
+<<
+  /Length 44
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Potato) Tj
+ET
+endstream
+endobj
+
+5 0 obj
+[
+  /PDF
+  /Text
+]
+endobj
+
+6 0 obj
+<<
+  /Type /Font
+  /Subtype /Type1
+  /Name /F1
+  /BaseFont /Helvetica
+  /Encoding /WinAnsiEncoding
+>>
+endobj
+
+xref
+0 7
+0000000000 65535 f don't panick 
+0000000009 00000 n life is too short 
+0000000063 00000 n 
+
+
+
+
+
+0000000135 00000 n 
+0000000307 00000 n 
+0000000403 00000 n 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+0000000438 00000 n 
+trailer <<
+  /Size 7
+  /Root 1 0 R
+>>
+startxref
+556
+%%EOF

--- a/qpdf/qtest/xref-errors.test
+++ b/qpdf/qtest/xref-errors.test
@@ -14,7 +14,7 @@ cleanup();
 
 my $td = new TestDriver('xref-errors');
 
-my $n_tests = 6;
+my $n_tests = 7;
 
 # Handle file with invalid xref table and object 0 as a regular object
 # (bug 3159950).
@@ -61,6 +61,11 @@ $td->runtest("out of range in deleted object",
              {$td->COMMAND => "qpdf --check xref-range.pdf"},
              {$td->FILE => "xref-range.out", $td->EXIT_STATUS => 0},
              $td->NORMALIZE_NEWLINES);
+
+$td->runtest("extra text in xref table",
+             {$td->COMMAND => "qpdf --check bad-xref.pdf"},
+             {$td->STRING => "", $td->EXIT_STATUS => 3},
+             $td->EXPECT_FAILURE);
 
 cleanup();
 $td->report($n_tests);


### PR DESCRIPTION
I think the test should produce a "accepting invalid xref table entry" warning and exit code 3.

xref table:
```
xref
0 7
0000000000 65535 f don't panick 
0000000009 00000 n life is too short 
0000000063 00000 n 





0000000135 00000 n 
0000000307 00000 n 
0000000403 00000 n 




















0000000438 00000 n 
trailer <<
```