### PR TITLE
Tune JSON::JSON_string

### DIFF
--- a/include/qpdf/JSON.hh
+++ b/include/qpdf/JSON.hh
@@ -329,7 +329,6 @@ class JSON
         ~JSON_string() override = default;
         void write(Pipeline*, size_t depth) const override;
         std::string utf8;
-        std::string encoded;
     };
     struct JSON_number: public JSON_value
     {

--- a/libqpdf/JSON.cc
+++ b/libqpdf/JSON.cc
@@ -120,15 +120,14 @@ JSON::JSON_array::write(Pipeline* p, size_t depth) const
 
 JSON::JSON_string::JSON_string(std::string const& utf8) :
     JSON_value(vt_string),
-    utf8(utf8),
-    encoded(Writer::encode_string(utf8))
+    utf8(utf8)
 {
 }
 
 void
 JSON::JSON_string::write(Pipeline* p, size_t) const
 {
-    *p << std::string("\"") + encoded + "\"";
+    *p << std::string("\"") + Writer::encode_string(utf8) + "\"";
 }
 
 JSON::JSON_number::JSON_number(long long value) :


### PR DESCRIPTION
Remove member encoded and encode strings only when required.

Encoded is only used when writing JSON. Since most JSON writing is now done on the fly without creating a JSON representation, creating and storing the encoded string in almost all cases no longer serves any purpose.