### PR TITLE
Refactor QPDFWriter::writeObjectStreamOffsets

### DIFF
--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -19,6 +19,7 @@
 #include <qpdf/QTC.hh>
 #include <qpdf/QUtil.hh>
 #include <qpdf/RC4.hh>
+#include <qpdf/Util.hh>
 
 #include <algorithm>
 #include <cstdlib>
@@ -1624,14 +1625,19 @@ QPDFWriter::unparseObject(
 void
 QPDFWriter::writeObjectStreamOffsets(std::vector<qpdf_offset_t>& offsets, int first_obj)
 {
-    for (size_t i = 0; i < offsets.size(); ++i) {
-        if (i != 0) {
+    qpdf_assert_debug(first_obj > 0);
+    bool is_first = true;
+    auto id = std::to_string(first_obj) + ' ';
+    for (auto& offset: offsets) {
+        if (is_first) {
+            is_first = false;
+        } else {
             writeStringQDF("\n");
             writeStringNoQDF(" ");
         }
-        writeString(std::to_string(i + QIntC::to_size(first_obj)));
-        writeString(" ");
-        writeString(std::to_string(offsets.at(i)));
+        writeString(id);
+        util::increment(id, 1);
+        writeString(std::to_string(offset));
     }
     writeString("\n");
 }

--- a/libqpdf/qpdf/Util.hh
+++ b/libqpdf/qpdf/Util.hh
@@ -44,6 +44,21 @@ namespace qpdf::util
         return {'#', hexchars[static_cast<unsigned char>(c) >> 4], hexchars[c & 0x0f]};
     }
 
+    // Numerically increment a digit string. Ignore the last 'tail' characters.
+    inline void
+    increment(std::string& s, int tail = 0)
+    {
+        auto end = s.rend();
+        for (auto it = s.rbegin() + tail; it != end; ++it) {
+            ++*it;
+            if (*it != ':') {
+                return;
+            }
+            *it = '0';
+        }
+        s.insert(0, 1, '1');
+    }
+
 } // namespace qpdf::util
 
 #endif // UTIL_HH


### PR DESCRIPTION
Rather than converting each (sequential) object id to a string, generate a string for the first id and than increment the digits in the string.