### PR TITLE
QPDF::processXRefStream

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1032,7 +1032,7 @@ class QPDF
     processXRefW(QPDFObjectHandle& dict, std::function<QPDFExc(std::string_view)> damaged);
     int processXRefSize(
         QPDFObjectHandle& dict, int entry_size, std::function<QPDFExc(std::string_view)> damaged);
-    std::pair<int, std::vector<long long>> processXRefIndex(
+    std::pair<int, std::vector<std::pair<int, int>>> processXRefIndex(
         QPDFObjectHandle& dict,
         int max_num_entries,
         std::function<QPDFExc(std::string_view)> damaged);

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1028,6 +1028,8 @@ class QPDF
     qpdf_offset_t read_xrefTable(qpdf_offset_t offset);
     qpdf_offset_t read_xrefStream(qpdf_offset_t offset);
     qpdf_offset_t processXRefStream(qpdf_offset_t offset, QPDFObjectHandle& xref_stream);
+    std::pair<size_t, std::array<int, 3>>
+    processXRefW(QPDFObjectHandle& dict, std::function<QPDFExc(std::string_view)> damaged);
     std::pair<size_t, std::vector<long long>> processXRefIndex(
         QPDFObjectHandle& dict,
         size_t entry_size,

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1028,6 +1028,10 @@ class QPDF
     qpdf_offset_t read_xrefTable(qpdf_offset_t offset);
     qpdf_offset_t read_xrefStream(qpdf_offset_t offset);
     qpdf_offset_t processXRefStream(qpdf_offset_t offset, QPDFObjectHandle& xref_stream);
+    std::pair<size_t, std::vector<long long>> processXRefIndex(
+        QPDFObjectHandle& dict,
+        size_t entry_size,
+        std::function<QPDFExc(std::string_view)> damaged);
     void insertXrefEntry(int obj, int f0, qpdf_offset_t f1, int f2);
     void insertFreeXrefEntry(QPDFObjGen);
     void insertReconstructedXrefEntry(int obj, qpdf_offset_t f1, int f2);

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1028,11 +1028,13 @@ class QPDF
     qpdf_offset_t read_xrefTable(qpdf_offset_t offset);
     qpdf_offset_t read_xrefStream(qpdf_offset_t offset);
     qpdf_offset_t processXRefStream(qpdf_offset_t offset, QPDFObjectHandle& xref_stream);
-    std::pair<size_t, std::array<int, 3>>
+    std::pair<int, std::array<int, 3>>
     processXRefW(QPDFObjectHandle& dict, std::function<QPDFExc(std::string_view)> damaged);
-    std::pair<size_t, std::vector<long long>> processXRefIndex(
+    int processXRefSize(
+        QPDFObjectHandle& dict, int entry_size, std::function<QPDFExc(std::string_view)> damaged);
+    std::pair<int, std::vector<long long>> processXRefIndex(
         QPDFObjectHandle& dict,
-        size_t entry_size,
+        int max_num_entries,
         std::function<QPDFExc(std::string_view)> damaged);
     void insertXrefEntry(int obj, int f0, qpdf_offset_t f1, int f2);
     void insertFreeXrefEntry(QPDFObjGen);


### PR DESCRIPTION
Break processXRefStream into smaller methods.

Other changes:
- simplify some pointer arithmetic
- simplify calculation of object ids / handling of subsection transitions by adding an outer loop of subsections around the loop of entries
- change the processed Index array into an array of pairs <first object id, number of entries> to simplify
- simplify int casting