### PR TITLE
Detect text using a heuristic for clear-text metadata

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -835,6 +835,7 @@ class QPDF
         qpdf_offset_t offset,
         size_t length,
         QPDFObjectHandle dict,
+        bool is_root_metadata,
         Pipeline* pipeline,
         bool suppress_warnings,
         bool will_retry);
@@ -848,6 +849,7 @@ class QPDF
         qpdf_offset_t offset,
         size_t length,
         QPDFObjectHandle dict,
+        bool is_root_metadata,
         Pipeline* pipeline,
         bool suppress_warnings,
         bool will_retry);
@@ -920,6 +922,7 @@ class QPDF
         Pipeline*& pipeline,
         QPDFObjGen og,
         QPDFObjectHandle& stream_dict,
+        bool is_root_metadata,
         std::unique_ptr<Pipeline>& heap);
 
     // Methods to support object copying

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -115,13 +115,15 @@ QPDF::ForeignStreamData::ForeignStreamData(
     QPDFObjGen foreign_og,
     qpdf_offset_t offset,
     size_t length,
-    QPDFObjectHandle local_dict) :
+    QPDFObjectHandle local_dict,
+    bool is_root_metadata) :
     encp(encp),
     file(file),
     foreign_og(foreign_og),
     offset(offset),
     length(length),
-    local_dict(local_dict)
+    local_dict(local_dict),
+    is_root_metadata(is_root_metadata)
 {
 }
 
@@ -740,7 +742,8 @@ QPDF::copyStreamData(QPDFObjectHandle result, QPDFObjectHandle foreign)
             foreign,
             foreign.getParsedOffset(),
             stream.getLength(),
-            dict);
+            dict,
+            stream.isRootMetadata());
         m->copied_stream_data_provider->registerForeignStream(local_og, foreign_stream_data);
         result.replaceStreamData(
             m->copied_streams, dict.getKey("/Filter"), dict.getKey("/DecodeParms"));
@@ -849,13 +852,15 @@ QPDF::pipeStreamData(
     qpdf_offset_t offset,
     size_t length,
     QPDFObjectHandle stream_dict,
+    bool is_root_metadata,
     Pipeline* pipeline,
     bool suppress_warnings,
     bool will_retry)
 {
     std::unique_ptr<Pipeline> to_delete;
     if (encp->encrypted) {
-        decryptStream(encp, file, qpdf_for_warning, pipeline, og, stream_dict, to_delete);
+        decryptStream(
+            encp, file, qpdf_for_warning, pipeline, og, stream_dict, is_root_metadata, to_delete);
     }
 
     bool attempted_finish = false;
@@ -911,6 +916,7 @@ QPDF::pipeStreamData(
     qpdf_offset_t offset,
     size_t length,
     QPDFObjectHandle stream_dict,
+    bool is_root_metadata,
     Pipeline* pipeline,
     bool suppress_warnings,
     bool will_retry)
@@ -923,6 +929,7 @@ QPDF::pipeStreamData(
         offset,
         length,
         stream_dict,
+        is_root_metadata,
         pipeline,
         suppress_warnings,
         will_retry);
@@ -946,6 +953,7 @@ QPDF::pipeForeignStreamData(
         foreign->offset,
         foreign->length,
         foreign->local_dict,
+        foreign->is_root_metadata,
         pipeline,
         suppress_warnings,
         will_retry);

--- a/libqpdf/QPDF_Stream.cc
+++ b/libqpdf/QPDF_Stream.cc
@@ -281,6 +281,16 @@ Stream::getRawStreamData()
 }
 
 bool
+Stream::isRootMetadata() const
+{
+    if (!getDict().isDictionaryOfType("/Metadata", "/XML")) {
+        return false;
+    }
+    auto root_metadata = qpdf()->getRoot().getKey("/Metadata");
+    return root_metadata.isStream() && root_metadata.getObjGen() == obj->getObjGen();
+}
+
+bool
 Stream::filterable(
     std::vector<std::shared_ptr<QPDFStreamFilter>>& filters,
     bool& specialized_compression,
@@ -520,6 +530,7 @@ Stream::pipeStreamData(
                 obj->getParsedOffset(),
                 s->length,
                 s->stream_dict,
+                isRootMetadata(),
                 pipeline,
                 suppress_warnings,
                 will_retry)) {

--- a/libqpdf/QPDF_encryption.cc
+++ b/libqpdf/QPDF_encryption.cc
@@ -1049,6 +1049,7 @@ QPDF::decryptStream(
     Pipeline*& pipeline,
     QPDFObjGen og,
     QPDFObjectHandle& stream_dict,
+    bool is_root_metadata,
     std::unique_ptr<Pipeline>& decrypt_pipeline)
 {
     std::string type;
@@ -1094,7 +1095,7 @@ QPDF::decryptStream(
         }
 
         if (method == e_unknown) {
-            if ((!encp->encrypt_metadata) && (type == "/Metadata")) {
+            if ((!encp->encrypt_metadata) && is_root_metadata) {
                 QTC::TC("qpdf", "QPDF_encryption cleartext metadata");
                 method = e_none;
             } else {

--- a/libqpdf/qpdf/QPDFObjectHandle_private.hh
+++ b/libqpdf/qpdf/QPDFObjectHandle_private.hh
@@ -246,6 +246,7 @@ namespace qpdf
             return stream()->stream_provider;
         }
 
+
         // See comments in QPDFObjectHandle.hh for these methods.
         bool pipeStreamData(
             Pipeline* p,
@@ -296,6 +297,8 @@ namespace qpdf
         static void registerStreamFilter(
             std::string const& filter_name,
             std::function<std::shared_ptr<QPDFStreamFilter>()> factory);
+
+        bool isRootMetadata() const;
 
       private:
         QPDF_Stream::Members*

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -143,12 +143,13 @@ class QPDF::Pipe
         qpdf_offset_t offset,
         size_t length,
         QPDFObjectHandle dict,
+        bool is_root_metadata,
         Pipeline* pipeline,
         bool suppress_warnings,
         bool will_retry)
     {
         return qpdf->pipeStreamData(
-            og, offset, length, dict, pipeline, suppress_warnings, will_retry);
+            og, offset, length, dict, is_root_metadata, pipeline, suppress_warnings, will_retry);
     }
 };
 
@@ -216,7 +217,8 @@ class QPDF::ForeignStreamData
         QPDFObjGen foreign_og,
         qpdf_offset_t offset,
         size_t length,
-        QPDFObjectHandle local_dict);
+        QPDFObjectHandle local_dict,
+        bool is_root_metadata);
 
   private:
     std::shared_ptr<EncryptionParameters> encp;
@@ -225,6 +227,7 @@ class QPDF::ForeignStreamData
     qpdf_offset_t offset;
     size_t length;
     QPDFObjectHandle local_dict;
+    bool is_root_metadata{false};
 };
 
 class QPDF::CopiedStreamDataProvider: public QPDFObjectHandle::StreamDataProvider


### PR DESCRIPTION
I'm not quite done yet because I still need to add tests with actual PDF files with various combinations of encrypted/clear-text metadata, but this is ready for your initial comments. There is a performance cost to this, but hopefully not very large because it will only impact metadata streams. Unfortunately, I had to change std::unique_ptr<Pipeline> to std::vector<std::shared_ptr<Pipeline>> for heap. I could pass two arguments if you think it is important enough. This is where I have tended toward simplicity over performance, but I don't want to undo your hard work.