### PR TITLE
Fix object stream error/warning messages reporting wrong object id

### DIFF
--- a/libqpdf/QPDF_objects.cc
+++ b/libqpdf/QPDF_objects.cc
@@ -1613,6 +1613,7 @@ QPDF::resolveObjectsInStream(int obj_stream_number)
     QPDFObjectHandle obj_stream = getObjectByID(obj_stream_number, 0);
     if (!obj_stream.isStream()) {
         throw damagedPDF(
+            "object " + std::to_string(obj_stream_number) + " 0",
             "supposed object stream " + std::to_string(obj_stream_number) + " is not a stream");
     }
 
@@ -1626,12 +1627,14 @@ QPDF::resolveObjectsInStream(int obj_stream_number)
     if (!dict.isDictionaryOfType("/ObjStm")) {
         QTC::TC("qpdf", "QPDF ERR object stream with wrong type");
         warn(damagedPDF(
+            "object " + std::to_string(obj_stream_number) + " 0",
             "supposed object stream " + std::to_string(obj_stream_number) + " has wrong type"));
     }
 
     if (!(dict.getKey("/N").isInteger() && dict.getKey("/First").isInteger())) {
         throw damagedPDF(
-            ("object stream " + std::to_string(obj_stream_number) + " has incorrect keys"));
+            "object " + std::to_string(obj_stream_number) + " 0",
+            "object stream " + std::to_string(obj_stream_number) + " has incorrect keys");
     }
 
     int n = dict.getKey("/N").getIntValueAsInt();
@@ -1653,7 +1656,7 @@ QPDF::resolveObjectsInStream(int obj_stream_number)
         if (!(tnum.isInteger() && toffset.isInteger())) {
             throw damagedPDF(
                 *input,
-                m->last_object_description,
+                "object " + std::to_string(obj_stream_number) + " 0",
                 input->getLastOffset(),
                 "expected integer in object stream header");
         }
@@ -1665,7 +1668,7 @@ QPDF::resolveObjectsInStream(int obj_stream_number)
             QTC::TC("qpdf", "QPDF ignore self-referential object stream");
             warn(damagedPDF(
                 *input,
-                m->last_object_description,
+                "object " + std::to_string(obj_stream_number) + " 0",
                 input->getLastOffset(),
                 "object stream claims to contain itself"));
             continue;
@@ -1675,8 +1678,8 @@ QPDF::resolveObjectsInStream(int obj_stream_number)
             QTC::TC("qpdf", "QPDF object stream contains id < 1");
             warn(damagedPDF(
                 *input,
-                "object "s + std::to_string(num) + " 0, offset " + std::to_string(offset),
-                0,
+                "object " + std::to_string(num) + " 0",
+                input->getLastOffset(),
                 "object id is invalid"s));
             continue;
         }
@@ -1685,8 +1688,8 @@ QPDF::resolveObjectsInStream(int obj_stream_number)
             QTC::TC("qpdf", "QPDF object stream offsets not increasing");
             warn(damagedPDF(
                 *input,
-                "object "s + std::to_string(num) + " 0, offset " + std::to_string(offset),
-                0,
+                "object " + std::to_string(num) + " 0",
+                offset,
                 "offset is invalid (must be larger than previous offset " +
                     std::to_string(last_offset) + ")"));
             continue;

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -21,6 +21,9 @@ more detail.
       integer object. Previously the method returned false if the first
       dictionary object was not a linearization parameter dictionary.
 
+    - Fix two object stream error/warning messages that reported the wrong
+      object id.
+
   - Other enhancements
 
     - There have been further enhancements to how files with damaged xref

--- a/qpdf/qtest/qpdf/fuzz-16214.out
+++ b/qpdf/qtest/qpdf/fuzz-16214.out
@@ -16,8 +16,8 @@ WARNING: fuzz-16214.pdf (object 1 0, offset 7189): expected n n obj
 WARNING: fuzz-16214.pdf: Attempting to reconstruct cross-reference table
 WARNING: fuzz-16214.pdf (offset 7207): error decoding stream data for object 2 0: stream inflate: inflate: data: invalid code lengths set
 WARNING: fuzz-16214.pdf (offset 7207): getStreamData called on unfilterable stream
-WARNING: fuzz-16214.pdf (object 7 0, offset 7207): supposed object stream 5 has wrong type
-WARNING: fuzz-16214.pdf (object 7 0, offset 7207): object stream 5 has incorrect keys
+WARNING: fuzz-16214.pdf (object 5 0, offset 7207): supposed object stream 5 has wrong type
+WARNING: fuzz-16214.pdf (object 5 0, offset 7207): object stream 5 has incorrect keys
 WARNING: fuzz-16214.pdf (object 21 0, offset 3639): expected endstream
 WARNING: fuzz-16214.pdf (object 21 0, offset 3112): attempting to recover stream length
 WARNING: fuzz-16214.pdf (object 21 0, offset 3112): recovered stream length: 340

--- a/qpdf/qtest/qpdf/issue-143.out
+++ b/qpdf/qtest/qpdf/issue-143.out
@@ -14,9 +14,9 @@ WARNING: issue-143.pdf (object 1 0, offset 24): expected dictionary key but foun
 WARNING: issue-143.pdf (object 1 0, offset 21): stream dictionary lacks /Length key
 WARNING: issue-143.pdf (object 1 0, offset 84): attempting to recover stream length
 WARNING: issue-143.pdf (object 1 0, offset 84): recovered stream length: 606
-WARNING: issue-143.pdf object stream 1 (object 0 0, offset 0): object id is invalid
-WARNING: issue-143.pdf object stream 1 (object 0 0, offset 0): object id is invalid
-WARNING: issue-143.pdf object stream 1 (object 6 0, offset 0): offset is invalid (must be larger than previous offset 0)
-WARNING: issue-143.pdf object stream 1 (object 0 0, offset 0): object id is invalid
+WARNING: issue-143.pdf object stream 1 (object 0 0, offset 4): object id is invalid
+WARNING: issue-143.pdf object stream 1 (object 0 0, offset 15): object id is invalid
+WARNING: issue-143.pdf object stream 1 (object 6 0): offset is invalid (must be larger than previous offset 0)
+WARNING: issue-143.pdf object stream 1 (object 0 0, offset 27): object id is invalid
 WARNING: issue-143.pdf object stream 1 (object 2 0, offset 33): expected dictionary key but found non-name object; inserting key /QPDFFake1
 qpdf: issue-143.pdf: unable to find page tree


### PR DESCRIPTION
This was due to the use of last_object_description, which is not set for the object stream itself.

Also, modify the messages introduced #1391 and #1392 to report the supposed offset of the objects.