### PR TITLE
CMake: correctly detect that timezone is not an int

### DIFF
--- a/libqpdf/CMakeLists.txt
+++ b/libqpdf/CMakeLists.txt
@@ -328,7 +328,7 @@ check_c_source_compiles(
 #include <stdio.h>
 int main(int argc, char* argv[]) {
     tzset();
-    printf(\"%ld\", timezone);
+    printf(\"%ld\", timezone / 60);
     return 0;
 }"
     HAVE_EXTERN_LONG_TIMEZONE)


### PR DESCRIPTION
The simple CMake test that `printf("%ld", timezone)` **incorrectly set  `HAVE_EXTERN_LONG_TIMEZONE=1`**\
after casting FreeBSD's `char * timezone(int zone, int dst)` pointer function to an int.

By dividing it by `60` (as will occur in the .cc file), we ensure the test program will fail,\
and thus we get `HAVE_EXTERN_LONG_TIMEZONE` not to be defined.