### PR TITLE
Deprecate QPDF::optimize

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -674,8 +674,7 @@ class QPDF
     // /Length, /Filter, and /DecodeParms; 1 if it should discard /Length, and 0 if it should
     // preserve all keys. This is used by QPDFWriter to avoid creation of dangling objects for
     // stream dictionary keys it will be regenerating.
-    QPDF_DLL
-    void optimize(
+    [[deprecated("Unused - see release notes for qpdf 12.1.0")]] QPDF_DLL void optimize(
         std::map<int, int> const& object_stream_data,
         bool allow_changes = true,
         std::function<int(QPDFObjectHandle&)> skip_stream_parameters = nullptr);

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -483,7 +483,7 @@ QPDF::checkLinearizationInternal()
                 object_stream_data[og.getObj()] = entry.getObjStreamNumber();
             }
         }
-        optimize(object_stream_data, false);
+        optimize_internal(object_stream_data, false, nullptr);
         calculateLinearizationData(object_stream_data);
     }
 

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -41,6 +41,9 @@ more detail.
 
   - Other changes
 
+    - The ``QPDF::optimize`` method is believed to be not in use and has been
+      deprecated. If you are relying on it please open a ticket_.
+
     - The parsing of object streams including the creation of error/warning
       messages and object descriptions has been refactored with some
       improvement both in runtime and memory usage.


### PR DESCRIPTION
optimize populates private tables that are not accessible through the public API. There seems no point exposing the method publicly. 