### PR TITLE
Mark intentional unsigned integer wrapping in MD5_native::transform and adjust fuzzer memory limits

### DIFF
--- a/fuzz/qpdf_fuzzer.cc
+++ b/fuzz/qpdf_fuzzer.cc
@@ -181,8 +181,8 @@ FuzzHelper::doChecks()
     // occur legitimately and therefore must be allowed during normal operations.
     Pl_DCT::setMemoryLimit(1'000'000'000);
 
-    Pl_PNGFilter::setMemoryLimit(1'000'000'000);
-    Pl_TIFFPredictor::setMemoryLimit(1'000'000'000);
+    Pl_PNGFilter::setMemoryLimit(1'000'000);
+    Pl_TIFFPredictor::setMemoryLimit(1'000'000);
 
     // Do not decompress corrupt data. This may cause extended runtime within jpeglib without
     // exercising additional code paths in qpdf, and potentially causing counterproductive timeouts.

--- a/libqpdf/MD5_native.cc
+++ b/libqpdf/MD5_native.cc
@@ -193,7 +193,12 @@ MD5_native::digest(Digest result)
 }
 
 // MD5 basic transformation. Transforms state based on block.
+//
+// NB The algorithm intentionally relies on unsigned integer wrap-around
 void MD5_native::transform(uint32_t state[4], unsigned char block[64])
+#if defined(__clang__)
+__attribute__((no_sanitize("unsigned-integer-overflow")))
+#endif
 {
     uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 


### PR DESCRIPTION
see https://github.com/qpdf/qpdf-dev/discussions/6 for context