### PR TITLE
Fix stream filter handling.

### DIFF
--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -1294,7 +1294,8 @@ QPDFWriter::willFilterStream(
     }
 
     // Disable compression for empty streams to improve compatibility
-    if (stream_dict.getKey("/Length").isInteger() && stream_dict.getKey("/Length").getIntValue() == 0) {
+    if (stream_dict.getKey("/Length").isInteger() &&
+        stream_dict.getKey("/Length").getIntValue() == 0) {
         filter = true;
         compress_stream = false;
     }

--- a/libqpdf/qpdf/QPDFObject_private.hh
+++ b/libqpdf/qpdf/QPDFObject_private.hh
@@ -226,6 +226,7 @@ class QPDF_Stream final
         std::shared_ptr<Buffer> stream_data;
         std::shared_ptr<QPDFObjectHandle::StreamDataProvider> stream_provider;
         std::vector<std::shared_ptr<QPDFObjectHandle::TokenFilter>> token_filters;
+        std::string expand_filter_name(std::string const& name) const;
         std::function<std::shared_ptr<QPDFStreamFilter>()>
         filter_factory(std::string const& name) const;
     };

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -30,6 +30,13 @@ more detail.
     - More sanity checks have been added when files with damaged xref tables
       are recovered.
 
+  - Other changes
+
+    - There has been some refactoring of stream filtering. These are optimized
+      for the common case where no user provided stream filters  are
+      registered by calling ``QPDF::registerStreamFilter``. If you are
+      providing your own stream filters please open a ticket_.
+
 12.2.0: May 4, 2025
   - Upcoming C++ Version Change
 


### PR DESCRIPTION
qpdf permits replacing standard stream filters with user provided filters. #1457 incorrectly removed that option.