### PR TITLE
Add additional sanity check during xref recovery

### DIFF
--- a/libqpdf/QPDF_pages.cc
+++ b/libqpdf/QPDF_pages.cc
@@ -146,12 +146,21 @@ QPDF::getAllPagesInternal(
                 // Make a copy of the page. This does the same as shallowCopyPage in
                 // QPDFPageObjectHelper.
                 QTC::TC("qpdf", "QPDF resolve duplicated page object");
-                cur_node.warnIfPossible(
-                    "kid " + std::to_string(i) +
-                    " (from 0) appears more than once in the pages tree;"
-                    " creating a new page object as a copy");
-                kid = makeIndirectObject(QPDFObjectHandle(kid).shallowCopy());
-                seen.add(kid);
+                if (!m->in_xref_reconstruction) {
+                    cur_node.warnIfPossible(
+                        "kid " + std::to_string(i) +
+                        " (from 0) appears more than once in the pages tree;"
+                        " creating a new page object as a copy");
+                    kid = makeIndirectObject(QPDFObjectHandle(kid).shallowCopy());
+                    seen.add(kid);
+                } else {
+                    cur_node.warnIfPossible(
+                        "kid " + std::to_string(i) +
+                        " (from 0) appears more than once in the pages tree; ignoring duplicate");
+                    m->invalid_page_found = true;
+                    kid = QPDFObjectHandle::newNull();
+                    continue;
+                }
             }
             if (!kid.isDictionaryOfType("/Page")) {
                 kid.warnIfPossible("/Type key should be /Page but is not; overriding");

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -34,6 +34,14 @@ more detail.
 
     - Fix Android build issues.
 
+  - Other enhancements
+
+    - More sanity checks have been added when files with damaged xref tables
+      are recovered in order to avoid long runtimes and large memory use.
+      Objects with with very large arrays or dictionaries (more than 5000
+      elements) and duplicate pages are ignored as they are almost certainly
+      invalid.
+
 12.1.0: April 6, 2025
   - Upcoming C++ Version Change
 


### PR DESCRIPTION
Do not copy duplicate pages during xref recovery.