### PR TITLE
Added prefix m to page ranges

### DIFF
--- a/libqpdf/QUtil.cc
+++ b/libqpdf/QUtil.cc
@@ -1308,7 +1308,7 @@ QUtil::parse_numrange(char const* range, int max)
     // range parsing is used only during argument processing. It is not used during processing of
     // PDF files.
 
-    static std::regex group_re(R"((x)?(z|r?\d+)(?:-(z|r?\d+))?)");
+    static std::regex group_re(R"((x)?(z|[rm]?\d+)(?:-(z|[rm]?\d+))?)");
     auto parse_num = [&max](std::string const& s) -> int {
         if (s == "z") {
             return max;
@@ -1316,6 +1316,9 @@ QUtil::parse_numrange(char const* range, int max)
         int num;
         if (s.at(0) == 'r') {
             num = max + 1 - string_to_int(s.substr(1).c_str());
+        }
+        else if (s.at(0) == 'm') {
+          num = std::min(string_to_int(s.substr(1).c_str()), max);
         } else {
             num = string_to_int(s.c_str());
         }

--- a/libqpdf/qpdf/auto_job_help.hh
+++ b/libqpdf/qpdf/auto_job_help.hh
@@ -301,6 +301,7 @@ previous group. A number may be one of
 
 - <n>        where <n> represents a number is the <n>th page
 - r<n>       is the <n>th page from the end
+- m<n>       is the <n>th page or the last page, if <n> is larger than the number of pages
 - z          the last page, same as r1
 
 - a,b,c      pages a, b, and c

--- a/libtests/qtest/numrange.test
+++ b/libtests/qtest/numrange.test
@@ -73,6 +73,10 @@ my @nrange_tests = (
     ["4-10,x7-9,12-8,xr5",
      "numeric range 4-10,x7-9,12-8,xr5 -> 4 5 6 10 12 10 9 8",
      0],
+    ,
+    ["4-m10",
+     "numeric range 4-m10 -> 4 5 6 7 8 9 10",
+     0],
     );
 foreach my $d (@nrange_tests)
 {

--- a/manual/cli.rst
+++ b/manual/cli.rst
@@ -1298,6 +1298,7 @@ Page Ranges
 
    - <n>        where <n> represents a number is the <n>th page
    - r<n>       is the <n>th page from the end
+   - m<n>       is the <n>th page or the last page, if <n> is larger than the number of pages
    - z          the last page, same as r1
 
    - a,b,c      pages a, b, and c
@@ -1318,6 +1319,9 @@ section describes the syntax of a page range.
 
 - A number preceded by ``r`` counts from the end, so ``r1`` is the
   last page, ``r2`` is the second-to-last page, etc.
+
+- A number preceded by ``m`` indicates the page numbered from 1 or the last page,
+  if the number is greater than the number of pages in the document.
 
 - The letter ``z`` represents the last page and is the same as ``r1``.
 
@@ -1387,6 +1391,10 @@ section describes the syntax of a page range.
        that order. That is pages 4 through 10 except 7 through 9
        followed by 12 through 8 descending except 11 (the fifth page
        from the end)
+
+   - - ``1-m10``
+     - In a 15-page file, this is the first 10 pages, in a 5 page
+       file this is the first 5 pages.
 
 .. _modification-options:
 


### PR DESCRIPTION
The new prefix m can be used to specify a number as the maximum of pages that should be used.
Before these changes specifying a range larger than the amount of pages in the document would give an error.
When using qpdf to split large numbers of documents with varying page numbers it was not possible to use the same parameters to always get a set number of the first pages.

For example to get at most the first 5 pages one would use 1-m5.

This commit changes the regular expression to parse page ranges to accept m or r as prefixes. In addition the CLI help as well as the online documentation have been expanded. A very basic test was added aswell.