### PR TITLE
libtests: include cstdint for GCC 15

### DIFF
--- a/libtests/cxx11.cc
+++ b/libtests/cxx11.cc
@@ -1,5 +1,6 @@
 #include <qpdf/assert_test.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
GCC 15 starts to no longer include this by default, requiring it to be explicitly included.

Error message:
```
libtests/cxx11.cc:75:16: error: ‘uint8_t’ was not declared in this scope
   75 |     check_size<uint8_t>(1, false);
      |                ^~~~~~~
libtests/cxx11.cc:10:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    9 | #include <regex>
  +++ |+#include <cstdint>
   10 | #include <type_traits>
```