### PR TITLE
Refactor QPDFObjectHandle::getTypeName

### DIFF
--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -30,6 +30,7 @@
 #include <qpdf/QUtil.hh>
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <climits>
 #include <cstdlib>
@@ -263,7 +264,23 @@ char const*
 QPDFObjectHandle::getTypeName() const
 #endif
 {
-    return obj ? obj->getTypeName() : "uninitialized";
+    static constexpr std::array<char const*, 15> tn{
+        "uninitialized",
+        "reserved",
+        "null",
+        "boolean",
+        "integer",
+        "real",
+        "string",
+        "name",
+        "array",
+        "dictionary",
+        "stream",
+        "operator",
+        "inline-image",
+        "unresolved",
+        "destroyed"};
+    return obj ? tn[getTypeCode()] : "uninitialized";
 }
 
 QPDF_Array*
@@ -2528,7 +2545,7 @@ QPDFObjectHandle::typeWarning(char const* expected_type, std::string const& warn
             description,
             0,
             std::string("operation for ") + expected_type + " attempted on object of type " +
-                obj->getTypeName() + ": " + warning));
+                QPDFObjectHandle(*this).getTypeName() + ": " + warning));
 }
 
 #ifndef QPDF_FUTURE
@@ -2565,7 +2582,7 @@ QPDFObjectHandle::assertType(char const* type_name, bool istype) const
     if (!istype) {
         throw std::runtime_error(
             std::string("operation for ") + type_name + " attempted on object of type " +
-            (obj ? obj->getTypeName() : "uninitialized"));
+            QPDFObjectHandle(*this).getTypeName());
     }
 }
 

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -26,24 +26,24 @@ QPDF_Array::checkOwnership(QPDFObjectHandle const& item) const
 }
 
 QPDF_Array::QPDF_Array() :
-    QPDFValue(::ot_array, "array")
+    QPDFValue(::ot_array)
 {
 }
 
 QPDF_Array::QPDF_Array(QPDF_Array const& other) :
-    QPDFValue(::ot_array, "array"),
+    QPDFValue(::ot_array),
     sp(other.sp ? std::make_unique<Sparse>(*other.sp) : nullptr)
 {
 }
 
 QPDF_Array::QPDF_Array(std::vector<QPDFObjectHandle> const& v) :
-    QPDFValue(::ot_array, "array")
+    QPDFValue(::ot_array)
 {
     setFromVector(v);
 }
 
 QPDF_Array::QPDF_Array(std::vector<std::shared_ptr<QPDFObject>>&& v, bool sparse) :
-    QPDFValue(::ot_array, "array")
+    QPDFValue(::ot_array)
 {
     if (sparse) {
         sp = std::make_unique<Sparse>();

--- a/libqpdf/QPDF_Bool.cc
+++ b/libqpdf/QPDF_Bool.cc
@@ -3,7 +3,7 @@
 #include <qpdf/JSON_writer.hh>
 
 QPDF_Bool::QPDF_Bool(bool val) :
-    QPDFValue(::ot_boolean, "boolean"),
+    QPDFValue(::ot_boolean),
     val(val)
 {
 }

--- a/libqpdf/QPDF_Destroyed.cc
+++ b/libqpdf/QPDF_Destroyed.cc
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 QPDF_Destroyed::QPDF_Destroyed() :
-    QPDFValue(::ot_destroyed, "destroyed")
+    QPDFValue(::ot_destroyed)
 {
 }
 

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -9,13 +9,13 @@
 using namespace std::literals;
 
 QPDF_Dictionary::QPDF_Dictionary(std::map<std::string, QPDFObjectHandle> const& items) :
-    QPDFValue(::ot_dictionary, "dictionary"),
+    QPDFValue(::ot_dictionary),
     items(items)
 {
 }
 
 QPDF_Dictionary::QPDF_Dictionary(std::map<std::string, QPDFObjectHandle>&& items) :
-    QPDFValue(::ot_dictionary, "dictionary"),
+    QPDFValue(::ot_dictionary),
     items(items)
 {
 }

--- a/libqpdf/QPDF_InlineImage.cc
+++ b/libqpdf/QPDF_InlineImage.cc
@@ -3,7 +3,7 @@
 #include <qpdf/JSON_writer.hh>
 
 QPDF_InlineImage::QPDF_InlineImage(std::string const& val) :
-    QPDFValue(::ot_inlineimage, "inline-image"),
+    QPDFValue(::ot_inlineimage),
     val(val)
 {
 }

--- a/libqpdf/QPDF_Integer.cc
+++ b/libqpdf/QPDF_Integer.cc
@@ -4,7 +4,7 @@
 #include <qpdf/QUtil.hh>
 
 QPDF_Integer::QPDF_Integer(long long val) :
-    QPDFValue(::ot_integer, "integer"),
+    QPDFValue(::ot_integer),
     val(val)
 {
 }

--- a/libqpdf/QPDF_Name.cc
+++ b/libqpdf/QPDF_Name.cc
@@ -4,7 +4,7 @@
 #include <qpdf/QUtil.hh>
 
 QPDF_Name::QPDF_Name(std::string const& name) :
-    QPDFValue(::ot_name, "name"),
+    QPDFValue(::ot_name),
     name(name)
 {
 }

--- a/libqpdf/QPDF_Null.cc
+++ b/libqpdf/QPDF_Null.cc
@@ -4,7 +4,7 @@
 #include <qpdf/QPDFObject_private.hh>
 
 QPDF_Null::QPDF_Null(QPDF* qpdf, QPDFObjGen og) :
-    QPDFValue(::ot_null, "null", qpdf, og)
+    QPDFValue(::ot_null, qpdf, og)
 {
 }
 

--- a/libqpdf/QPDF_Operator.cc
+++ b/libqpdf/QPDF_Operator.cc
@@ -3,7 +3,7 @@
 #include <qpdf/JSON_writer.hh>
 
 QPDF_Operator::QPDF_Operator(std::string const& val) :
-    QPDFValue(::ot_operator, "operator"),
+    QPDFValue(::ot_operator),
     val(val)
 {
 }

--- a/libqpdf/QPDF_Real.cc
+++ b/libqpdf/QPDF_Real.cc
@@ -4,13 +4,13 @@
 #include <qpdf/QUtil.hh>
 
 QPDF_Real::QPDF_Real(std::string const& val) :
-    QPDFValue(::ot_real, "real"),
+    QPDFValue(::ot_real),
     val(val)
 {
 }
 
 QPDF_Real::QPDF_Real(double value, int decimal_places, bool trim_trailing_zeroes) :
-    QPDFValue(::ot_real, "real"),
+    QPDFValue(::ot_real),
     val(QUtil::double_to_string(value, decimal_places, trim_trailing_zeroes))
 {
 }

--- a/libqpdf/QPDF_Reserved.cc
+++ b/libqpdf/QPDF_Reserved.cc
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 QPDF_Reserved::QPDF_Reserved() :
-    QPDFValue(::ot_reserved, "reserved")
+    QPDFValue(::ot_reserved)
 {
 }
 

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -112,7 +112,7 @@ QPDF_Stream::QPDF_Stream(
     QPDFObjectHandle stream_dict,
     qpdf_offset_t offset,
     size_t length) :
-    QPDFValue(::ot_stream, "stream"),
+    QPDFValue(::ot_stream),
     filter_on_write(true),
     stream_dict(stream_dict),
     length(length)

--- a/libqpdf/QPDF_String.cc
+++ b/libqpdf/QPDF_String.cc
@@ -13,7 +13,7 @@ is_iso_latin1_printable(char ch)
 }
 
 QPDF_String::QPDF_String(std::string const& val) :
-    QPDFValue(::ot_string, "string"),
+    QPDFValue(::ot_string),
     val(val)
 {
 }

--- a/libqpdf/QPDF_Unresolved.cc
+++ b/libqpdf/QPDF_Unresolved.cc
@@ -4,7 +4,7 @@
 #include <qpdf/QPDFObject_private.hh>
 
 QPDF_Unresolved::QPDF_Unresolved(QPDF* qpdf, QPDFObjGen const& og) :
-    QPDFValue(::ot_unresolved, "unresolved", qpdf, og)
+    QPDFValue(::ot_unresolved, qpdf, og)
 {
 }
 

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -58,12 +58,6 @@ class QPDFObject
     {
         return value->type_code;
     }
-    // Return a string literal that describes the type, useful for debugging and testing
-    char const*
-    getTypeName() const
-    {
-        return resolved_object()->value->type_name;
-    }
 
     QPDF*
     getQPDF() const

--- a/libqpdf/qpdf/QPDFValue.hh
+++ b/libqpdf/qpdf/QPDFValue.hh
@@ -122,15 +122,12 @@ class QPDFValue: public std::enable_shared_from_this<QPDFValue>
   protected:
     QPDFValue() = default;
 
-    QPDFValue(qpdf_object_type_e type_code, char const* type_name) :
-        type_code(type_code),
-        type_name(type_name)
+    QPDFValue(qpdf_object_type_e type_code) :
+        type_code(type_code)
     {
     }
-    QPDFValue(
-        qpdf_object_type_e type_code, char const* type_name, QPDF* qpdf, QPDFObjGen const& og) :
+    QPDFValue(qpdf_object_type_e type_code, QPDF* qpdf, QPDFObjGen og) :
         type_code(type_code),
-        type_name(type_name),
         qpdf(qpdf),
         og(og)
     {
@@ -144,7 +141,6 @@ class QPDFValue: public std::enable_shared_from_this<QPDFValue>
     std::shared_ptr<Description> object_description;
 
     const qpdf_object_type_e type_code{::ot_uninitialized};
-    char const* type_name{"uninitialized"};
 
   protected:
     QPDF* qpdf{nullptr};


### PR DESCRIPTION
Reduces footprint foe e.g. `qpdf pdf-spec-1-100.pdf  out.pdf` by around 2.75%.