### PR TITLE
Iterative update object maps

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -4,6 +4,7 @@
     <configurations>
       <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" />
       <configuration PROFILE_NAME="Maintainer" ENABLED="true" CONFIG_NAME="RelWithDebInfo" GENERATION_OPTIONS="-DMAINTAINER_MODE=ON -DBUILD_STATIC_LIBS=OFF" />
+      <configuration PROFILE_NAME="Windows" ENABLED="true" CONFIG_NAME="RelWithDebInfo" TOOLCHAIN_NAME="Visual Studio" GENERATION_OPTIONS="-DBUILD_SHARED_LIBS=OFF" />
     </configurations>
   </component>
 </project>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,9 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <SqlCodeStyleSettings version="6">
+    <RiderCodeStyleSettings>
+      <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/EnableClangFormatSupport/@EntryValue" value="true" type="bool" />
+    </RiderCodeStyleSettings>
+    <SqlCodeStyleSettings version="7">
       <option name="KEYWORD_CASE" value="2" />
     </SqlCodeStyleSettings>
     <clangFormatSettings>

--- a/.idea/editor.xml
+++ b/.idea/editor.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="BackendCodeEditorSettings">
+    <option name="/Default/Housekeeping/GlobalSettingsUpgraded/IsUpgraded/@EntryValue" value="true" type="bool" />
+    <option name="/Default/CodeStyle/CodeFormatting/CppClangFormat/EnableClangFormatSupport/@EntryValue" value="true" type="bool" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CMakePythonSetting">
+    <option name="pythonIntegrationState" value="YES" />
+  </component>
   <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
 </project>

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1343,6 +1343,18 @@ class QPDF
         std::string key; // if ou_trailer_key or ou_root_key
     };
 
+    struct UpdateObjectMapsFrame
+    {
+        UpdateObjectMapsFrame(
+            ObjUser const& ou,
+            QPDFObjectHandle oh,
+            bool top);
+
+        ObjUser const& ou;
+        QPDFObjectHandle oh;
+        bool top;
+    };
+
     class PatternFinder: public InputSource::Finder
     {
       public:
@@ -1426,12 +1438,6 @@ class QPDF
         ObjUser const& ou,
         QPDFObjectHandle oh,
         std::function<int(QPDFObjectHandle&)> skip_stream_parameters);
-    void updateObjectMapsInternal(
-        ObjUser const& ou,
-        QPDFObjectHandle oh,
-        std::function<int(QPDFObjectHandle&)> skip_stream_parameters,
-        QPDFObjGen::set& visited,
-        bool top);
     void filterCompressedObjects(std::map<int, int> const& object_stream_data);
     void filterCompressedObjects(QPDFWriter::ObjTable const& object_stream_data);
 


### PR DESCRIPTION
@m-holger Would you mind taking a look? If you don't have time, I can merge and you can look at it after the fact. My goal isn't to be super-optimal, but I don't want to be foolish about it. This is intended to be a surgical fix. It is in response to a long-time user of qpdf who uses it on Windows with the DLL. Certain files were failing to linearize because very deep structures in the Outline hierarchy were causing a stack overflow. There was nothing technically wrong with the files. This switches a recursive function. This commit also adds some IDE configuration that enabled me to build and debug this in Windows with CLion, which is a game changer in my ability to debug Windows issues.