### PR TITLE
Refactor QPDF::resolveObjectsInStream

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -785,7 +785,7 @@ class QPDF
     QPDFObjectHandle readObject(std::string const& description, QPDFObjGen og);
     void readStream(QPDFObjectHandle& object, QPDFObjGen og, qpdf_offset_t offset);
     void validateStreamLineEnd(QPDFObjectHandle& object, QPDFObjGen og, qpdf_offset_t offset);
-    QPDFObjectHandle readObjectInStream(BufferInputSource& input, int obj);
+    QPDFObjectHandle readObjectInStream(BufferInputSource& input, int stream_id, int obj_id);
     size_t recoverStreamLength(
         std::shared_ptr<InputSource> input, QPDFObjGen og, qpdf_offset_t stream_offset);
     QPDFTokenizer::Token readToken(InputSource&, size_t max_len = 0);

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -48,6 +48,7 @@
 class QPDF_Stream;
 class BitStream;
 class BitWriter;
+class BufferInputSource;
 class QPDFLogger;
 class QPDFParser;
 
@@ -784,7 +785,7 @@ class QPDF
     QPDFObjectHandle readObject(std::string const& description, QPDFObjGen og);
     void readStream(QPDFObjectHandle& object, QPDFObjGen og, qpdf_offset_t offset);
     void validateStreamLineEnd(QPDFObjectHandle& object, QPDFObjGen og, qpdf_offset_t offset);
-    QPDFObjectHandle readObjectInStream(std::shared_ptr<InputSource>& input, int obj);
+    QPDFObjectHandle readObjectInStream(BufferInputSource& input, int obj);
     size_t recoverStreamLength(
         std::shared_ptr<InputSource> input, QPDFObjGen og, qpdf_offset_t stream_offset);
     QPDFTokenizer::Token readToken(InputSource&, size_t max_len = 0);

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -10,6 +10,8 @@
 
 #include <memory>
 
+using namespace std::literals;
+
 using ObjectPtr = std::shared_ptr<QPDFObject>;
 
 QPDFObjectHandle
@@ -524,7 +526,13 @@ QPDFParser::warnDuplicateKey()
 void
 QPDFParser::warn(qpdf_offset_t offset, std::string const& msg) const
 {
-    warn(QPDFExc(qpdf_e_damaged_pdf, input.getName(), object_description, offset, msg));
+    if (stream_id) {
+        std::string descr = "object "s + std::to_string(obj_id) + " 0";
+        std::string name = context->getFilename() + " object stream " + std::to_string(stream_id);
+        warn(QPDFExc(qpdf_e_damaged_pdf, name, descr, offset, msg));
+    } else {
+        warn(QPDFExc(qpdf_e_damaged_pdf, input.getName(), object_description, offset, msg));
+    }
 }
 
 void

--- a/libqpdf/qpdf/QPDFObjectHandle_private.hh
+++ b/libqpdf/qpdf/QPDFObjectHandle_private.hh
@@ -4,6 +4,7 @@
 #include <qpdf/QPDFObjectHandle.hh>
 
 #include <qpdf/QPDFObject_private.hh>
+#include <qpdf/QPDF_private.hh>
 #include <qpdf/QUtil.hh>
 
 namespace qpdf
@@ -426,6 +427,18 @@ inline std::shared_ptr<QPDFObject>
 QPDFObject::create(Args&&... args)
 {
     return std::make_shared<QPDFObject>(std::forward<T>(T(std::forward<Args>(args)...)));
+}
+
+inline qpdf_object_type_e
+QPDFObject::getResolvedTypeCode() const
+{
+    if (getTypeCode() == ::ot_unresolved) {
+        return QPDF::Resolver::resolved(qpdf, og)->getTypeCode();
+    }
+    if (getTypeCode() == ::ot_reference) {
+        return std::get<QPDF_Reference>(value).obj->getTypeCode();
+    }
+    return getTypeCode();
 }
 
 inline qpdf::Array

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -7,8 +7,8 @@
 #include <qpdf/Constants.h>
 #include <qpdf/JSON.hh>
 #include <qpdf/JSON_writer.hh>
+#include <qpdf/QPDF.hh>
 #include <qpdf/QPDFObjGen.hh>
-#include <qpdf/QPDF_private.hh>
 #include <qpdf/Types.h>
 
 #include <map>
@@ -301,17 +301,8 @@ class QPDFObject
     std::string getStringValue() const;
 
     // Return a unique type code for the resolved object
-    qpdf_object_type_e
-    getResolvedTypeCode() const
-    {
-        if (getTypeCode() == ::ot_unresolved) {
-            return QPDF::Resolver::resolved(qpdf, og)->getTypeCode();
-        }
-        if (getTypeCode() == ::ot_reference) {
-            return std::get<QPDF_Reference>(value).obj->getTypeCode();
-        }
-        return getTypeCode();
-    }
+    inline qpdf_object_type_e getResolvedTypeCode() const;
+
     // Return a unique type code for the object
     qpdf_object_type_e
     getTypeCode() const

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -381,7 +381,17 @@ class QPDFObject
         std::string var_descr;
     };
 
-    using Description = std::variant<std::string, JSON_Descr, ChildDescr>;
+    struct ObjStreamDescr
+    {
+        ObjStreamDescr(int stream_id, int obj_id) :
+            stream_id(stream_id),
+            obj_id(obj_id) {};
+
+        int stream_id;
+        int obj_id;
+    };
+
+    using Description = std::variant<std::string, JSON_Descr, ChildDescr, ObjStreamDescr>;
 
     void
     setDescription(

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -62,9 +62,32 @@ class QPDFParser
         decrypter(nullptr),
         context(context),
         description(std::move(sp_description)),
-        parse_pdf(false)
+        parse_pdf(true)
     {
     }
+
+    // Used by readObjectInStream only
+    QPDFParser(
+        InputSource& input,
+        int stream_id,
+        int obj_id,
+        std::string const& object_description,
+        qpdf::Tokenizer& tokenizer,
+        QPDF* context) :
+        input(input),
+        object_description(object_description),
+        tokenizer(tokenizer),
+        decrypter(nullptr),
+        context(context),
+        description(
+            std::make_shared<QPDFObject::Description>(
+                QPDFObject::ObjStreamDescr(stream_id, obj_id))),
+        parse_pdf(true),
+        stream_id(stream_id),
+        obj_id(obj_id)
+    {
+    }
+
     ~QPDFParser() = default;
 
     QPDFObjectHandle parse(bool& empty, bool content_stream);
@@ -124,6 +147,8 @@ class QPDFParser
     QPDF* context;
     std::shared_ptr<QPDFObject::Description> description;
     bool parse_pdf;
+    int stream_id{0};
+    int obj_id{0};
 
     std::vector<StackFrame> stack;
     StackFrame* frame{nullptr};

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -3,6 +3,7 @@
 
 #include <qpdf/QPDF.hh>
 
+#include <qpdf/QPDFObject_private.hh>
 #include <qpdf/QPDFTokenizer_private.hh>
 
 // Writer class is restricted to QPDFWriter so that only it can call certain methods.
@@ -457,6 +458,7 @@ class QPDF::Members
     qpdf::Tokenizer tokenizer;
     std::shared_ptr<InputSource> file;
     std::string last_object_description;
+    std::shared_ptr<QPDFObject::Description> last_ostream_description;
     bool provided_password_is_hex_key{false};
     bool ignore_xref_streams{false};
     bool suppress_warnings{false};

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -29,6 +29,12 @@ more detail.
     - There have been further enhancements to how files with damaged xref
       tables are recovered.
 
+  - Other changes
+
+    - The parsing of object streams including the creation of error/warning
+      messages and object descriptions has been refactored with some
+      improvement both in runtime and memory usage.
+
     - There has been some refactoring of how object streams are written with
       some performance improvement.
 


### PR DESCRIPTION
Main changes:

- object description strings are now only created when needed
- a vector is used instead of a map to process the object id / offset info

