### PR TITLE
Discontinue ChangeLog; update release notes as you go

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
-2025-02-15  Jay Berkenbilt  <ejb@ql.org>
+2025-02-19  Jay Berkenbilt  <ejb@ql.org>
 
-	* Disable PointerHolder by default.
+        * END USE OF ChangeLog. From this point forward, please consult
+        the release notes for important changes and version control
+        history for detailed changes.
 
 2025-02-15  Jay Berkenbilt  <ejb@ql.org>
 

--- a/README-maintainer.md
+++ b/README-maintainer.md
@@ -23,6 +23,11 @@
 
 ## ROUTINE DEVELOPMENT
 
+**When making changes that users need to know about, update the release notes
+(manual/release-notes.rst) as you go.** Major changes to the internal API can also be mentioned in
+the release notes in a section called "Internal Changes" or similar. This removes ChangeLog as a
+separate mechanism for tracking changes.
+
 **Remember to check pull requests as well as issues in github.**
 
 Include `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` with cmake if using emacs lsp mode.
@@ -536,11 +541,9 @@ When done, the following should happen:
   `make_dist` verifies this consistency, and CI fails if they are
   inconsistent.
 
-* Update release notes in manual. Look at diffs and ChangeLog.
+* Update release notes in manual. Review version control history.
   Update release date in `manual/release-notes.rst`. Change "not yet
   released" to an actual date for the release.
-
-* Add a release entry to ChangeLog: "x.y.z: release"
 
 * Commit changes with title "Prepare x.y.z release"
 

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -3,8 +3,10 @@
 Release Notes
 =============
 
-For a detailed list of changes, please see the file
-:file:`ChangeLog` in the source distribution.
+This is a curated list of user-facing and developer-facing changes.
+Prior to version 12, file :file:`ChangeLog` contained more detail.
+From version 12 onward, please consult version control history for
+more detail.
 
 .. x.y.z: not yet released
 


### PR DESCRIPTION
@m-holger What do you think? If you agree with this, feel free to merge. I think it's a waste of time and energy at this point to keep multiple ways of tracking changes. This means the release notes may be slightly more detailed. I think we should get into the habit of updating the release notes as we go. It makes main more useful, and it makes it easier at release time.