### PR TITLE
Fix build against a standard zopfli install

### DIFF
--- a/libqpdf/CMakeLists.txt
+++ b/libqpdf/CMakeLists.txt
@@ -192,7 +192,7 @@ if(NOT EXTERNAL_LIBS)
 endif()
 
 if(ZOPFLI)
-  find_path(ZOPFLI_H_PATH zopfli/zopfli.h)
+  find_path(ZOPFLI_H_PATH NAMES zopfli.h PATH_SUFFIXES zopfli)
   find_library(ZOPFLI_LIB_PATH NAMES zopfli)
   if(ZOPFLI_H_PATH AND ZOPFLI_LIB_PATH)
     list(APPEND dep_include_directories ${ZOPFLI_H_PATH})

--- a/libqpdf/Pl_Flate.cc
+++ b/libqpdf/Pl_Flate.cc
@@ -9,7 +9,7 @@
 #include <qpdf/qpdf-config.h>
 
 #ifdef ZOPFLI
-# include <zopfli/zopfli.h>
+# include <zopfli.h>
 #endif
 
 namespace


### PR DESCRIPTION
Fix the logic to accept a top-level `zopfli.h` header, as that is the location used by upstream's build system.