### PR TITLE
Fix qdf output file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-02-02  Jay Berkenbilt  <ejb@ql.org>
+
+	* Have fix-qdf accept a second argument, interpreted as the output
+	file. Fixes #1330.
+
 2024-02-01  M Holger  <m.holger@qpdf.org>
 
 	* Bug fix: in qpdf CLI / QPDFJob throw a QPDFUsage exception if a

--- a/manual/fix-qdf.1.in
+++ b/manual/fix-qdf.1.in
@@ -3,9 +3,11 @@
 fix-qdf \- repair PDF files in QDF form after editing
 .SH SYNOPSIS
 .B fix-qdf
-< \fIinfilename\fR > \fIoutfilename\fR
+[\fIinfilename\fR [\fIoutfilename\fR]]
 .SH DESCRIPTION
-The fix-qdf program is part of the qpdf package.
+The fix-qdf program is part of the qpdf package. With no arguments,
+fix-qdf reads from standard input and writes to standard output. With
+one argument, it reads from that file and writes to standard output.
 .PP
 The fix-qdf program reads a PDF file in QDF form and writes out
 the same file with stream lengths, cross-reference table entries, and

--- a/manual/qdf.rst
+++ b/manual/qdf.rst
@@ -23,10 +23,18 @@ files are full of offset and length information that makes it hard to
 add or remove data. A QDF file is organized in a manner such that, if
 edits are kept within certain constraints, the
 :command:`fix-qdf` program, distributed with qpdf, is
-able to restore edited files to a correct state. The
-:command:`fix-qdf` program takes no command-line
-arguments. It reads a possibly edited QDF file from standard input and
-writes a repaired file to standard output.
+able to restore edited files to a correct state.
+
+.. code-block:: bash
+
+  fix-qdf [infilename [outfilename]]
+
+With no arguments, :command:`fix-qdf` reads the possibly-edited QDF
+file from standard input and writes a repaired file to standard
+output. You can also specify the input and output files as
+command-line arguments. With one argument, the argument is taken as an
+input file. With two arguments, the first argument is an input file,
+and the second is an output file.
 
 For another way to work with PDF files in an editor, see :ref:`json`.
 Using qpdf JSON format allows you to edit the PDF file semantically

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -38,6 +38,14 @@ Planned changes for future 12.x (subject to change):
 
 .. x.y.z: not yet released
 
+11.10.0: not yet released
+  - CLI Enhancements
+
+    - The :command:`fix-qdf` command now allows an output file to be
+      specified as an optional second argument. This is useful for
+      environments in which writing a binary file to standard output
+      doesn't work (such as PowerShell 5).
+
 11.9.1: June 7, 2024
   - Bug Fixes
 

--- a/qpdf/qtest/fix-qdf.test
+++ b/qpdf/qtest/fix-qdf.test
@@ -14,7 +14,7 @@ cleanup();
 
 my $td = new TestDriver('fix-qdf');
 
-my $n_tests = 5;
+my $n_tests = 11;
 
 for (my $n = 1; $n <= 2; ++$n)
 {
@@ -22,6 +22,15 @@ for (my $n = 1; $n <= 2; ++$n)
                  {$td->COMMAND => "fix-qdf fix$n.qdf"},
                  {$td->FILE => "fix$n.qdf.out",
                   $td->EXIT_STATUS => 0});
+
+    $td->runtest("fix-qdf $n with named output",
+                 {$td->COMMAND => "fix-qdf fix$n.qdf a.pdf"},
+                 {$td->STRING => "",
+                  $td->EXIT_STATUS => 0});
+
+    $td->runtest("check fix-qdf $n output",
+                 {$td->FILE => "a.pdf"},
+                 {$td->FILE => "fix$n.qdf.out"});
 
     $td->runtest("identity fix-qdf $n",
                  {$td->COMMAND => "fix-qdf fix$n.qdf.out"},
@@ -53,6 +62,16 @@ $td->runtest("fix-qdf with big object stream", # > 255 objects in a stream
              {$td->COMMAND => "fix-qdf big-ostream.pdf"},
              {$td->FILE => "big-ostream.pdf",
               $td->EXIT_STATUS => 0});
+
+$td->runtest("fix-qdf error opening input",
+             {$td->COMMAND => "fix-qdf /does/not/exist/potato.pdf"},
+             {$td->REGEXP => "^fix-qdf: error: open .*/does/not/exist/potato.pdf: .*",
+              $td->EXIT_STATUS => 2});
+
+$td->runtest("fix-qdf error opening output", # > 255 objects in a stream
+             {$td->COMMAND => "fix-qdf fix1.qdf /does/not/exist/salad.pdf"},
+             {$td->REGEXP => "^fix-qdf: error: open .*/does/not/exist/salad.pdf: .*",
+              $td->EXIT_STATUS => 2});
 
 cleanup();
 $td->report($n_tests);


### PR DESCRIPTION
Allow fix-qdf to accept a second argument as the output file helps in environments like PowerShell 5 where binary standard output is mangled even with proper handling by the writing executable. This also fixes documentation, which was never updated when fix-qdf was changed to accept an input file as a parameter.