### PR TITLE
Refactor: Eliminate unnecessary `this` qualifiers

### DIFF
--- a/libqpdf/Pipeline.cc
+++ b/libqpdf/Pipeline.cc
@@ -14,7 +14,7 @@ Pipeline::getNext(bool allow_null)
 {
     if (!next_ && !allow_null) {
         throw std::logic_error(
-            this->identifier + ": Pipeline::getNext() called on pipeline with no next");
+            identifier + ": Pipeline::getNext() called on pipeline with no next");
     }
     return next_;
 }
@@ -22,93 +22,93 @@ Pipeline::getNext(bool allow_null)
 std::string
 Pipeline::getIdentifier() const
 {
-    return this->identifier;
+    return identifier;
 }
 
 void
 Pipeline::writeCStr(char const* cstr)
 {
-    this->write(cstr, strlen(cstr));
+    write(cstr, strlen(cstr));
 }
 
 void
 Pipeline::writeString(std::string const& str)
 {
-    this->write(str.c_str(), str.length());
+    write(str.c_str(), str.length());
 }
 
 Pipeline&
 Pipeline::operator<<(char const* cstr)
 {
-    this->writeCStr(cstr);
+    writeCStr(cstr);
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(std::string const& str)
 {
-    this->writeString(str);
+    writeString(str);
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(short i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(int i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(long i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(long long i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(unsigned short i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(unsigned int i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(unsigned long i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 Pipeline&
 Pipeline::operator<<(unsigned long long i)
 {
-    this->writeString(std::to_string(i));
+    writeString(std::to_string(i));
     return *this;
 }
 
 void
 Pipeline::write(char const* data, size_t len)
 {
-    this->write(reinterpret_cast<unsigned char const*>(data), len);
+    write(reinterpret_cast<unsigned char const*>(data), len);
 }

--- a/libqpdf/Pl_AES_PDF.cc
+++ b/libqpdf/Pl_AES_PDF.cc
@@ -36,32 +36,32 @@ Pl_AES_PDF::Pl_AES_PDF(
 void
 Pl_AES_PDF::useZeroIV()
 {
-    this->use_zero_iv = true;
+    use_zero_iv = true;
 }
 
 void
 Pl_AES_PDF::disablePadding()
 {
-    this->disable_padding = true;
+    disable_padding = true;
 }
 
 void
 Pl_AES_PDF::setIV(unsigned char const* iv, size_t bytes)
 {
-    if (bytes != this->buf_size) {
+    if (bytes != buf_size) {
         throw std::logic_error(
             "Pl_AES_PDF: specified initialization vector"
             " size in bytes must be " +
             std::to_string(bytes));
     }
-    this->use_specified_iv = true;
-    memcpy(this->specified_iv, iv, bytes);
+    use_specified_iv = true;
+    memcpy(specified_iv, iv, bytes);
 }
 
 void
 Pl_AES_PDF::disableCBC()
 {
-    this->cbc_mode = false;
+    cbc_mode = false;
 }
 
 void
@@ -77,15 +77,15 @@ Pl_AES_PDF::write(unsigned char const* data, size_t len)
     unsigned char const* p = data;
 
     while (bytes_left > 0) {
-        if (this->offset == this->buf_size) {
+        if (offset == buf_size) {
             flush(false);
         }
 
-        size_t available = this->buf_size - this->offset;
+        size_t available = buf_size - offset;
         size_t bytes = (bytes_left < available ? bytes_left : available);
         bytes_left -= bytes;
-        std::memcpy(this->inbuf + this->offset, p, bytes);
-        this->offset += bytes;
+        std::memcpy(inbuf + offset, p, bytes);
+        offset += bytes;
         p += bytes;
     }
 }
@@ -93,32 +93,32 @@ Pl_AES_PDF::write(unsigned char const* data, size_t len)
 void
 Pl_AES_PDF::finish()
 {
-    if (this->encrypt) {
-        if (this->offset == this->buf_size) {
+    if (encrypt) {
+        if (offset == buf_size) {
             flush(false);
         }
-        if (!this->disable_padding) {
+        if (!disable_padding) {
             // Pad as described in section 3.5.1 of version 1.7 of the PDF specification, including
             // providing an entire block of padding if the input was a multiple of 16 bytes.
-            unsigned char pad = QIntC::to_uchar(this->buf_size - this->offset);
-            memset(this->inbuf + this->offset, pad, pad);
-            this->offset = this->buf_size;
+            unsigned char pad = QIntC::to_uchar(buf_size - offset);
+            memset(inbuf + offset, pad, pad);
+            offset = buf_size;
             flush(false);
         }
     } else {
-        if (this->offset != this->buf_size) {
+        if (offset != buf_size) {
             // This is never supposed to happen as the output is always supposed to be padded.
             // However, we have encountered files for which the output is not a multiple of the
             // block size.  In this case, pad with zeroes and hope for the best.
-            if (this->offset >= this->buf_size) {
+            if (offset >= buf_size) {
                 throw std::logic_error("buffer overflow in AES encryption pipeline");
             }
-            std::memset(this->inbuf + this->offset, 0, this->buf_size - this->offset);
-            this->offset = this->buf_size;
+            std::memset(inbuf + offset, 0, buf_size - offset);
+            offset = buf_size;
         }
-        flush(!this->disable_padding);
+        flush(!disable_padding);
     }
-    this->crypto->rijndael_finalize();
+    crypto->rijndael_finalize();
     next()->finish();
 }
 
@@ -126,65 +126,64 @@ void
 Pl_AES_PDF::initializeVector()
 {
     if (use_zero_iv) {
-        for (unsigned int i = 0; i < this->buf_size; ++i) {
-            this->cbc_block[i] = 0;
+        for (unsigned int i = 0; i < buf_size; ++i) {
+            cbc_block[i] = 0;
         }
     } else if (use_specified_iv) {
-        std::memcpy(this->cbc_block, this->specified_iv, this->buf_size);
+        std::memcpy(cbc_block, specified_iv, buf_size);
     } else if (use_static_iv) {
-        for (unsigned int i = 0; i < this->buf_size; ++i) {
-            this->cbc_block[i] = static_cast<unsigned char>(14U * (1U + i));
+        for (unsigned int i = 0; i < buf_size; ++i) {
+            cbc_block[i] = static_cast<unsigned char>(14U * (1U + i));
         }
     } else {
-        QUtil::initializeWithRandomBytes(this->cbc_block, this->buf_size);
+        QUtil::initializeWithRandomBytes(cbc_block, buf_size);
     }
 }
 
 void
 Pl_AES_PDF::flush(bool strip_padding)
 {
-    if (this->offset != this->buf_size) {
+    if (offset != buf_size) {
         throw std::logic_error("AES pipeline: flush called when buffer was not full");
     }
 
     if (first) {
         first = false;
         bool return_after_init = false;
-        if (this->cbc_mode) {
+        if (cbc_mode) {
             if (encrypt) {
                 // Set cbc_block to the initialization vector, and if not zero, write it to the
                 // output stream.
                 initializeVector();
-                if (!(this->use_zero_iv || this->use_specified_iv)) {
-                    next()->write(this->cbc_block, this->buf_size);
+                if (!(use_zero_iv || use_specified_iv)) {
+                    next()->write(cbc_block, buf_size);
                 }
-            } else if (this->use_zero_iv || this->use_specified_iv) {
+            } else if (use_zero_iv || use_specified_iv) {
                 // Initialize vector with zeroes; zero vector was not written to the beginning of
                 // the input file.
                 initializeVector();
             } else {
                 // Take the first block of input as the initialization vector.  There's nothing to
                 // write at this time.
-                memcpy(this->cbc_block, this->inbuf, this->buf_size);
-                this->offset = 0;
+                memcpy(cbc_block, inbuf, buf_size);
+                offset = 0;
                 return_after_init = true;
             }
         }
-        this->crypto->rijndael_init(
-            encrypt, this->key.get(), key_bytes, this->cbc_mode, this->cbc_block);
+        crypto->rijndael_init(encrypt, key.get(), key_bytes, cbc_mode, cbc_block);
         if (return_after_init) {
             return;
         }
     }
 
-    this->crypto->rijndael_process(this->inbuf, this->outbuf);
-    unsigned int bytes = this->buf_size;
+    crypto->rijndael_process(inbuf, outbuf);
+    unsigned int bytes = buf_size;
     if (strip_padding) {
-        unsigned char last = this->outbuf[this->buf_size - 1];
-        if (last <= this->buf_size) {
+        unsigned char last = outbuf[buf_size - 1];
+        if (last <= buf_size) {
             bool strip = true;
             for (unsigned int i = 1; i <= last; ++i) {
-                if (this->outbuf[this->buf_size - i] != last) {
+                if (outbuf[buf_size - i] != last) {
                     strip = false;
                     break;
                 }
@@ -194,6 +193,6 @@ Pl_AES_PDF::flush(bool strip_padding)
             }
         }
     }
-    this->offset = 0;
-    next()->write(this->outbuf, bytes);
+    offset = 0;
+    next()->write(outbuf, bytes);
 }

--- a/libqpdf/Pl_Base64.cc
+++ b/libqpdf/Pl_Base64.cc
@@ -42,7 +42,7 @@ Pl_Base64::write(unsigned char const* data, size_t len)
     if (finished) {
         throw std::logic_error("Pl_Base64 used after finished");
     }
-    if (this->action == a_decode) {
+    if (action == a_decode) {
         decode(data, len);
     } else {
         encode(data, len);
@@ -55,8 +55,8 @@ Pl_Base64::decode(unsigned char const* data, size_t len)
     unsigned char const* p = data;
     while (len > 0) {
         if (!util::is_space(to_c(*p))) {
-            this->buf[this->pos++] = *p;
-            if (this->pos == 4) {
+            buf[pos++] = *p;
+            if (pos == 4) {
                 flush();
             }
         }
@@ -70,8 +70,8 @@ Pl_Base64::encode(unsigned char const* data, size_t len)
 {
     unsigned char const* p = data;
     while (len > 0) {
-        this->buf[this->pos++] = *p;
-        if (this->pos == 3) {
+        buf[pos++] = *p;
+        if (pos == 3) {
             flush();
         }
         ++p;
@@ -82,7 +82,7 @@ Pl_Base64::encode(unsigned char const* data, size_t len)
 void
 Pl_Base64::flush()
 {
-    if (this->action == a_decode) {
+    if (action == a_decode) {
         flush_decode();
     } else {
         flush_encode();
@@ -93,7 +93,7 @@ Pl_Base64::flush()
 void
 Pl_Base64::flush_decode()
 {
-    if (this->end_of_data) {
+    if (end_of_data) {
         throw std::runtime_error(getIdentifier() + ": base64 decode: data follows pad characters");
     }
     int pad = 0;
@@ -101,7 +101,7 @@ Pl_Base64::flush_decode()
     int outval = 0;
     for (size_t i = 0; i < 4; ++i) {
         int v = 0;
-        char ch = to_c(this->buf[i]);
+        char ch = to_c(buf[i]);
         if ((ch >= 'A') && (ch <= 'Z')) {
             v = ch - 'A';
         } else if ((ch >= 'a') && (ch <= 'z')) {
@@ -112,9 +112,9 @@ Pl_Base64::flush_decode()
             v = 62;
         } else if ((ch == '/') || (ch == '_')) {
             v = 63;
-        } else if ((ch == '=') && ((i == 3) || ((i == 2) && (this->buf[3] == '=')))) {
+        } else if ((ch == '=') && ((i == 3) || ((i == 2) && (buf[3] == '=')))) {
             ++pad;
-            this->end_of_data = true;
+            end_of_data = true;
             v = 0;
         } else {
             throw std::runtime_error(getIdentifier() + ": base64 decode: invalid input");
@@ -134,7 +134,7 @@ Pl_Base64::flush_decode()
 void
 Pl_Base64::flush_encode()
 {
-    int outval = ((this->buf[0] << 16) | (this->buf[1] << 8) | (this->buf[2]));
+    int outval = ((buf[0] << 16) | (buf[1] << 8) | (buf[2]));
     unsigned char out[4] = {
         to_uc(outval >> 18),
         to_uc(0x3f & (outval >> 12)),
@@ -158,7 +158,7 @@ Pl_Base64::flush_encode()
         }
         out[i] = to_uc(ch);
     }
-    for (size_t i = 0; i < 3 - this->pos; ++i) {
+    for (size_t i = 0; i < 3 - pos; ++i) {
         out[3 - i] = '=';
     }
     next()->write(out, 4);
@@ -167,24 +167,24 @@ Pl_Base64::flush_encode()
 void
 Pl_Base64::finish()
 {
-    if (this->pos > 0) {
+    if (pos > 0) {
         if (finished) {
             throw std::logic_error("Pl_Base64 used after finished");
         }
-        if (this->action == a_decode) {
-            for (size_t i = this->pos; i < 4; ++i) {
-                this->buf[i] = '=';
+        if (action == a_decode) {
+            for (size_t i = pos; i < 4; ++i) {
+                buf[i] = '=';
             }
         }
         flush();
     }
-    this->finished = true;
+    finished = true;
     next()->finish();
 }
 
 void
 Pl_Base64::reset()
 {
-    this->pos = 0;
+    pos = 0;
     memset(buf, 0, 4);
 }

--- a/libqpdf/QPDFFormFieldObjectHelper.cc
+++ b/libqpdf/QPDFFormFieldObjectHelper.cc
@@ -553,7 +553,7 @@ ValueSetter::handleToken(QPDFTokenizer::Token const& token)
 void
 ValueSetter::handleEOF()
 {
-    if (!this->replaced) {
+    if (!replaced) {
         QTC::TC("qpdf", "QPDFFormFieldObjectHelper replaced BMC at EOF");
         write("/Tx BMC\n");
         writeAppearance();
@@ -563,7 +563,7 @@ ValueSetter::handleEOF()
 void
 ValueSetter::writeAppearance()
 {
-    this->replaced = true;
+    replaced = true;
 
     // This code does not take quadding into consideration because doing so requires font metric
     // information, which we don't have in many cases.
@@ -713,18 +713,18 @@ TfFinder::handleToken(QPDFTokenizer::Token const& token)
 double
 TfFinder::getTf()
 {
-    return this->tf;
+    return tf;
 }
 
 std::string
 TfFinder::getDA()
 {
     std::string result;
-    size_t n = this->DA.size();
+    size_t n = DA.size();
     for (size_t i = 0; i < n; ++i) {
-        std::string cur = this->DA.at(i);
+        std::string cur = DA.at(i);
         if (QIntC::to_int(i) == tf_idx) {
-            double delta = strtod(cur.c_str(), nullptr) - this->tf;
+            double delta = strtod(cur.c_str(), nullptr) - tf;
             if ((delta > 0.001) || (delta < -0.001)) {
                 // tf doesn't match the font size passed to Tf, so substitute.
                 QTC::TC("qpdf", "QPDFFormFieldObjectHelper fallback Tf");
@@ -739,7 +739,7 @@ TfFinder::getDA()
 std::string
 TfFinder::getFontName()
 {
-    return this->font_name;
+    return font_name;
 }
 
 QPDFObjectHandle

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -191,9 +191,9 @@ ImageOptimizer::makePipeline(std::string const& description, Pipeline* next)
         }
         return result;
     }
-    if (((this->oi_min_width > 0) && (w <= this->oi_min_width)) ||
-        ((this->oi_min_height > 0) && (h <= this->oi_min_height)) ||
-        ((this->oi_min_area > 0) && ((w * h) <= this->oi_min_area))) {
+    if (((oi_min_width > 0) && (w <= oi_min_width)) ||
+        ((oi_min_height > 0) && (h <= oi_min_height)) ||
+        ((oi_min_area > 0) && ((w * h) <= oi_min_area))) {
         QTC::TC("qpdf", "QPDFJob image optimize too small");
         if (!description.empty()) {
             o.doIfVerbose([&](Pipeline& v, std::string const& prefix) {
@@ -277,8 +277,7 @@ QPDFPageData::QPDFPageData(std::string const& filename, QPDF* qpdf, std::string 
     orig_pages(qpdf->getAllPages())
 {
     try {
-        this->selected_pages =
-            QUtil::parse_numrange(range.c_str(), QIntC::to_int(this->orig_pages.size()));
+        selected_pages = QUtil::parse_numrange(range.c_str(), QIntC::to_int(orig_pages.size()));
     } catch (std::runtime_error& e) {
         throw std::runtime_error("parsing numeric range for " + filename + ": " + e.what());
     }
@@ -289,13 +288,13 @@ QPDFPageData::QPDFPageData(QPDFPageData const& other, int page) :
     qpdf(other.qpdf),
     orig_pages(other.orig_pages)
 {
-    this->selected_pages.push_back(page);
+    selected_pages.push_back(page);
 }
 
 void
 ProgressReporter::reportProgress(int percentage)
 {
-    this->p << prefix << ": " << filename << ": write progress: " << percentage << "%\n";
+    p << prefix << ": " << filename << ": write progress: " << percentage << "%\n";
 }
 
 QPDFJob::Members::Members() :

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -82,7 +82,7 @@ QPDFObjectHandle::StreamDataProvider::provideStreamData(
 bool
 QPDFObjectHandle::StreamDataProvider::supportsRetry()
 {
-    return this->supports_retry;
+    return supports_retry;
 }
 
 namespace
@@ -121,17 +121,17 @@ QPDFObjectHandle::TokenFilter::handleEOF()
 void
 QPDFObjectHandle::TokenFilter::setPipeline(Pipeline* p)
 {
-    this->pipeline = p;
+    pipeline = p;
 }
 
 void
 QPDFObjectHandle::TokenFilter::write(char const* data, size_t len)
 {
-    if (!this->pipeline) {
+    if (!pipeline) {
         return;
     }
     if (len) {
-        this->pipeline->write(data, len);
+        pipeline->write(data, len);
     }
 }
 
@@ -199,7 +199,7 @@ void
 LastChar::write(unsigned char const* data, size_t len)
 {
     if (len > 0) {
-        this->last_char = data[len - 1];
+        last_char = data[len - 1];
     }
     next()->write(data, len);
 }
@@ -213,7 +213,7 @@ LastChar::finish()
 unsigned char
 LastChar::getLastChar()
 {
-    return this->last_char;
+    return last_char;
 }
 
 std::pair<bool, bool>
@@ -648,7 +648,7 @@ QPDFObject::getStringValue() const
 bool
 QPDFObjectHandle::isSameObjectAs(QPDFObjectHandle const& rhs) const
 {
-    return this->obj == rhs.obj;
+    return obj == rhs.obj;
 }
 
 qpdf_object_type_e
@@ -1326,7 +1326,7 @@ QPDFObjectHandle::getPageContents()
 {
     std::string description = "page object " + getObjGen().unparse(' ');
     std::string all_description;
-    return this->getKey("/Contents").arrayOrStreamToStreamArray(description, all_description);
+    return getKey("/Contents").arrayOrStreamToStreamArray(description, all_description);
 }
 
 void
@@ -1347,7 +1347,7 @@ QPDFObjectHandle::addPageContents(QPDFObjectHandle new_contents, bool first)
         content_streams.push_back(new_contents);
     }
 
-    this->replaceKey("/Contents", newArray(content_streams));
+    replaceKey("/Contents", newArray(content_streams));
 }
 
 void
@@ -1386,7 +1386,7 @@ QPDFObjectHandle::rotatePage(int angle, bool relative)
 void
 QPDFObjectHandle::coalesceContentStreams()
 {
-    QPDFObjectHandle contents = this->getKey("/Contents");
+    QPDFObjectHandle contents = getKey("/Contents");
     if (contents.isStream()) {
         QTC::TC("qpdf", "QPDFObjectHandle coalesce called on stream");
         return;
@@ -1402,7 +1402,7 @@ QPDFObjectHandle::coalesceContentStreams()
     QPDF& qpdf = getQPDF("coalesceContentStreams called on object  with no associated PDF file");
 
     QPDFObjectHandle new_contents = newStream(&qpdf);
-    this->replaceKey("/Contents", new_contents);
+    replaceKey("/Contents", new_contents);
 
     auto provider = std::shared_ptr<StreamDataProvider>(new CoalesceProvider(*this, contents));
     new_contents.replaceStreamData(provider, newNull(), newNull());
@@ -1411,7 +1411,7 @@ QPDFObjectHandle::coalesceContentStreams()
 std::string
 QPDFObjectHandle::unparse() const
 {
-    if (this->isIndirect()) {
+    if (isIndirect()) {
         return getObjGen().unparse(' ') + " R";
     } else {
         return unparseResolved();
@@ -1520,7 +1520,7 @@ QPDFObjectHandle::pipePageContents(Pipeline* p)
 {
     std::string description = "page object " + getObjGen().unparse(' ');
     std::string all_description;
-    this->getKey("/Contents").pipeContentStreams(p, description, all_description);
+    getKey("/Contents").pipeContentStreams(p, description, all_description);
 }
 
 void
@@ -1557,14 +1557,14 @@ void
 QPDFObjectHandle::parsePageContents(ParserCallbacks* callbacks)
 {
     std::string description = "page object " + getObjGen().unparse(' ');
-    this->getKey("/Contents").parseContentStream_internal(description, callbacks);
+    getKey("/Contents").parseContentStream_internal(description, callbacks);
 }
 
 void
 QPDFObjectHandle::parseAsContents(ParserCallbacks* callbacks)
 {
     std::string description = "object " + getObjGen().unparse(' ');
-    this->parseContentStream_internal(description, callbacks);
+    parseContentStream_internal(description, callbacks);
 }
 
 void
@@ -1572,7 +1572,7 @@ QPDFObjectHandle::filterPageContents(TokenFilter* filter, Pipeline* next)
 {
     auto description = "token filter for page object " + getObjGen().unparse(' ');
     Pl_QPDFTokenizer token_pipeline(description.c_str(), filter, next);
-    this->pipePageContents(&token_pipeline);
+    pipePageContents(&token_pipeline);
 }
 
 void
@@ -1580,7 +1580,7 @@ QPDFObjectHandle::filterAsContents(TokenFilter* filter, Pipeline* next)
 {
     auto description = "token filter for object " + getObjGen().unparse(' ');
     Pl_QPDFTokenizer token_pipeline(description.c_str(), filter, next);
-    this->pipeStreamData(&token_pipeline, 0, qpdf_dl_specialized);
+    pipeStreamData(&token_pipeline, 0, qpdf_dl_specialized);
 }
 
 void
@@ -1667,7 +1667,7 @@ void
 QPDFObjectHandle::addContentTokenFilter(std::shared_ptr<TokenFilter> filter)
 {
     coalesceContentStreams();
-    this->getKey("/Contents").addTokenFilter(filter);
+    getKey("/Contents").addTokenFilter(filter);
 }
 
 void
@@ -1910,14 +1910,14 @@ QPDFObjectHandle::makeDirect(QPDFObjGen::set& visited, bool stop_at_streams)
     }
 
     if (isBool() || isInteger() || isName() || isNull() || isReal() || isString()) {
-        this->obj = copy(true);
+        obj = copy(true);
     } else if (auto a = as_array(strict)) {
         std::vector<QPDFObjectHandle> items;
         for (auto const& item: a) {
             items.emplace_back(item);
             items.back().makeDirect(visited, stop_at_streams);
         }
-        this->obj = QPDFObject::create<QPDF_Array>(items);
+        obj = QPDFObject::create<QPDF_Array>(items);
     } else if (isDictionary()) {
         std::map<std::string, QPDFObjectHandle> items;
         for (auto const& [key, value]: as_dictionary(strict)) {
@@ -1926,7 +1926,7 @@ QPDFObjectHandle::makeDirect(QPDFObjGen::set& visited, bool stop_at_streams)
                 items[key].makeDirect(visited, stop_at_streams);
             }
         }
-        this->obj = QPDFObject::create<QPDF_Dictionary>(items);
+        obj = QPDFObject::create<QPDF_Dictionary>(items);
     } else if (isStream()) {
         QTC::TC("qpdf", "QPDFObjectHandle copy stream", stop_at_streams ? 0 : 1);
         if (!stop_at_streams) {
@@ -1946,7 +1946,7 @@ QPDFObjectHandle
 QPDFObjectHandle::copyStream()
 {
     assertStream();
-    QPDFObjectHandle result = newStream(this->getOwningQPDF());
+    QPDFObjectHandle result = newStream(getOwningQPDF());
     QPDFObjectHandle dict = result.getDict();
     QPDFObjectHandle old_dict = getDict();
     for (auto& iter: QPDFDictItems(old_dict)) {
@@ -2208,14 +2208,14 @@ QPDFObjectHandle::QPDFDictItems::iterator::reference
 QPDFObjectHandle::QPDFDictItems::iterator::operator*()
 {
     updateIValue();
-    return this->ivalue;
+    return ivalue;
 }
 
 QPDFObjectHandle::QPDFDictItems::iterator::pointer
 QPDFObjectHandle::QPDFDictItems::iterator::operator->()
 {
     updateIValue();
-    return &this->ivalue;
+    return &ivalue;
 }
 
 bool
@@ -2227,7 +2227,7 @@ QPDFObjectHandle::QPDFDictItems::iterator::operator==(iterator const& other) con
     if (m->is_end || other.m->is_end) {
         return false;
     }
-    return (this->ivalue.first == other.ivalue.first);
+    return (ivalue.first == other.ivalue.first);
 }
 
 QPDFObjectHandle::QPDFDictItems::iterator::iterator(QPDFObjectHandle& oh, bool for_begin) :
@@ -2241,19 +2241,19 @@ QPDFObjectHandle::QPDFDictItems::iterator::updateIValue()
 {
     m->is_end = (m->iter == m->keys.end());
     if (m->is_end) {
-        this->ivalue.first = "";
-        this->ivalue.second = QPDFObjectHandle();
+        ivalue.first = "";
+        ivalue.second = QPDFObjectHandle();
     } else {
-        this->ivalue.first = *(m->iter);
-        this->ivalue.second = m->oh.getKey(this->ivalue.first);
+        ivalue.first = *(m->iter);
+        ivalue.second = m->oh.getKey(ivalue.first);
     }
 }
 
 QPDFObjectHandle::QPDFDictItems::iterator::Members::Members(QPDFObjectHandle& oh, bool for_begin) :
     oh(oh)
 {
-    this->keys = oh.getKeys();
-    this->iter = for_begin ? this->keys.begin() : this->keys.end();
+    keys = oh.getKeys();
+    iter = for_begin ? keys.begin() : keys.end();
 }
 
 QPDFObjectHandle::QPDFDictItems::iterator
@@ -2297,14 +2297,14 @@ QPDFObjectHandle::QPDFArrayItems::iterator::reference
 QPDFObjectHandle::QPDFArrayItems::iterator::operator*()
 {
     updateIValue();
-    return this->ivalue;
+    return ivalue;
 }
 
 QPDFObjectHandle::QPDFArrayItems::iterator::pointer
 QPDFObjectHandle::QPDFArrayItems::iterator::operator->()
 {
     updateIValue();
-    return &this->ivalue;
+    return &ivalue;
 }
 
 bool
@@ -2324,16 +2324,16 @@ QPDFObjectHandle::QPDFArrayItems::iterator::updateIValue()
 {
     m->is_end = (m->item_number >= m->oh.getArrayNItems());
     if (m->is_end) {
-        this->ivalue = QPDFObjectHandle();
+        ivalue = QPDFObjectHandle();
     } else {
-        this->ivalue = m->oh.getArrayItem(m->item_number);
+        ivalue = m->oh.getArrayItem(m->item_number);
     }
 }
 
 QPDFObjectHandle::QPDFArrayItems::iterator::Members::Members(QPDFObjectHandle& oh, bool for_begin) :
     oh(oh)
 {
-    this->item_number = for_begin ? 0 : oh.getArrayNItems();
+    item_number = for_begin ? 0 : oh.getArrayNItems();
 }
 
 QPDFObjectHandle::QPDFArrayItems::iterator

--- a/libqpdf/QPDFPageDocumentHelper.cc
+++ b/libqpdf/QPDFPageDocumentHelper.cc
@@ -13,7 +13,7 @@ std::vector<QPDFPageObjectHelper>
 QPDFPageDocumentHelper::getAllPages()
 {
     std::vector<QPDFPageObjectHelper> pages;
-    for (auto const& iter: this->qpdf.getAllPages()) {
+    for (auto const& iter: qpdf.getAllPages()) {
         pages.emplace_back(iter);
     }
     return pages;
@@ -22,7 +22,7 @@ QPDFPageDocumentHelper::getAllPages()
 void
 QPDFPageDocumentHelper::pushInheritedAttributesToPage()
 {
-    this->qpdf.pushInheritedAttributesToPage();
+    qpdf.pushInheritedAttributesToPage();
 }
 
 void
@@ -36,28 +36,28 @@ QPDFPageDocumentHelper::removeUnreferencedResources()
 void
 QPDFPageDocumentHelper::addPage(QPDFPageObjectHelper newpage, bool first)
 {
-    this->qpdf.addPage(newpage.getObjectHandle(), first);
+    qpdf.addPage(newpage.getObjectHandle(), first);
 }
 
 void
 QPDFPageDocumentHelper::addPageAt(
     QPDFPageObjectHelper newpage, bool before, QPDFPageObjectHelper refpage)
 {
-    this->qpdf.addPageAt(newpage.getObjectHandle(), before, refpage.getObjectHandle());
+    qpdf.addPageAt(newpage.getObjectHandle(), before, refpage.getObjectHandle());
 }
 
 void
 QPDFPageDocumentHelper::removePage(QPDFPageObjectHelper page)
 {
-    this->qpdf.removePage(page.getObjectHandle());
+    qpdf.removePage(page.getObjectHandle());
 }
 
 void
 QPDFPageDocumentHelper::flattenAnnotations(int required_flags, int forbidden_flags)
 {
-    QPDFAcroFormDocumentHelper afdh(this->qpdf);
+    QPDFAcroFormDocumentHelper afdh(qpdf);
     if (afdh.getNeedAppearances()) {
-        this->qpdf.getRoot()
+        qpdf.getRoot()
             .getKey("/AcroForm")
             .warnIfPossible(
                 "document does not have updated appearance streams, so form fields "
@@ -73,7 +73,7 @@ QPDFPageDocumentHelper::flattenAnnotations(int required_flags, int forbidden_fla
         flattenAnnotationsForPage(ph, resources, afdh, required_flags, forbidden_flags);
     }
     if (!afdh.getNeedAppearances()) {
-        this->qpdf.getRoot().removeKey("/AcroForm");
+        qpdf.getRoot().removeKey("/AcroForm");
     }
 }
 
@@ -147,7 +147,7 @@ QPDFPageDocumentHelper::flattenAnnotationsForPage(
             QPDFObjectHandle new_annots_oh = QPDFObjectHandle::newArray(new_annots);
             if (old_annots.isIndirect()) {
                 QTC::TC("qpdf", "QPDFPageDocumentHelper replace indirect annots");
-                this->qpdf.replaceObject(old_annots.getObjGen(), new_annots_oh);
+                qpdf.replaceObject(old_annots.getObjGen(), new_annots_oh);
             } else {
                 QTC::TC("qpdf", "QPDFPageDocumentHelper replace direct annots");
                 page_oh.replaceKey("/Annots", new_annots_oh);

--- a/libqpdf/QPDFPageObjectHelper.cc
+++ b/libqpdf/QPDFPageObjectHelper.cc
@@ -177,13 +177,13 @@ InlineImageTracker::handleToken(QPDFTokenizer::Token const& token)
         if (token.getType() == QPDFTokenizer::tt_inline_image) {
             std::string image_data(token.getValue());
             size_t len = image_data.length();
-            if (len >= this->min_size) {
+            if (len >= min_size) {
                 QTC::TC("qpdf", "QPDFPageObjectHelper externalize inline image");
                 QPDFObjectHandle dict = convertIIDict(QPDFObjectHandle::parse(dict_str));
                 dict.replaceKey("/Length", QPDFObjectHandle::newInteger(QIntC::to_longlong(len)));
-                std::string name = resources.getUniqueResourceName("/IIm", this->min_suffix);
+                std::string name = resources.getUniqueResourceName("/IIm", min_suffix);
                 QPDFObjectHandle image = QPDFObjectHandle::newStream(
-                    this->qpdf, std::make_shared<Buffer>(std::move(image_data)));
+                    qpdf, std::make_shared<Buffer>(std::move(image_data)));
                 image.replaceDict(dict);
                 resources.getKey("/XObject").replaceKey(name, image);
                 write(name);
@@ -278,7 +278,7 @@ QPDFPageObjectHelper::getCropBox(bool copy_if_shared, bool copy_if_fallback)
     return getAttribute(
         "/CropBox",
         copy_if_shared,
-        [this, copy_if_shared]() { return this->getMediaBox(copy_if_shared); },
+        [this, copy_if_shared]() { return getMediaBox(copy_if_shared); },
         copy_if_fallback);
 }
 
@@ -289,7 +289,7 @@ QPDFPageObjectHelper::getTrimBox(bool copy_if_shared, bool copy_if_fallback)
         "/TrimBox",
         copy_if_shared,
         [this, copy_if_shared, copy_if_fallback]() {
-            return this->getCropBox(copy_if_shared, copy_if_fallback);
+            return getCropBox(copy_if_shared, copy_if_fallback);
         },
         copy_if_fallback);
 }
@@ -301,7 +301,7 @@ QPDFPageObjectHelper::getArtBox(bool copy_if_shared, bool copy_if_fallback)
         "/ArtBox",
         copy_if_shared,
         [this, copy_if_shared, copy_if_fallback]() {
-            return this->getCropBox(copy_if_shared, copy_if_fallback);
+            return getCropBox(copy_if_shared, copy_if_fallback);
         },
         copy_if_fallback);
 }
@@ -313,7 +313,7 @@ QPDFPageObjectHelper::getBleedBox(bool copy_if_shared, bool copy_if_fallback)
         "/BleedBox",
         copy_if_shared,
         [this, copy_if_shared, copy_if_fallback]() {
-            return this->getCropBox(copy_if_shared, copy_if_fallback);
+            return getCropBox(copy_if_shared, copy_if_fallback);
         },
         copy_if_fallback);
 }

--- a/libqpdf/QPDF_String.cc
+++ b/libqpdf/QPDF_String.cc
@@ -30,12 +30,12 @@ QPDF_String::writeJSON(int json_version, JSON::Writer& p)
         p << "\"" << JSON::Writer::encode_string(candidate) << "\"";
     } else {
         // See if we can unambiguously represent as Unicode.
-        if (QUtil::is_utf16(this->val) || QUtil::is_explicit_utf8(this->val)) {
+        if (QUtil::is_utf16(val) || QUtil::is_explicit_utf8(val)) {
             p << "\"u:" << JSON::Writer::encode_string(candidate) << "\"";
             return;
         } else if (!useHexString()) {
             std::string test;
-            if (QUtil::utf8_to_pdf_doc(candidate, test, '?') && (test == this->val)) {
+            if (QUtil::utf8_to_pdf_doc(candidate, test, '?') && (test == val)) {
                 // This is a PDF-doc string that can be losslessly encoded as Unicode.
                 p << "\"u:" << JSON::Writer::encode_string(candidate) << "\"";
                 return;
@@ -52,7 +52,7 @@ QPDF_String::useHexString() const
     // PDF Doc encoding) characters or if too large of a proportion of the string consists of
     // non-ASCII characters.
     unsigned int non_ascii = 0;
-    for (auto const ch: this->val) {
+    for (auto const ch: val) {
         if (ch > 126) {
             ++non_ascii;
         } else if (ch >= 32) {
@@ -73,17 +73,17 @@ QPDF_String::unparse(bool force_binary)
     std::string result;
     if (use_hexstring) {
         static auto constexpr hexchars = "0123456789abcdef";
-        result.reserve(2 * this->val.length() + 2);
+        result.reserve(2 * val.length() + 2);
         result += '<';
-        for (const char c: this->val) {
+        for (const char c: val) {
             result += hexchars[static_cast<unsigned char>(c) >> 4];
             result += hexchars[c & 0x0f];
         }
         result += '>';
     } else {
         result += "(";
-        for (unsigned int i = 0; i < this->val.length(); ++i) {
-            char ch = this->val.at(i);
+        for (unsigned int i = 0; i < val.length(); ++i) {
+            char ch = val.at(i);
             switch (ch) {
             case '\n':
                 result += "\\n";
@@ -119,7 +119,7 @@ QPDF_String::unparse(bool force_binary)
 
             default:
                 if (is_iso_latin1_printable(ch)) {
-                    result += this->val.at(i);
+                    result += val.at(i);
                 } else {
                     result += "\\" +
                         QUtil::int_to_string_base(
@@ -137,13 +137,13 @@ QPDF_String::unparse(bool force_binary)
 std::string
 QPDF_String::getUTF8Val() const
 {
-    if (QUtil::is_utf16(this->val)) {
-        return QUtil::utf16_to_utf8(this->val);
-    } else if (QUtil::is_explicit_utf8(this->val)) {
+    if (QUtil::is_utf16(val)) {
+        return QUtil::utf16_to_utf8(val);
+    } else if (QUtil::is_explicit_utf8(val)) {
         // PDF 2.0 allows UTF-8 strings when explicitly prefixed with the three-byte representation
         // of U+FEFF.
-        return this->val.substr(3);
+        return val.substr(3);
     } else {
-        return QUtil::pdf_doc_to_utf8(this->val);
+        return QUtil::pdf_doc_to_utf8(val);
     }
 }

--- a/libqpdf/SHA2_native.cc
+++ b/libqpdf/SHA2_native.cc
@@ -9,13 +9,13 @@ SHA2_native::SHA2_native(int bits) :
 {
     switch (bits) {
     case 256:
-        sph_sha256_init(&this->ctx256);
+        sph_sha256_init(&ctx256);
         break;
     case 384:
-        sph_sha384_init(&this->ctx384);
+        sph_sha384_init(&ctx384);
         break;
     case 512:
-        sph_sha512_init(&this->ctx512);
+        sph_sha512_init(&ctx512);
         break;
     default:
         badBits();
@@ -34,13 +34,13 @@ SHA2_native::update(unsigned char const* buf, size_t len)
 {
     switch (bits) {
     case 256:
-        sph_sha256(&this->ctx256, buf, len);
+        sph_sha256(&ctx256, buf, len);
         break;
     case 384:
-        sph_sha384(&this->ctx384, buf, len);
+        sph_sha384(&ctx384, buf, len);
         break;
     case 512:
-        sph_sha512(&this->ctx512, buf, len);
+        sph_sha512(&ctx512, buf, len);
         break;
     default:
         badBits();
@@ -53,13 +53,13 @@ SHA2_native::finalize()
 {
     switch (bits) {
     case 256:
-        sph_sha256_close(&this->ctx256, sha256sum);
+        sph_sha256_close(&ctx256, sha256sum);
         break;
     case 384:
-        sph_sha384_close(&this->ctx384, sha384sum);
+        sph_sha384_close(&ctx384, sha384sum);
         break;
     case 512:
-        sph_sha512_close(&this->ctx512, sha512sum);
+        sph_sha512_close(&ctx512, sha512sum);
         break;
     default:
         badBits();
@@ -73,13 +73,13 @@ SHA2_native::getRawDigest()
     std::string result;
     switch (bits) {
     case 256:
-        result = std::string(reinterpret_cast<char*>(this->sha256sum), sizeof(this->sha256sum));
+        result = std::string(reinterpret_cast<char*>(sha256sum), sizeof(sha256sum));
         break;
     case 384:
-        result = std::string(reinterpret_cast<char*>(this->sha384sum), sizeof(this->sha384sum));
+        result = std::string(reinterpret_cast<char*>(sha384sum), sizeof(sha384sum));
         break;
     case 512:
-        result = std::string(reinterpret_cast<char*>(this->sha512sum), sizeof(this->sha512sum));
+        result = std::string(reinterpret_cast<char*>(sha512sum), sizeof(sha512sum));
         break;
     default:
         badBits();


### PR DESCRIPTION
Simplified code by removing redundant `this` qualifiers where they are not essential, improving readability and alignment with coding standards. No changes were made to functionality.