### PR TITLE
Remove more deprecated API

### DIFF
--- a/include/qpdf/QPDFObject.hh
+++ b/include/qpdf/QPDFObject.hh
@@ -23,58 +23,14 @@
 #ifndef QPDFOBJECT_OLD_HH
 #define QPDFOBJECT_OLD_HH
 
-// **********************************************************************
-//
-//   This file is for backward compatibility. The header file for the
-//   internal QPDFObject class (not part of the public API) is in
-//   QPDFObject_private.hh (not installed).
-//
-// **********************************************************************
+// This file exists so that if anyone still includes <qpdf/QPDFObject.hh>
+// and has been ignoring the warning, they will get an error. This reduces
+// the chances of someone accidentally including the file from an
+// installed, old version. The QPDFObject API, which is not part of the
+// public API, is defined in QPDFObject_private.hh. Prior to qpdf 11, this
+// file was exposed for some constants. This error was introduced in qpdf
+// 12.
 
-// ABI: in qpdf 12, leave this file in place and have it generate an
-// error. This is to prevent someone from being able to successfully
-// include this file and get a copy from a previous installation
-// thereby accidentally creating sources depend on having an older
-// version installed. When enough time has passed, this file can be
-// removed, and libqpdf/qpdf/QPDFObject_private.hh can be renamed to
-// libqpdf/qpdf/QPDFObject.hh.
-
-#ifndef QPDF_OBJECT_NOWARN
-// ABI: remove this file in qpdf 12
-# warning "QPDFObject.hh is deprecated see comments in QPDFObject.hh"
-#endif
-
-#include <qpdf/Constants.h>
-class QPDFObject
-{
-  public:
-    // This file and these symbols will be removed in QPDF 12. Instead
-    // of including this header, include <qpdf/Constants.h>. Replace
-    // `QPDFObject::ot_` with `::ot_` in your code.
-
-    // Prior to qpdf 10.5, qpdf_object_type_e was
-    // QPDFObject::object_type_e but was moved to make it accessible
-    // to the C API. The code below is for backward compatibility
-    // until qpdf 12.
-    typedef enum qpdf_object_type_e object_type_e;
-    static constexpr object_type_e ot_uninitialized = ::ot_uninitialized;
-    static constexpr object_type_e ot_reserved = ::ot_reserved;
-    static constexpr object_type_e ot_null = ::ot_null;
-    static constexpr object_type_e ot_boolean = ::ot_boolean;
-    static constexpr object_type_e ot_integer = ::ot_integer;
-    static constexpr object_type_e ot_real = ::ot_real;
-    static constexpr object_type_e ot_string = ::ot_string;
-    static constexpr object_type_e ot_name = ::ot_name;
-    static constexpr object_type_e ot_array = ::ot_array;
-    static constexpr object_type_e ot_dictionary = ::ot_dictionary;
-    static constexpr object_type_e ot_stream = ::ot_stream;
-    static constexpr object_type_e ot_operator = ::ot_operator;
-    static constexpr object_type_e ot_inlineimage = ::ot_inlineimage;
-
-  private:
-    QPDFObject() = delete;
-    QPDFObject(QPDFObject const&) = delete;
-    QPDFObject& operator=(QPDFObject const&) = delete;
-};
+#error "QPDFObject.hh is no longer a valid QPDF Header file"
 
 #endif // QPDFOBJECT_OLD_HH

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -963,10 +963,6 @@ class QPDFObjectHandle
     QPDF_DLL
     QPDFObjectHandle removeKeyAndGetOld(std::string const& key);
 
-    // ABI: Remove in qpdf 12
-    [[deprecated("use replaceKey -- it does the same thing")]] QPDF_DLL void
-    replaceOrRemoveKey(std::string const& key, QPDFObjectHandle const&);
-
     // Methods for stream objects
     QPDF_DLL
     QPDFObjectHandle getDict() const;

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1262,12 +1262,6 @@ QPDFObjectHandle::removeKeyAndGetOld(std::string const& key)
     return result;
 }
 
-void
-QPDFObjectHandle::replaceOrRemoveKey(std::string const& key, QPDFObjectHandle const& value)
-{
-    replaceKey(key, value);
-}
-
 // Stream accessors
 
 QPDFObjectHandle

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -15,6 +15,14 @@ more detail.
 12.0.0: not yet released
   - API: breaking changes
 
+    - The header file ``qpdf/QPDFObject.hh`` now generates an error if
+      included. This is to prevent that includes it from accidentally
+      working because an old version is installed somewhere on the
+      system.
+
+    - ``QPDFObjectHandle::replaceOrRemoveKey`` has been removed since
+      it was identical to ``QPDFObjectHandle::replaceKey``.
+
     - ``JSON::checkDictionaryKeySeen`` has been removed. If ``JSON::parse``
       encounters duplicate keys the last value is silently accepted instead
       of throwing a runtime error.

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -34,9 +34,6 @@
 #include <map>
 #include <sstream>
 
-#define QPDF_OBJECT_NOWARN
-#include <qpdf/QPDFObject.hh>
-
 static char const* whoami = nullptr;
 
 void
@@ -3489,10 +3486,6 @@ runtest(int n, char const* filename1, char const* arg2)
         QPDFObjectHandle uninitialized;
         assert(uninitialized.getTypeCode() == ::ot_uninitialized);
         assert(strcmp(uninitialized.getTypeName(), "uninitialized") == 0);
-
-        // ABI: until QPDF 12, spot check deprecated constants
-        assert(QPDFObject::ot_dictionary == ::ot_dictionary);
-        assert(QPDFObject::ot_uninitialized == ::ot_uninitialized);
     }
 
     QPDF pdf;


### PR DESCRIPTION
@m-holger Any issues? I'm deciding to leave QPDFObject.hh around indefinitely with an error. I don't think it hurts anything, and it's entirely possible for someone to be working on a system that has an ancient qpdf installed.