### PR TITLE
Pipeline_private.hh should include qpdf/Types.h for qpdf_offset_t

### DIFF
--- a/libqpdf/qpdf/Pipeline_private.hh
+++ b/libqpdf/qpdf/Pipeline_private.hh
@@ -4,6 +4,7 @@
 #include <qpdf/Pipeline.hh>
 
 #include <qpdf/Pl_Flate.hh>
+#include <qpdf/Types.h>
 
 namespace qpdf::pl
 {


### PR DESCRIPTION
Pipeline_private.hh should include qpdf/Types.h for qpdf_offset_t

https://github.com/qpdf/qpdf/issues/1464
