### PR TITLE
Refactor QPDFTokenizer

### DIFF
--- a/include/qpdf/QPDFTokenizer.hh
+++ b/include/qpdf/QPDFTokenizer.hh
@@ -29,6 +29,11 @@
 #include <memory>
 #include <string>
 
+namespace qpdf
+{
+    class Tokenizer;
+} // namespace qpdf
+
 class QPDFTokenizer
 {
   public:
@@ -129,6 +134,9 @@ class QPDFTokenizer
     QPDF_DLL
     QPDFTokenizer();
 
+    QPDF_DLL
+    ~QPDFTokenizer();
+
     // If called, treat EOF as a separate token type instead of an error.  This was introduced in
     // QPDF 4.1 to facilitate tokenizing content streams.
     QPDF_DLL
@@ -218,103 +226,7 @@ class QPDFTokenizer
     QPDFTokenizer(QPDFTokenizer const&) = delete;
     QPDFTokenizer& operator=(QPDFTokenizer const&) = delete;
 
-    bool isSpace(char);
-    bool isDelimiter(char);
-    void findEI(InputSource& input);
-
-    enum state_e {
-        st_top,
-        st_in_hexstring,
-        st_in_string,
-        st_in_hexstring_2nd,
-        st_name,
-        st_literal,
-        st_in_space,
-        st_in_comment,
-        st_string_escape,
-        st_char_code,
-        st_string_after_cr,
-        st_lt,
-        st_gt,
-        st_inline_image,
-        st_sign,
-        st_number,
-        st_real,
-        st_decimal,
-        st_name_hex1,
-        st_name_hex2,
-        st_before_token,
-        st_token_ready
-    };
-
-    void handleCharacter(char);
-    void inBeforeToken(char);
-    void inTop(char);
-    void inSpace(char);
-    void inComment(char);
-    void inString(char);
-    void inName(char);
-    void inLt(char);
-    void inGt(char);
-    void inStringAfterCR(char);
-    void inStringEscape(char);
-    void inLiteral(char);
-    void inCharCode(char);
-    void inHexstring(char);
-    void inHexstring2nd(char);
-    void inInlineImage(char);
-    void inTokenReady(char);
-    void inNameHex1(char);
-    void inNameHex2(char);
-    void inSign(char);
-    void inDecimal(char);
-    void inNumber(char);
-    void inReal(char);
-    void reset();
-
-    // Lexer state
-    state_e state;
-
-    bool allow_eof;
-    bool include_ignorable;
-
-    // Current token accumulation
-    token_type_e type;
-    std::string val;
-    std::string raw_val;
-    std::string error_message;
-    bool before_token;
-    bool in_token;
-    char char_to_unread;
-    size_t inline_image_bytes;
-    bool bad;
-
-    // State for strings
-    int string_depth;
-    int char_code;
-    char hex_char;
-    int digit_count;
+    std::unique_ptr<qpdf::Tokenizer> m;
 };
-
-inline QPDFTokenizer::token_type_e
-QPDFTokenizer::getType() const noexcept
-{
-    return this->type;
-}
-inline std::string const&
-QPDFTokenizer::getValue() const noexcept
-{
-    return (this->type == tt_name || this->type == tt_string) ? this->val : this->raw_val;
-}
-inline std::string const&
-QPDFTokenizer::getRawValue() const noexcept
-{
-    return this->raw_val;
-}
-inline std::string const&
-QPDFTokenizer::getErrorMessage() const noexcept
-{
-    return this->error_message;
-}
 
 #endif // QPDFTOKENIZER_HH

--- a/include/qpdf/QPDFTokenizer.hh
+++ b/include/qpdf/QPDFTokenizer.hh
@@ -206,23 +206,6 @@ class QPDFTokenizer
   private:
     friend class QPDFParser;
 
-    // Read a token from an input source. Context describes the context in which the token is being
-    // read and is used in the exception thrown if there is an error. After a token is read, the
-    // position of the input source returned by input->tell() points to just after the token, and
-    // the input source's "last offset" as returned by input->getLastOffset() points to the
-    // beginning of the token. Returns false if the token is bad or if scanning produced an error
-    // message for any reason.
-
-    bool nextToken(InputSource& input, std::string const& context, size_t max_len = 0);
-
-    // The following methods are only valid after nextToken has been called and until another
-    // QPDFTokenizer method is called. They allow the results of calling nextToken to be accessed
-    // without creating a Token, thus avoiding copying information that may not be needed.
-    inline token_type_e getType() const noexcept;
-    inline std::string const& getValue() const noexcept;
-    inline std::string const& getRawValue() const noexcept;
-    inline std::string const& getErrorMessage() const noexcept;
-
     QPDFTokenizer(QPDFTokenizer const&) = delete;
     QPDFTokenizer& operator=(QPDFTokenizer const&) = delete;
 

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -4,6 +4,7 @@
 #include <qpdf/QPDFObjGen.hh>
 #include <qpdf/QPDFObjectHandle.hh>
 #include <qpdf/QPDFObject_private.hh>
+#include <qpdf/QPDFTokenizer_private.hh>
 #include <qpdf/QTC.hh>
 #include <qpdf/QUtil.hh>
 

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -936,7 +936,13 @@ Tokenizer::getToken(Token& token, bool& unread_char, char& ch)
 bool
 QPDFTokenizer::betweenTokens()
 {
-    return m->before_token;
+    return m->betweenTokens();
+}
+
+bool
+Tokenizer::betweenTokens()
+{
+    return before_token;
 }
 
 QPDFTokenizer::Token
@@ -983,12 +989,6 @@ Tokenizer::readToken(
     std::shared_ptr<InputSource> input, std::string const& context, bool allow_bad, size_t max_len)
 {
     return readToken(*input, context, allow_bad, max_len);
-}
-
-bool
-QPDFTokenizer::nextToken(InputSource& input, std::string const& context, size_t max_len)
-{
-    return m->nextToken(input, context, max_len);
 }
 
 bool

--- a/libqpdf/QPDFTokenizer.cc
+++ b/libqpdf/QPDFTokenizer.cc
@@ -799,13 +799,7 @@ Tokenizer::presentEOF()
 void
 QPDFTokenizer::expectInlineImage(std::shared_ptr<InputSource> input)
 {
-    m->expectInlineImage(input);
-}
-
-void
-Tokenizer::expectInlineImage(std::shared_ptr<InputSource> input)
-{
-    expectInlineImage(*input);
+    m->expectInlineImage(*input);
 }
 
 void
@@ -953,6 +947,13 @@ QPDFTokenizer::readToken(
 }
 
 QPDFTokenizer::Token
+QPDFTokenizer::readToken(
+    std::shared_ptr<InputSource> input, std::string const& context, bool allow_bad, size_t max_len)
+{
+    return m->readToken(*input, context, allow_bad, max_len);
+}
+
+QPDFTokenizer::Token
 Tokenizer::readToken(InputSource& input, std::string const& context, bool allow_bad, size_t max_len)
 {
     nextToken(input, context, max_len);
@@ -975,20 +976,6 @@ Tokenizer::readToken(InputSource& input, std::string const& context, bool allow_
         }
     }
     return token;
-}
-
-QPDFTokenizer::Token
-QPDFTokenizer::readToken(
-    std::shared_ptr<InputSource> input, std::string const& context, bool allow_bad, size_t max_len)
-{
-    return m->readToken(*input, context, allow_bad, max_len);
-}
-
-QPDFTokenizer::Token
-Tokenizer::readToken(
-    std::shared_ptr<InputSource> input, std::string const& context, bool allow_bad, size_t max_len)
-{
-    return readToken(*input, context, allow_bad, max_len);
 }
 
 bool

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -3,6 +3,7 @@
 
 #include <qpdf/QPDFObjectHandle_private.hh>
 #include <qpdf/QPDFObject_private.hh>
+#include <qpdf/QPDFTokenizer_private.hh>
 
 #include <memory>
 #include <string>
@@ -20,7 +21,7 @@ class QPDFParser
         bool parse_pdf) :
         input(input),
         object_description(object_description),
-        tokenizer(tokenizer),
+        tokenizer(*tokenizer.m),
         decrypter(decrypter),
         context(context),
         description(
@@ -75,7 +76,7 @@ class QPDFParser
     void setDescription(std::shared_ptr<QPDFObject>& obj, qpdf_offset_t parsed_offset);
     InputSource& input;
     std::string const& object_description;
-    QPDFTokenizer& tokenizer;
+    qpdf::Tokenizer& tokenizer;
     QPDFObjectHandle::StringDecrypter* decrypter;
     QPDF* context;
     std::shared_ptr<QPDFObject::Description> description;

--- a/libqpdf/qpdf/QPDFTokenizer_private.hh
+++ b/libqpdf/qpdf/QPDFTokenizer_private.hh
@@ -8,10 +8,10 @@ namespace qpdf
 
     class Tokenizer
     {
-        friend class ::QPDFTokenizer;
-
       public:
         Tokenizer();
+        Tokenizer(Tokenizer const&) = delete;
+        Tokenizer& operator=(Tokenizer const&) = delete;
 
         // Methods to support QPDFTokenizer. See QPDFTokenizer.hh for detail. Some of these are used
         // by Tokenizer internally but are not accessed directly by the rest of qpdf.
@@ -20,13 +20,12 @@ namespace qpdf
         void includeIgnorable();
         void presentCharacter(char ch);
         void presentEOF();
+        bool betweenTokens();
 
         // If a token is available, return true and initialize token with the token, unread_char
         // with whether or not we have to unread the last character, and if unread_char, ch with the
         // character to unread.
         bool getToken(QPDFTokenizer::Token& token, bool& unread_char, char& ch);
-
-        // Pull mode:
 
         // Read a token from an input source. Context describes the context in which the token is
         // being read and is used in the exception thrown if there is an error. After a token is
@@ -55,7 +54,6 @@ namespace qpdf
 
         void expectInlineImage(InputSource& input);
 
-      private:
         // Read a token from an input source. Context describes the context in which the token is
         // being read and is used in the exception thrown if there is an error. After a token is
         // read, the position of the input source returned by input->tell() points to just after the
@@ -73,9 +71,7 @@ namespace qpdf
         inline std::string const& getRawValue() const;
         inline std::string const& getErrorMessage() const;
 
-        Tokenizer(Tokenizer const&) = delete;
-        Tokenizer& operator=(Tokenizer const&) = delete;
-
+      private:
         bool isSpace(char);
         bool isDelimiter(char);
         void findEI(InputSource& input);
@@ -178,26 +174,5 @@ namespace qpdf
     }
 
 } // namespace qpdf
-
-inline QPDFTokenizer::token_type_e
-QPDFTokenizer::getType() const noexcept
-{
-    return m->type;
-}
-inline std::string const&
-QPDFTokenizer::getValue() const noexcept
-{
-    return (m->type == tt_name || m->type == tt_string) ? m->val : m->raw_val;
-}
-inline std::string const&
-QPDFTokenizer::getRawValue() const noexcept
-{
-    return m->raw_val;
-}
-inline std::string const&
-QPDFTokenizer::getErrorMessage() const noexcept
-{
-    return m->error_message;
-}
 
 #endif // QPDFTOKENIZER_PRIVATE_HH

--- a/libqpdf/qpdf/QPDFTokenizer_private.hh
+++ b/libqpdf/qpdf/QPDFTokenizer_private.hh
@@ -38,20 +38,12 @@ namespace qpdf
             bool allow_bad = false,
             size_t max_len = 0);
 
-        QPDFTokenizer::Token readToken(
-            std::shared_ptr<InputSource> input,
-            std::string const& context,
-            bool allow_bad = false,
-            size_t max_len = 0);
-
         // Calling this method puts the tokenizer in a state for reading inline images. You should
         // call this method after reading the character following the ID operator. In that state, it
         // will return all data up to BUT NOT INCLUDING the next EI token. After you call this
         // method, the next call to readToken (or the token created next time getToken returns true)
         // will either be tt_inline_image or tt_bad. This is the only way readToken returns a
         // tt_inline_image token.
-        void expectInlineImage(std::shared_ptr<InputSource> input);
-
         void expectInlineImage(InputSource& input);
 
         // Read a token from an input source. Context describes the context in which the token is
@@ -66,10 +58,29 @@ namespace qpdf
         // QPDFTokenizer method is called. They allow the results of calling nextToken to be
         // accessed without creating a Token, thus avoiding copying information that may not be
         // needed.
-        inline QPDFTokenizer::token_type_e getType() const;
-        inline std::string const& getValue() const;
-        inline std::string const& getRawValue() const;
-        inline std::string const& getErrorMessage() const;
+
+        inline QPDFTokenizer::token_type_e
+        getType() const
+        {
+            return this->type;
+        }
+        inline std::string const&
+        getValue() const
+        {
+            return (this->type == QPDFTokenizer::tt_name || this->type == QPDFTokenizer::tt_string)
+                ? this->val
+                : this->raw_val;
+        }
+        inline std::string const&
+        getRawValue() const
+        {
+            return this->raw_val;
+        }
+        inline std::string const&
+        getErrorMessage() const
+        {
+            return this->error_message;
+        }
 
       private:
         bool isSpace(char);
@@ -149,29 +160,6 @@ namespace qpdf
         char hex_char;
         int digit_count;
     };
-
-    inline QPDFTokenizer::token_type_e
-    Tokenizer::getType() const
-    {
-        return this->type;
-    }
-    inline std::string const&
-    Tokenizer::getValue() const
-    {
-        return (this->type == QPDFTokenizer::tt_name || this->type == QPDFTokenizer::tt_string)
-            ? this->val
-            : this->raw_val;
-    }
-    inline std::string const&
-    Tokenizer::getRawValue() const
-    {
-        return this->raw_val;
-    }
-    inline std::string const&
-    Tokenizer::getErrorMessage() const
-    {
-        return this->error_message;
-    }
 
 } // namespace qpdf
 

--- a/libqpdf/qpdf/QPDFTokenizer_private.hh
+++ b/libqpdf/qpdf/QPDFTokenizer_private.hh
@@ -1,0 +1,203 @@
+#ifndef QPDFTOKENIZER_PRIVATE_HH
+#define QPDFTOKENIZER_PRIVATE_HH
+
+#include <qpdf/QPDFTokenizer.hh>
+
+namespace qpdf
+{
+
+    class Tokenizer
+    {
+        friend class ::QPDFTokenizer;
+
+      public:
+        Tokenizer();
+
+        // Methods to support QPDFTokenizer. See QPDFTokenizer.hh for detail. Some of these are used
+        // by Tokenizer internally but are not accessed directly by the rest of qpdf.
+
+        void allowEOF();
+        void includeIgnorable();
+        void presentCharacter(char ch);
+        void presentEOF();
+
+        // If a token is available, return true and initialize token with the token, unread_char
+        // with whether or not we have to unread the last character, and if unread_char, ch with the
+        // character to unread.
+        bool getToken(QPDFTokenizer::Token& token, bool& unread_char, char& ch);
+
+        // Pull mode:
+
+        // Read a token from an input source. Context describes the context in which the token is
+        // being read and is used in the exception thrown if there is an error. After a token is
+        // read, the position of the input source returned by input->tell() points to just after the
+        // token, and the input source's "last offset" as returned by input->getLastOffset() points
+        // to the beginning of the token.
+        QPDFTokenizer::Token readToken(
+            InputSource& input,
+            std::string const& context,
+            bool allow_bad = false,
+            size_t max_len = 0);
+
+        QPDFTokenizer::Token readToken(
+            std::shared_ptr<InputSource> input,
+            std::string const& context,
+            bool allow_bad = false,
+            size_t max_len = 0);
+
+        // Calling this method puts the tokenizer in a state for reading inline images. You should
+        // call this method after reading the character following the ID operator. In that state, it
+        // will return all data up to BUT NOT INCLUDING the next EI token. After you call this
+        // method, the next call to readToken (or the token created next time getToken returns true)
+        // will either be tt_inline_image or tt_bad. This is the only way readToken returns a
+        // tt_inline_image token.
+        void expectInlineImage(std::shared_ptr<InputSource> input);
+
+        void expectInlineImage(InputSource& input);
+
+      private:
+        // Read a token from an input source. Context describes the context in which the token is
+        // being read and is used in the exception thrown if there is an error. After a token is
+        // read, the position of the input source returned by input->tell() points to just after the
+        // token, and the input source's "last offset" as returned by input->getLastOffset() points
+        // to the beginning of the token. Returns false if the token is bad or if scanning produced
+        // an error message for any reason.
+        bool nextToken(InputSource& input, std::string const& context, size_t max_len = 0);
+
+        // The following methods are only valid after nextToken has been called and until another
+        // QPDFTokenizer method is called. They allow the results of calling nextToken to be
+        // accessed without creating a Token, thus avoiding copying information that may not be
+        // needed.
+        inline QPDFTokenizer::token_type_e getType() const;
+        inline std::string const& getValue() const;
+        inline std::string const& getRawValue() const;
+        inline std::string const& getErrorMessage() const;
+
+        Tokenizer(Tokenizer const&) = delete;
+        Tokenizer& operator=(Tokenizer const&) = delete;
+
+        bool isSpace(char);
+        bool isDelimiter(char);
+        void findEI(InputSource& input);
+
+        enum state_e {
+            st_top,
+            st_in_hexstring,
+            st_in_string,
+            st_in_hexstring_2nd,
+            st_name,
+            st_literal,
+            st_in_space,
+            st_in_comment,
+            st_string_escape,
+            st_char_code,
+            st_string_after_cr,
+            st_lt,
+            st_gt,
+            st_inline_image,
+            st_sign,
+            st_number,
+            st_real,
+            st_decimal,
+            st_name_hex1,
+            st_name_hex2,
+            st_before_token,
+            st_token_ready
+        };
+
+        void handleCharacter(char);
+        void inBeforeToken(char);
+        void inTop(char);
+        void inSpace(char);
+        void inComment(char);
+        void inString(char);
+        void inName(char);
+        void inLt(char);
+        void inGt(char);
+        void inStringAfterCR(char);
+        void inStringEscape(char);
+        void inLiteral(char);
+        void inCharCode(char);
+        void inHexstring(char);
+        void inHexstring2nd(char);
+        void inInlineImage(char);
+        void inTokenReady(char);
+        void inNameHex1(char);
+        void inNameHex2(char);
+        void inSign(char);
+        void inDecimal(char);
+        void inNumber(char);
+        void inReal(char);
+        void reset();
+
+        // Lexer state
+        state_e state;
+
+        bool allow_eof{false};
+        bool include_ignorable{false};
+
+        // Current token accumulation
+        QPDFTokenizer::token_type_e type;
+        std::string val;
+        std::string raw_val;
+        std::string error_message;
+        bool before_token;
+        bool in_token;
+        char char_to_unread;
+        size_t inline_image_bytes;
+        bool bad;
+
+        // State for strings
+        int string_depth;
+        int char_code;
+        char hex_char;
+        int digit_count;
+    };
+
+    inline QPDFTokenizer::token_type_e
+    Tokenizer::getType() const
+    {
+        return this->type;
+    }
+    inline std::string const&
+    Tokenizer::getValue() const
+    {
+        return (this->type == QPDFTokenizer::tt_name || this->type == QPDFTokenizer::tt_string)
+            ? this->val
+            : this->raw_val;
+    }
+    inline std::string const&
+    Tokenizer::getRawValue() const
+    {
+        return this->raw_val;
+    }
+    inline std::string const&
+    Tokenizer::getErrorMessage() const
+    {
+        return this->error_message;
+    }
+
+} // namespace qpdf
+
+inline QPDFTokenizer::token_type_e
+QPDFTokenizer::getType() const noexcept
+{
+    return m->type;
+}
+inline std::string const&
+QPDFTokenizer::getValue() const noexcept
+{
+    return (m->type == tt_name || m->type == tt_string) ? m->val : m->raw_val;
+}
+inline std::string const&
+QPDFTokenizer::getRawValue() const noexcept
+{
+    return m->raw_val;
+}
+inline std::string const&
+QPDFTokenizer::getErrorMessage() const noexcept
+{
+    return m->error_message;
+}
+
+#endif // QPDFTOKENIZER_PRIVATE_HH


### PR DESCRIPTION
To facilitate future refactoring, turn QPDFTokenizer into the private class qpdf::Tokenizer and recreate the public parts of QPDFTokenizer as a thin wrapper around Tokenizer.