### PR TITLE
In qpdf_fuzzer and dct_fuzzer add a scan limit for Pl_DCT

### DIFF
--- a/fuzz/dct_fuzzer.cc
+++ b/fuzz/dct_fuzzer.cc
@@ -31,6 +31,7 @@ FuzzHelper::doChecks()
     // jpeg_start_decompress is called. During normal use of qpdf very large JPEGs can occasionally
     // occur legitimately and therefore must be allowed during normal operations.
     Pl_DCT::setMemoryLimit(200'000'000);
+    Pl_DCT::setScanLimit(50);
 
     // Do not decompress corrupt data. This may cause extended runtime within jpeglib without
     // exercising additional code paths in qpdf.

--- a/fuzz/qpdf_fuzzer.cc
+++ b/fuzz/qpdf_fuzzer.cc
@@ -181,6 +181,7 @@ FuzzHelper::doChecks()
     // jpeg_start_decompress is called. During normal use of qpdf very large JPEGs can occasionally
     // occur legitimately and therefore must be allowed during normal operations.
     Pl_DCT::setMemoryLimit(100'000'000);
+    Pl_DCT::setScanLimit(50);
 
     Pl_PNGFilter::setMemoryLimit(1'000'000);
     Pl_TIFFPredictor::setMemoryLimit(1'000'000);

--- a/include/qpdf/Pl_DCT.hh
+++ b/include/qpdf/Pl_DCT.hh
@@ -39,6 +39,11 @@ class QPDF_DLL_CLASS Pl_DCT: public Pipeline
     QPDF_DLL
     static void setMemoryLimit(long limit);
 
+    // Limit the number of scans used by jpeglib when decompressing progressive jpegs.
+    // NB This is a static option affecting all Pl_DCT instances.
+    QPDF_DLL
+    static void setScanLimit(int limit);
+
     // Treat corrupt data as a runtime error rather than attempting to decompress regardless. This
     // is the qpdf default behaviour. To attempt to decompress corrupt data set 'treat_as_error' to
     // false.


### PR DESCRIPTION
Provide a sanity check to detect corrupt progressive jpegs with long processing times in libjpeg-turbo.

see https://github.com/qpdf/qpdf-dev/discussions/6 for context