### PR TITLE
Don't apply filters to empty stream objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Doxyfile
 
 # ./Testing is created if you run ctest from the wrong place.
 /Testing
+
+# macOS junk files
+.DS_Store
+._*

--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -1293,6 +1293,12 @@ QPDFWriter::willFilterStream(
         QTC::TC("qpdf", "QPDFWriter compressing uncompressed stream");
     }
 
+    // Disable compression for empty streams to improve compatibility
+    if (stream_dict.getKey("/Length").isInteger() && stream_dict.getKey("/Length").getIntValue() == 0) {
+        filter = true;
+        compress_stream = false;
+    }
+
     bool filtered = false;
     for (bool first_attempt: {true, false}) {
         PipelinePopper pp_stream_data(this);

--- a/qpdf/qtest/object-stream.test
+++ b/qpdf/qtest/object-stream.test
@@ -16,7 +16,7 @@ cleanup();
 
 my $td = new TestDriver('object-stream');
 
-my $n_tests = 10 + (36 * 4) + (12 * 2);
+my $n_tests = 10 + (36 * 4) + (12 * 2) + 4;
 my $n_compare_pdfs = 36;
 
 for (my $n = 16; $n <= 19; ++$n)
@@ -125,6 +125,24 @@ $td->runtest("adjacent compressed objects",
              {$td->FILE => "no-space-compressed-object.out",
               $td->EXIT_STATUS => 0},
              $td->NORMALIZE_NEWLINES);
+
+# Never compress empty streams
+$td->runtest("never compress empty streams",
+             {$td->COMMAND => "qpdf --compress-streams=y --static-id" .
+                  " empty-stream-uncompressed.pdf a.pdf"},
+             {$td->STRING => "", $td->EXIT_STATUS => 0});
+$td->runtest("check file",
+             {$td->FILE => "a.pdf"},
+             {$td->FILE => "empty-stream-uncompressed.pdf"});
+
+# Always remove filters from compressed empty streams
+$td->runtest("always remove filters from empty streams",
+             {$td->COMMAND => "qpdf --compress-streams=y --static-id" .
+                  " empty-stream-compressed.pdf a.pdf"},
+             {$td->STRING => "", $td->EXIT_STATUS => 0});
+$td->runtest("check file",
+             {$td->FILE => "a.pdf"},
+             {$td->FILE => "empty-stream-uncompressed.pdf"});
 
 cleanup();
 $td->report(calc_ntests($n_tests, $n_compare_pdfs));

--- a/qpdf/qtest/qpdf/empty-stream-compressed.pdf
+++ b/qpdf/qtest/qpdf/empty-stream-compressed.pdf
@@ -1,0 +1,31 @@
+%PDF-1.4
+%¿÷¢þ
+1 0 obj
+<< /Pages 3 0 R /Type /Catalog /ViewerPreferences << /DisplayDocTitle true /Type /ViewerPreferences >> >>
+endobj
+2 0 obj
+<< /CreationDate (D:20250409064524+00'00') /Creator (Mozilla/5.0 \(X11; Linux x86_64\) AppleWebKit/537.36 \(KHTML, like Gecko\) Chrome/135.0.0.0 Safari/537.36) /ModDate (D:20250409064524+00'00') /Producer (Skia/PDF m135) /Title (about:blank) >>
+endobj
+3 0 obj
+<< /Count 1 /Kids [ 4 0 R ] /Type /Pages >>
+endobj
+4 0 obj
+<< /Contents 5 0 R /MediaBox [ 0 0 594.95996 841.91998 ] /Parent 3 0 R /Resources << /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+5 0 obj
+<< /Length 0 /Filter /FlateDecode >>
+stream
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000136 00000 n 
+0000000396 00000 n 
+0000000455 00000 n 
+0000000647 00000 n 
+trailer << /Info 2 0 R /Root 1 0 R /Size 6 /ID [<c1d8baf5144c3a51530c879d5c908f31><31415926535897932384626433832795>] >>
+startxref
+716
+%%EOF

--- a/qpdf/qtest/qpdf/empty-stream-uncompressed.pdf
+++ b/qpdf/qtest/qpdf/empty-stream-uncompressed.pdf
@@ -1,0 +1,31 @@
+%PDF-1.4
+%¿÷¢þ
+1 0 obj
+<< /Pages 3 0 R /Type /Catalog /ViewerPreferences << /DisplayDocTitle true /Type /ViewerPreferences >> >>
+endobj
+2 0 obj
+<< /CreationDate (D:20250409064524+00'00') /Creator (Mozilla/5.0 \(X11; Linux x86_64\) AppleWebKit/537.36 \(KHTML, like Gecko\) Chrome/135.0.0.0 Safari/537.36) /ModDate (D:20250409064524+00'00') /Producer (Skia/PDF m135) /Title (about:blank) >>
+endobj
+3 0 obj
+<< /Count 1 /Kids [ 4 0 R ] /Type /Pages >>
+endobj
+4 0 obj
+<< /Contents 5 0 R /MediaBox [ 0 0 594.95996 841.91998 ] /Parent 3 0 R /Resources << /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+5 0 obj
+<< /Length 0 >>
+stream
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000136 00000 n 
+0000000396 00000 n 
+0000000455 00000 n 
+0000000647 00000 n 
+trailer << /Info 2 0 R /Root 1 0 R /Size 6 /ID [<c1d8baf5144c3a51530c879d5c908f31><31415926535897932384626433832795>] >>
+startxref
+695
+%%EOF


### PR DESCRIPTION
Decoding an empty stream is never going to yield a meaningful output, drop the filter for empty stream objects to improve compatibility with some Brother printers. Fixes #1426.