### PR TITLE
Implement QPDFFormFieldObjectHelper::isChecked

### DIFF
--- a/libqpdf/QPDFFormFieldObjectHelper.cc
+++ b/libqpdf/QPDFFormFieldObjectHelper.cc
@@ -248,6 +248,12 @@ QPDFFormFieldObjectHelper::isCheckbox()
 }
 
 bool
+QPDFFormFieldObjectHelper::isChecked()
+{
+    return isCheckbox() && getValue().isName() && (getValue().getName() != "/Off");
+}
+
+bool
 QPDFFormFieldObjectHelper::isRadioButton()
 {
     return ((getFieldType() == "/Btn") && ((getFlags() & ff_btn_radio) == ff_btn_radio));


### PR DESCRIPTION
API was defined, but .cc had no implementation. PDF 2.0 manual is surprisingly unclear as to on/off values, giving /Yes in an example and /Off in descriptive text as "not on".