### PR TITLE
Fix parsing of object streams containing objects with no white-space between them

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -45,6 +45,11 @@
 #include <qpdf/QPDFWriter.hh>
 #include <qpdf/QPDFXRefEntry.hh>
 
+namespace qpdf::is
+{
+    class OffsetBuffer;
+}
+
 class QPDF_Stream;
 class BitStream;
 class BitWriter;
@@ -785,7 +790,7 @@ class QPDF
     QPDFObjectHandle readObject(std::string const& description, QPDFObjGen og);
     void readStream(QPDFObjectHandle& object, QPDFObjGen og, qpdf_offset_t offset);
     void validateStreamLineEnd(QPDFObjectHandle& object, QPDFObjGen og, qpdf_offset_t offset);
-    QPDFObjectHandle readObjectInStream(BufferInputSource& input, int stream_id, int obj_id);
+    QPDFObjectHandle readObjectInStream(qpdf::is::OffsetBuffer& input, int stream_id, int obj_id);
     size_t recoverStreamLength(
         std::shared_ptr<InputSource> input, QPDFObjGen og, qpdf_offset_t stream_offset);
     QPDFTokenizer::Token readToken(InputSource&, size_t max_len = 0);

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -12,6 +12,7 @@
 #include <memory>
 
 using namespace std::literals;
+using namespace qpdf;
 
 using ObjectPtr = std::shared_ptr<QPDFObject>;
 
@@ -87,7 +88,7 @@ QPDFParser::parse(
 
 std::pair<QPDFObjectHandle, bool>
 QPDFParser::parse(
-    BufferInputSource& input, int stream_id, int obj_id, qpdf::Tokenizer& tokenizer, QPDF& context)
+    is::OffsetBuffer& input, int stream_id, int obj_id, qpdf::Tokenizer& tokenizer, QPDF& context)
 {
     bool empty{false};
     auto result = QPDFParser(

--- a/libqpdf/qpdf/InputSource_private.hh
+++ b/libqpdf/qpdf/InputSource_private.hh
@@ -1,7 +1,84 @@
 #ifndef QPDF_INPUTSOURCE_PRIVATE_HH
 #define QPDF_INPUTSOURCE_PRIVATE_HH
 
+#include <qpdf/BufferInputSource.hh>
 #include <qpdf/InputSource.hh>
+
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+namespace qpdf::is
+{
+    class OffsetBuffer final: public InputSource
+    {
+      public:
+        OffsetBuffer(std::string const& description, Buffer* buf, qpdf_offset_t global_offset) :
+            proxied(description, buf),
+            global_offset(global_offset)
+        {
+            if (global_offset < 0) {
+                throw std::logic_error("is::OffsetBuffer constructed with negative offset");
+            }
+            last_offset = global_offset;
+        }
+
+        ~OffsetBuffer() final = default;
+
+        qpdf_offset_t
+        findAndSkipNextEOL() final
+        {
+            return proxied.findAndSkipNextEOL() + global_offset;
+        }
+
+        std::string const&
+        getName() const final
+        {
+            return proxied.getName();
+        }
+
+        qpdf_offset_t
+        tell() final
+        {
+            return proxied.tell() + global_offset;
+        }
+
+        void
+        seek(qpdf_offset_t offset, int whence) final
+        {
+            if (whence == SEEK_SET) {
+                proxied.seek(offset - global_offset, whence);
+            } else {
+                proxied.seek(offset, whence);
+            }
+        }
+
+        void
+        rewind() final
+        {
+            seek(0, SEEK_SET);
+        }
+
+        size_t
+        read(char* buffer, size_t length) final
+        {
+            size_t result = proxied.read(buffer, length);
+            setLastOffset(proxied.getLastOffset() + global_offset);
+            return result;
+        }
+
+        void
+        unreadCh(char ch) final
+        {
+            proxied.unreadCh(ch);
+        }
+
+      private:
+        BufferInputSource proxied;
+        qpdf_offset_t global_offset;
+    };
+
+} // namespace qpdf::is
 
 inline size_t
 InputSource::read(std::string& str, size_t count, qpdf_offset_t at)

--- a/libqpdf/qpdf/QPDFParser.hh
+++ b/libqpdf/qpdf/QPDFParser.hh
@@ -1,6 +1,7 @@
 #ifndef QPDFPARSER_HH
 #define QPDFPARSER_HH
 
+#include <qpdf/InputSource_private.hh>
 #include <qpdf/QPDFObjectHandle_private.hh>
 #include <qpdf/QPDFObject_private.hh>
 #include <qpdf/QPDFTokenizer_private.hh>
@@ -38,7 +39,7 @@ class QPDFParser
         QPDF& context);
 
     static std::pair<QPDFObjectHandle, bool> parse(
-        BufferInputSource& input,
+        qpdf::is::OffsetBuffer& input,
         int stream_id,
         int obj_id,
         qpdf::Tokenizer& tokenizer,

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -21,6 +21,11 @@ more detail.
       integer object. Previously the method returned false if the first
       dictionary object was not a linearization parameter dictionary.
 
+    = Fix parsing of object streams containing objects not seperated by
+      white-space. Pre-2020 editions of the PDF specification incorrectly
+      stated that white-space was required between objects. qpdf relied on this
+      when parsing object streams.
+
     - Fix two object stream error/warning messages that reported the wrong
       object id.
 

--- a/qpdf/qtest/object-stream.test
+++ b/qpdf/qtest/object-stream.test
@@ -124,7 +124,7 @@ $td->runtest("adjacent compressed objects",
              {$td->COMMAND => "test_driver 99 no-space-compressed-object.pdf"},
              {$td->FILE => "no-space-compressed-object.out",
               $td->EXIT_STATUS => 0},
-             $td->EXPECT_FAILURE);
+             $td->NORMALIZE_NEWLINES);
 
 cleanup();
 $td->report(calc_ntests($n_tests, $n_compare_pdfs));


### PR DESCRIPTION
To enforce the rule that objects end at the start-offset of the next
object, each object is parsed in it own object stream.

To facilitate this, a new private API input source is::OffsetBuffer has
been added which only contains the object but reports offsets relative to
the start of the object stream. This is adapted from OffsetInputSource by
changing the direction of the offset, endowing it with its own
BufferInputSource and striooing out checks duplicated in BufferInputSource.

Fixes the expected failure in the test case added in #1266.