### PR TITLE
Fix QPDFOutlineDocumentHelper::resolveNamedDest  (fixes #1238)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,12 @@
+2024-07-14  M Holger  <m.holger@qpdf.org>
+
+	* Bug fix: handle named destinations where the entry is a
+	dictionary with /D entry instead of an explicit destination.
+	Fixes #1238.
+
 2024-07-04  M Holger  <m.holger@qpdf.org>
 
-	* Treat corrupt JPEG streams as unfilterable. This avoids them 
+	* Treat corrupt JPEG streams as unfilterable. This avoids them
 	getting uncompressed when writing PDF files with decode level all.
 
 2024-07-02  Jay Berkenbilt  <ejb@ql.org>
@@ -24,12 +30,12 @@
 
 2024-06-29  M Holger  <m.holger@qpdf.org>
 
-	* Bug fix: in QPDFOutlineObjectHelper detect loops in the list of 
+	* Bug fix: in QPDFOutlineObjectHelper detect loops in the list of
 	direct children of an outline item.
 
 2024-06-27  M Holger  <m.holger@qpdf.org>
 
-	* Add sanity check in QPDF xref table reconstruction to reject 
+	* Add sanity check in QPDF xref table reconstruction to reject
 	objects with impossibly large object id in order to improve
 	handling of severely damaged PDF files.
 

--- a/libqpdf/QPDFOutlineDocumentHelper.cc
+++ b/libqpdf/QPDFOutlineDocumentHelper.cc
@@ -68,30 +68,25 @@ QPDFOutlineDocumentHelper::resolveNamedDest(QPDFObjectHandle name)
     QPDFObjectHandle result;
     if (name.isName()) {
         if (!m->dest_dict.isInitialized()) {
-            m->dest_dict = this->qpdf.getRoot().getKey("/Dests");
+            m->dest_dict = qpdf.getRoot().getKey("/Dests");
         }
-        if (m->dest_dict.isDictionary()) {
-            QTC::TC("qpdf", "QPDFOutlineDocumentHelper name named dest");
-            result = m->dest_dict.getKey(name.getName());
-        }
+        QTC::TC("qpdf", "QPDFOutlineDocumentHelper name named dest");
+        result=  m->dest_dict.getKeyIfDict(name.getName());
     } else if (name.isString()) {
-        if (nullptr == m->names_dest) {
-            QPDFObjectHandle names = this->qpdf.getRoot().getKey("/Names");
-            if (names.isDictionary()) {
-                QPDFObjectHandle dests = names.getKey("/Dests");
-                if (dests.isDictionary()) {
-                    m->names_dest = std::make_shared<QPDFNameTreeObjectHelper>(dests, this->qpdf);
-                }
+        if (!m->names_dest) {
+            auto dests = qpdf.getRoot().getKey("/Names").getKeyIfDict("/Dests");
+            if (dests.isDictionary()) {
+                m->names_dest = std::make_shared<QPDFNameTreeObjectHelper>(dests, qpdf);
             }
         }
-        if (m->names_dest.get()) {
+        if (m->names_dest) {
             if (m->names_dest->findObject(name.getUTF8Value(), result)) {
                 QTC::TC("qpdf", "QPDFOutlineDocumentHelper string named dest");
             }
         }
     }
     if (!result.isInitialized()) {
-        result = QPDFObjectHandle::newNull();
+        return QPDFObjectHandle::newNull();
     }
     return result;
 }

--- a/libqpdf/QPDFOutlineDocumentHelper.cc
+++ b/libqpdf/QPDFOutlineDocumentHelper.cc
@@ -88,5 +88,9 @@ QPDFOutlineDocumentHelper::resolveNamedDest(QPDFObjectHandle name)
     if (!result.isInitialized()) {
         return QPDFObjectHandle::newNull();
     }
+    if (result.isDictionary()) {
+        QTC::TC("qpdf", "QPDFOutlineDocumentHelper named dest dictionary");
+        return result.getKey("/D");
+    }
     return result;
 }

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -356,6 +356,7 @@ QPDFOutlineObjectHelper action dest 0
 QPDFOutlineObjectHelper named dest 0
 QPDFOutlineDocumentHelper name named dest 0
 QPDFOutlineDocumentHelper string named dest 0
+QPDFOutlineDocumentHelper named dest dictionary 0
 QPDFOutlineObjectHelper loop 0
 QPDFObjectHandle merge top type mismatch 0
 QPDFObjectHandle merge shallow copy 0

--- a/qpdf/qtest/outlines.test
+++ b/qpdf/qtest/outlines.test
@@ -18,6 +18,7 @@ my @outline_files = (
     'page-labels-and-outlines',
     'outlines-with-actions',
     'outlines-with-old-root-dests',
+    'outlines-with-old-root-dests-dict',
     'outlines-with-loop',
     );
 my $n_tests = scalar(@outline_files);

--- a/qpdf/qtest/qpdf/outlines-with-old-root-dests-dict.out
+++ b/qpdf/qtest/qpdf/outlines-with-old-root-dests-dict.out
@@ -1,0 +1,12 @@
+page 0: •Merschqaberschq (A) 1.2.2 -> 0: /XYZ null null null -> [ 6 0 R /XYZ null null null ]
+page 1: •Gabeebeebee (name) 1.2.1 -> 1: /FitR 66 714 180 770 -> [ 7 0 R /FitR 66 714 180 770 ]
+page 5: •Potato 1 -> 5: /XYZ null null null -> [ 11 0 R /XYZ null null null ]
+page 11: •Mern 1.1 -> 11: /Fit -> [ 17 0 R /Fit ]
+page 12: •Biherbadem 1.1.1 -> 12: /FitV 100 -> [ 18 0 R /FitV 100 ]
+page 12: •Gawehwehweh 1.1.2 -> 12: /XYZ null null null -> [ 18 0 R /XYZ null null null ]
+page 13: •Squash ÷πʬ÷ 1.2 -> 13: /FitH 792 -> [ 19 0 R /FitH 792 ]
+page 15: •Salad 2 -> 15: /XYZ 66 756 3 -> [ 21 0 R /XYZ 66 756 3 ]
+page 18: •Glarpenspliel (A, name) 1.1.1.1 -> 18: /XYZ null null null -> [ 24 0 R /XYZ null null null ]
+page 19: •Hagoogamagoogle 1.1.1.2 -> 19: /XYZ null null null -> [ 25 0 R /XYZ null null null ]
+page 22: •Jawarnianbvarwash 1.1.2.1 -> 22: /XYZ null null null -> [ 28 0 R /XYZ null null null ]
+test 49 done

--- a/qpdf/qtest/qpdf/outlines-with-old-root-dests-dict.pdf
+++ b/qpdf/qtest/qpdf/outlines-with-old-root-dests-dict.pdf
@@ -1,0 +1,1569 @@
+%PDF-1.3
+%¿÷¢þ
+%QDF-1.0
+
+1 0 obj
+<<
+  /PageLabels << /Nums [ 0 << /P (0) >> 1 << /S /R >> ] >>
+  /Outlines 2 0 R
+  /PageMode /UseOutlines
+  /Pages 3 0 R
+  /Type /Catalog
+  /Dests 107 0 R
+>>
+endobj
+
+2 0 obj
+<<
+  /Count 6
+  /First 4 0 R
+  /Last 5 0 R
+  /Type /Outlines
+>>
+endobj
+
+3 0 obj
+<<
+  /Count 30
+  /Kids [
+    6 0 R
+    7 0 R
+    8 0 R
+    9 0 R
+    10 0 R
+    11 0 R
+    12 0 R
+    13 0 R
+    14 0 R
+    15 0 R
+    16 0 R
+    17 0 R
+    18 0 R
+    19 0 R
+    20 0 R
+    21 0 R
+    22 0 R
+    23 0 R
+    24 0 R
+    25 0 R
+    26 0 R
+    27 0 R
+    28 0 R
+    29 0 R
+    30 0 R
+    31 0 R
+    32 0 R
+    33 0 R
+    34 0 R
+    35 0 R
+  ]
+  /Type /Pages
+>>
+endobj
+
+4 0 obj
+<<
+  /Count 4
+  /Dest [
+    11 0 R
+    /XYZ
+    null
+    null
+    null
+  ]
+  /First 36 0 R
+  /Last 37 0 R
+  /Next 5 0 R
+  /Parent 2 0 R
+  /Title (€Potato 1 -> 5: /XYZ null null null)
+  /Type /Outline
+>>
+endobj
+
+5 0 obj
+<<
+  /Dest [
+    21 0 R
+    /XYZ
+    66
+    756
+    3
+  ]
+  /Parent 2 0 R
+  /Prev 4 0 R
+  /Title (€Salad 2 -> 15: /XYZ 66 756 3)
+  /Type /Outline
+>>
+endobj
+
+%% Page 1
+6 0 obj
+<<
+  /Contents 38 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 2
+7 0 obj
+<<
+  /Contents 42 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 3
+8 0 obj
+<<
+  /Contents 44 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 4
+9 0 obj
+<<
+  /Contents 46 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 5
+10 0 obj
+<<
+  /Contents 48 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 6
+11 0 obj
+<<
+  /Contents 50 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 7
+12 0 obj
+<<
+  /Contents 52 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 8
+13 0 obj
+<<
+  /Contents 54 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 9
+14 0 obj
+<<
+  /Contents 56 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 10
+15 0 obj
+<<
+  /Contents 58 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 11
+16 0 obj
+<<
+  /Contents 60 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 12
+17 0 obj
+<<
+  /Contents 62 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 13
+18 0 obj
+<<
+  /Contents 64 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 14
+19 0 obj
+<<
+  /Contents 66 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 15
+20 0 obj
+<<
+  /Contents 68 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 16
+21 0 obj
+<<
+  /Contents 70 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 17
+22 0 obj
+<<
+  /Contents 72 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 18
+23 0 obj
+<<
+  /Contents 74 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 19
+24 0 obj
+<<
+  /Contents 76 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 20
+25 0 obj
+<<
+  /Contents 78 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 21
+26 0 obj
+<<
+  /Contents 80 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 22
+27 0 obj
+<<
+  /Contents 82 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 23
+28 0 obj
+<<
+  /Contents 84 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 24
+29 0 obj
+<<
+  /Contents 86 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 25
+30 0 obj
+<<
+  /Contents 88 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 26
+31 0 obj
+<<
+  /Contents 90 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 27
+32 0 obj
+<<
+  /Contents 92 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 28
+33 0 obj
+<<
+  /Contents 94 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 29
+34 0 obj
+<<
+  /Contents 96 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+%% Page 30
+35 0 obj
+<<
+  /Contents 98 0 R
+  /MediaBox [
+    0
+    0
+    612
+    792
+  ]
+  /Parent 3 0 R
+  /Resources <<
+    /Font <<
+      /F1 40 0 R
+    >>
+    /ProcSet 41 0 R
+  >>
+  /Type /Page
+>>
+endobj
+
+36 0 obj
+<<
+  /Count 3
+  /Dest [
+    17 0 R
+    /Fit
+  ]
+  /First 100 0 R
+  /Last 101 0 R
+  /Next 37 0 R
+  /Parent 4 0 R
+  /Title (€Mern 1.1 -> 11: /Fit)
+  /Type /Outline
+>>
+endobj
+
+37 0 obj
+<<
+  /Count 2
+  /Dest [
+    19 0 R
+    /FitH
+    792
+  ]
+  /First 102 0 R
+  /Last 103 0 R
+  /Parent 4 0 R
+  /Prev 36 0 R
+  /Title <feff2022005300710075006100730068002000f703c002ac00f700200031002e00320020002d003e002000310033003a0020002f00460069007400480020003700390032>
+  /Type /Outline
+>>
+endobj
+
+%% Contents for page 1
+38 0 obj
+<<
+  /Length 39 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 0) Tj
+ET
+endstream
+endobj
+
+39 0 obj
+44
+endobj
+
+40 0 obj
+<<
+  /BaseFont /Helvetica
+  /Encoding /WinAnsiEncoding
+  /Name /F1
+  /Subtype /Type1
+  /Type /Font
+>>
+endobj
+
+41 0 obj
+[
+  /PDF
+  /Text
+]
+endobj
+
+%% Contents for page 2
+42 0 obj
+<<
+  /Length 43 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 1) Tj
+ET
+endstream
+endobj
+
+43 0 obj
+44
+endobj
+
+%% Contents for page 3
+44 0 obj
+<<
+  /Length 45 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 2) Tj
+ET
+endstream
+endobj
+
+45 0 obj
+44
+endobj
+
+%% Contents for page 4
+46 0 obj
+<<
+  /Length 47 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 3) Tj
+ET
+endstream
+endobj
+
+47 0 obj
+44
+endobj
+
+%% Contents for page 5
+48 0 obj
+<<
+  /Length 49 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 4) Tj
+ET
+endstream
+endobj
+
+49 0 obj
+44
+endobj
+
+%% Contents for page 6
+50 0 obj
+<<
+  /Length 51 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 5) Tj
+ET
+endstream
+endobj
+
+51 0 obj
+44
+endobj
+
+%% Contents for page 7
+52 0 obj
+<<
+  /Length 53 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 6) Tj
+ET
+endstream
+endobj
+
+53 0 obj
+44
+endobj
+
+%% Contents for page 8
+54 0 obj
+<<
+  /Length 55 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 7) Tj
+ET
+endstream
+endobj
+
+55 0 obj
+44
+endobj
+
+%% Contents for page 9
+56 0 obj
+<<
+  /Length 57 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 8) Tj
+ET
+endstream
+endobj
+
+57 0 obj
+44
+endobj
+
+%% Contents for page 10
+58 0 obj
+<<
+  /Length 59 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 9) Tj
+ET
+endstream
+endobj
+
+59 0 obj
+44
+endobj
+
+%% Contents for page 11
+60 0 obj
+<<
+  /Length 61 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 10) Tj
+ET
+endstream
+endobj
+
+61 0 obj
+45
+endobj
+
+%% Contents for page 12
+62 0 obj
+<<
+  /Length 63 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 11) Tj
+ET
+endstream
+endobj
+
+63 0 obj
+45
+endobj
+
+%% Contents for page 13
+64 0 obj
+<<
+  /Length 65 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 12) Tj
+ET
+endstream
+endobj
+
+65 0 obj
+45
+endobj
+
+%% Contents for page 14
+66 0 obj
+<<
+  /Length 67 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 13) Tj
+ET
+endstream
+endobj
+
+67 0 obj
+45
+endobj
+
+%% Contents for page 15
+68 0 obj
+<<
+  /Length 69 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 14) Tj
+ET
+endstream
+endobj
+
+69 0 obj
+45
+endobj
+
+%% Contents for page 16
+70 0 obj
+<<
+  /Length 71 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 15) Tj
+ET
+endstream
+endobj
+
+71 0 obj
+45
+endobj
+
+%% Contents for page 17
+72 0 obj
+<<
+  /Length 73 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 16) Tj
+ET
+endstream
+endobj
+
+73 0 obj
+45
+endobj
+
+%% Contents for page 18
+74 0 obj
+<<
+  /Length 75 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 17) Tj
+ET
+endstream
+endobj
+
+75 0 obj
+45
+endobj
+
+%% Contents for page 19
+76 0 obj
+<<
+  /Length 77 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 18) Tj
+ET
+endstream
+endobj
+
+77 0 obj
+45
+endobj
+
+%% Contents for page 20
+78 0 obj
+<<
+  /Length 79 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 19) Tj
+ET
+endstream
+endobj
+
+79 0 obj
+45
+endobj
+
+%% Contents for page 21
+80 0 obj
+<<
+  /Length 81 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 20) Tj
+ET
+endstream
+endobj
+
+81 0 obj
+45
+endobj
+
+%% Contents for page 22
+82 0 obj
+<<
+  /Length 83 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 21) Tj
+ET
+endstream
+endobj
+
+83 0 obj
+45
+endobj
+
+%% Contents for page 23
+84 0 obj
+<<
+  /Length 85 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 22) Tj
+ET
+endstream
+endobj
+
+85 0 obj
+45
+endobj
+
+%% Contents for page 24
+86 0 obj
+<<
+  /Length 87 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 23) Tj
+ET
+endstream
+endobj
+
+87 0 obj
+45
+endobj
+
+%% Contents for page 25
+88 0 obj
+<<
+  /Length 89 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 24) Tj
+ET
+endstream
+endobj
+
+89 0 obj
+45
+endobj
+
+%% Contents for page 26
+90 0 obj
+<<
+  /Length 91 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 25) Tj
+ET
+endstream
+endobj
+
+91 0 obj
+45
+endobj
+
+%% Contents for page 27
+92 0 obj
+<<
+  /Length 93 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 26) Tj
+ET
+endstream
+endobj
+
+93 0 obj
+45
+endobj
+
+%% Contents for page 28
+94 0 obj
+<<
+  /Length 95 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 27) Tj
+ET
+endstream
+endobj
+
+95 0 obj
+45
+endobj
+
+%% Contents for page 29
+96 0 obj
+<<
+  /Length 97 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 28) Tj
+ET
+endstream
+endobj
+
+97 0 obj
+45
+endobj
+
+%% Contents for page 30
+98 0 obj
+<<
+  /Length 99 0 R
+>>
+stream
+BT
+  /F1 24 Tf
+  72 720 Td
+  (Soup 29) Tj
+ET
+endstream
+endobj
+
+99 0 obj
+45
+endobj
+
+100 0 obj
+<<
+  /Count -2
+  /Dest [
+    18 0 R
+    /FitV
+    100
+  ]
+  /First 104 0 R
+  /Last 105 0 R
+  /Next 101 0 R
+  /Parent 36 0 R
+  /Title (€Biherbadem 1.1.1 -> 12: /FitV 100)
+  /Type /Outline
+>>
+endobj
+
+101 0 obj
+<<
+  /Count 1
+  /Dest [
+    18 0 R
+    /XYZ
+    null
+    null
+    null
+  ]
+  /First 106 0 R
+  /Last 106 0 R
+  /Parent 36 0 R
+  /Prev 100 0 R
+  /Title (€Gawehwehweh 1.1.2 -> 12: /XYZ null null null)
+  /Type /Outline
+>>
+endobj
+
+102 0 obj
+<<
+  /Dest /gabeebee
+  /Next 103 0 R
+  /Parent 37 0 R
+  /Title (€Gabeebeebee (name) 1.2.1 -> 1: /FitR 66 714 180 770)
+  /Type /Outline
+>>
+endobj
+
+103 0 obj
+<<
+  /A <<
+    /Type /Action
+    /S /GoTo
+    /D [
+      6 0 R
+      /XYZ
+      null
+      null
+      null
+    ]
+  >>
+  /Parent 37 0 R
+  /Prev 102 0 R
+  /Title (€Merschqaberschq (A) 1.2.2 -> 0: /XYZ null null null)
+  /Type /Outline
+>>
+endobj
+
+104 0 obj
+<<
+  /A <<
+    /Type /Action
+    /S /GoTo
+    /D /glarp
+  >>
+  /Next 105 0 R
+  /Parent 100 0 R
+  /Title (€Glarpenspliel (A, name) 1.1.1.1 -> 18: /XYZ null null null)
+  /Type /Outline
+>>
+endobj
+
+105 0 obj
+<<
+  /Dest [
+    25 0 R
+    /XYZ
+    null
+    null
+    null
+  ]
+  /Parent 100 0 R
+  /Prev 104 0 R
+  /Title (€Hagoogamagoogle 1.1.1.2 -> 19: /XYZ null null null)
+  /Type /Outline
+>>
+endobj
+
+106 0 obj
+<<
+  /Dest [
+    28 0 R
+    /XYZ
+    null
+    null
+    null
+  ]
+  /Parent 101 0 R
+  /Title (€Jawarnianbvarwash 1.1.2.1 -> 22: /XYZ null null null)
+  /Type /Outline
+>>
+endobj
+
+107 0 obj
+<<
+  /gabeebee [
+    7 0 R
+    /FitR
+    66
+    714
+    180
+    770
+  ]
+  /glarp <<
+    /D [
+    24 0 R
+    /XYZ
+    null
+    null
+    null
+    ]
+  >>
+>>
+endobj
+
+xref
+0 108
+0000000000 65535 f 
+0000000025 00000 n 
+0000000198 00000 n 
+0000000278 00000 n 
+0000000667 00000 n 
+0000000886 00000 n 
+0000001061 00000 n 
+0000001266 00000 n 
+0000001471 00000 n 
+0000001676 00000 n 
+0000001881 00000 n 
+0000002087 00000 n 
+0000002293 00000 n 
+0000002499 00000 n 
+0000002705 00000 n 
+0000002912 00000 n 
+0000003119 00000 n 
+0000003326 00000 n 
+0000003533 00000 n 
+0000003740 00000 n 
+0000003947 00000 n 
+0000004154 00000 n 
+0000004361 00000 n 
+0000004568 00000 n 
+0000004775 00000 n 
+0000004982 00000 n 
+0000005189 00000 n 
+0000005396 00000 n 
+0000005603 00000 n 
+0000005810 00000 n 
+0000006017 00000 n 
+0000006224 00000 n 
+0000006431 00000 n 
+0000006638 00000 n 
+0000006845 00000 n 
+0000007052 00000 n 
+0000007248 00000 n 
+0000007430 00000 n 
+0000007759 00000 n 
+0000007860 00000 n 
+0000007880 00000 n 
+0000007999 00000 n 
+0000008058 00000 n 
+0000008159 00000 n 
+0000008202 00000 n 
+0000008303 00000 n 
+0000008346 00000 n 
+0000008447 00000 n 
+0000008490 00000 n 
+0000008591 00000 n 
+0000008634 00000 n 
+0000008735 00000 n 
+0000008778 00000 n 
+0000008879 00000 n 
+0000008922 00000 n 
+0000009023 00000 n 
+0000009066 00000 n 
+0000009167 00000 n 
+0000009211 00000 n 
+0000009312 00000 n 
+0000009356 00000 n 
+0000009458 00000 n 
+0000009502 00000 n 
+0000009604 00000 n 
+0000009648 00000 n 
+0000009750 00000 n 
+0000009794 00000 n 
+0000009896 00000 n 
+0000009940 00000 n 
+0000010042 00000 n 
+0000010086 00000 n 
+0000010188 00000 n 
+0000010232 00000 n 
+0000010334 00000 n 
+0000010378 00000 n 
+0000010480 00000 n 
+0000010524 00000 n 
+0000010626 00000 n 
+0000010670 00000 n 
+0000010772 00000 n 
+0000010816 00000 n 
+0000010918 00000 n 
+0000010962 00000 n 
+0000011064 00000 n 
+0000011108 00000 n 
+0000011210 00000 n 
+0000011254 00000 n 
+0000011356 00000 n 
+0000011400 00000 n 
+0000011502 00000 n 
+0000011546 00000 n 
+0000011648 00000 n 
+0000011692 00000 n 
+0000011794 00000 n 
+0000011838 00000 n 
+0000011940 00000 n 
+0000011984 00000 n 
+0000012086 00000 n 
+0000012130 00000 n 
+0000012232 00000 n 
+0000012252 00000 n 
+0000012460 00000 n 
+0000012696 00000 n 
+0000012852 00000 n 
+0000013105 00000 n 
+0000013309 00000 n 
+0000013508 00000 n 
+0000013693 00000 n 
+trailer <<
+  /Root 1 0 R
+  /Size 108
+  /ID [<d52b0c17c216506962ae6743afec260f><d52b0c17c216506962ae6743afec260f>]
+>>
+startxref
+13865
+%%EOF


### PR DESCRIPTION
Handle named destinations where the entry is a dictionary with /D entry.