### PR TITLE
Fix QPDF::copyForeignObject warning

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2268,8 +2268,11 @@ QPDF::copyForeignObject(QPDFObjectHandle foreign)
 
     auto og = foreign.getObjGen();
     if (!obj_copier.object_map.count(og)) {
-        warn(damagedPDF("unexpected reference to /Pages object while copying foreign object; "
-                        "replacing with null"));
+        warn(damagedPDF(
+            other.getFilename() + " object " + og.unparse(' '),
+            foreign.getParsedOffset(),
+            "unexpected reference to /Pages object while copying foreign object; replacing with "
+            "null"));
         return QPDFObjectHandle::newNull();
     }
     return obj_copier.object_map[foreign.getObjGen()];

--- a/qpdf/qtest/qpdf/copy-foreign-objects-25.out
+++ b/qpdf/qtest/qpdf/copy-foreign-objects-25.out
@@ -1,2 +1,2 @@
-WARNING: minimal.pdf (object 6 0, offset 556): unexpected reference to /Pages object while copying foreign object; replacing with null
+WARNING: minimal.pdf (copy-foreign-objects-in.pdf object 2 0, offset 768): unexpected reference to /Pages object while copying foreign object; replacing with null
 test 25 done


### PR DESCRIPTION
Provide correct obj_gen and offset.