### PR TITLE
Replace JetBrains-specific cmake profiles with CMakePresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ appimage/build
 .cache
 /html
 Doxyfile
+/CMakeUserPresets.json
+/compile_commands.json
+
+# ./Testing is created if you run ctest from the wrong place.
+/Testing

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -7,3 +7,5 @@
 /dataSources/
 /dataSources.local.xml
 /inspectionProfiles
+# We use CMakePresets.json. Don't check in cmake profiles.
+/cmake.xml

--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="CMakeSharedSettings">
-    <configurations>
-      <configuration PROFILE_NAME="Maintainer" ENABLED="true" CONFIG_NAME="RelWithDebInfo" GENERATION_OPTIONS="-DMAINTAINER_MODE=ON -DBUILD_STATIC_LIBS=OFF" />
-      <configuration PROFILE_NAME="Windows" ENABLED="true" CONFIG_NAME="RelWithDebInfo" TOOLCHAIN_NAME="Visual Studio" GENERATION_OPTIONS="-DBUILD_SHARED_LIBS=OFF" />
-    </configurations>
-  </component>
-</project>

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,204 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-config",
+      "hidden": true,
+      "description": "Common base settings",
+      "binaryDir": "${sourceDir}/cmake-build-${presetName}",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    },
+    {
+      "name": "base-debug",
+      "hidden": true,
+      "inherits": "base-config",
+      "description": "Base settings for debug builds",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_SHARED_LIBS": "OFF"
+      }
+    },
+    {
+      "name": "base-unix",
+      "hidden": true,
+      "inherits": "base-config",
+      "description": "Base settings for Linux & macOS",
+      "condition": {
+        "type": "anyOf",
+        "conditions": [
+          {
+            "type": "equals",
+            "lhs": "${hostSystemName}",
+            "rhs": "Linux"
+          },
+          {
+            "type": "equals",
+            "lhs": "${hostSystemName}",
+            "rhs": "Darwin"
+          }
+        ]
+      },
+      "generator": "Ninja"
+    },
+    {
+      "name": "base-msvc",
+      "hidden": true,
+      "inherits": "base-config",
+      "description": "Base settings for Windows using MSVC",
+      "environment": {
+        "TOOLCHAIN_NAME": "Visual Studio"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "base-maintainer",
+      "hidden": true,
+      "displayName": "Base settings for maintainer mode",
+      "description": "Unix Maintainer build",
+      "inherits": "base-unix",
+      "cacheVariables": {
+        "MAINTAINER_MODE": "ON",
+        "BUILD_STATIC_LIBS": "OFF"
+      }
+    },
+    {
+      "name": "maintainer",
+      "displayName": "Maintainer",
+      "description": "Unix Maintainer build",
+      "inherits": "base-maintainer",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "maintainer-debug",
+      "displayName": "Maintainer (debug)",
+      "description": "Unix Maintainer build",
+      "inherits": [
+        "base-maintainer",
+        "base-debug"
+      ],
+      "cacheVariables": {
+        "BUILD_STATIC_LIBS": "ON"
+      }
+    },
+    {
+      "name": "maintainer-coverage",
+      "displayName": "Maintainer (coverage)",
+      "description": "Unix Maintainer build",
+      "inherits": "maintainer-debug",
+      "cacheVariables": {
+        "ENABLE_COVERAGE": "ON"
+      }
+    },
+    {
+      "name": "maintainer-profile",
+      "displayName": "Maintainer (profile)",
+      "description": "Unix Maintainer build",
+      "inherits": "maintainer-debug",
+      "environment": {
+        "CFLAGS": "-pg",
+        "CXXFLAGS": "-pg",
+        "LDFLAGS": "-pg"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Debug build",
+      "inherits": "base-config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "description": "Release build",
+      "inherits": "base-config",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "sanitizers",
+      "displayName": "Unix + clang sanitizers",
+      "description": "Debug build with AddressSanitizer enabled",
+      "inherits": [
+        "base-unix",
+        "debug"
+      ],
+      "environment": {
+        "CFLAGS": "-fsanitize=address -fsanitize=undefined",
+        "CXXFLAGS": "-fsanitize=address -fsanitize=undefined",
+        "LDFLAGS": "-fsanitize=address -fsanitize=undefined",
+        "CC": "clang",
+        "CXX": "clang++"
+      },
+      "cacheVariables": {
+        "MAINTAINER_MODE": "ON",
+        "BUILD_SHARED_LIBS": "OFF",
+        "REQUIRE_CRYPTO_OPENSSL": "ON",
+        "REQUIRE_CRYPTO_GNUTLS": "ON",
+        "ENABLE_QTC": "ON"
+      }
+    },
+    {
+      "name": "msvc",
+      "displayName": "Windows/MSVC",
+      "description": "Visual Studio release with debug info build",
+      "inherits": [
+        "base-msvc"
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "BUILD_SHARED_LIBS": "OFF"
+      }
+    },
+    {
+      "name": "msvc-release",
+      "displayName": "Windows/MSVC Release",
+      "description": "Visual Studio release build",
+      "inherits": [
+        "base-msvc",
+        "release"
+      ]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "maintainer",
+      "configurePreset": "maintainer",
+      "description": "Run build for maintainer mode"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "maintainer",
+      "configurePreset": "maintainer",
+      "description": "Run default tests for maintainer mode",
+      "output": {
+        "verbosity": "verbose"
+      }
+    },
+    {
+      "name": "msvc",
+      "configurePreset": "msvc",
+      "description": "Run default tests for msvc",
+      "output": {
+        "verbosity": "verbose"
+      }
+    }
+  ]
+}

--- a/cSpell.json
+++ b/cSpell.json
@@ -612,6 +612,7 @@
     "stampfile",
     "stamppdf",
     "startxref",
+    "startxrefs",
     "stdexcept",
     "stdint",
     "stdiofile",

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -21,7 +21,7 @@ more detail.
       integer object. Previously the method returned false if the first
       dictionary object was not a linearization parameter dictionary.
 
-    - Fix parsing of object streams containing objects not seperated by
+    - Fix parsing of object streams containing objects not separated by
       white-space. Pre-2020 editions of the PDF specification incorrectly
       stated that white-space was required between objects. qpdf relied on this
       when parsing object streams.
@@ -38,6 +38,16 @@ more detail.
 
     - There have been further enhancements to how files with damaged xref
       tables are recovered.
+
+  - Build changes
+
+    - The file ``.idea/cmake.xml`` has been removed. Instead of
+      shipping with some CMake profiles in the CLion-specific
+      configuration, we now include a ``CMakePresets.json``. There is
+      information about using it in ``README-maintainer.md``. For
+      most users, running ``cmake`` in the normal way is fine.
+      Suggestions are welcome. None of the official builds use cmake
+      presets at the time of initial introduction.
 
   - Other changes
 


### PR DESCRIPTION
@m-holger Do you have an opinion about this? It's something I've been wanting to do for a while. I think it gives people a much better cmake experience. If it works out well, we can consider shifting this to other documentation, but I think experienced cmake people will know to look for it. It's mainly geared at maintainers.