### PR TITLE
In  QPDFParser add a limit on total number of errors in one object

### DIFF
--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -469,13 +469,14 @@ QPDFParser::fixMissingKeys()
 bool
 QPDFParser::tooManyBadTokens()
 {
-    if (good_count <= 4) {
-        if (++bad_count > 5) {
-            warn("too many errors; giving up on reading object");
-            return true;
-        }
-    } else {
+    if (--max_bad_count > 0 && good_count > 4) {
+        good_count = 0;
         bad_count = 1;
+        return false;
+    }
+    if (++bad_count > 5) {
+        warn("too many errors; giving up on reading object");
+        return true;
     }
     good_count = 0;
     return false;

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -83,9 +83,11 @@ class QPDFParser
     std::vector<StackFrame> stack;
     StackFrame* frame;
     // Number of recent bad tokens.
-    int bad_count = 0;
+    int bad_count{0};
+    // Number of bad tokens (remaining) before giving up.
+    int max_bad_count{15};
     // Number of good tokens since last bad token. Irrelevant if bad_count == 0.
-    int good_count = 0;
+    int good_count{0};
     // Start offset including any leading whitespace.
     qpdf_offset_t start;
     // Number of successive integer tokens.


### PR DESCRIPTION
Currently, QPDFParser gives up attempting to parse an object if 5 near-consecutive bad tokens are encountered. Add a limit of a total of 15 bad tokens in a single object before giving up.

For context see https://github.com/qpdf/qpdf-dev/discussions/6