### PR TITLE
Improve sanity checks and error handling in `QPDFParser`

### DIFF
--- a/qpdf/qtest/qpdf/issue-100.out
+++ b/qpdf/qtest/qpdf/issue-100.out
@@ -2,18 +2,18 @@ WARNING: issue-100.pdf: file is damaged
 WARNING: issue-100.pdf (offset 736): xref not found
 WARNING: issue-100.pdf: Attempting to reconstruct cross-reference table
 WARNING: issue-100.pdf (trailer, offset 953): dictionary ended prematurely; using null as value for last key
-WARNING: issue-100.pdf (trailer, offset 953): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-100.pdf (trailer, offset 953): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-100.pdf (trailer, offset 950): recovered trailer has no /Root entry
 WARNING: issue-100.pdf (trailer, offset 488): stream keyword found in trailer
 WARNING: issue-100.pdf (trailer, offset 418): recovered trailer has no /Root entry
 WARNING: issue-100.pdf (object 1 0, offset 83): unexpected dictionary close token
 WARNING: issue-100.pdf (object 1 0, offset 87): expected endobj
-WARNING: issue-100.pdf (object 5 0, offset 268): unknown token while reading object; treating as string
-WARNING: issue-100.pdf (object 5 0, offset 286): unknown token while reading object; treating as string
-WARNING: issue-100.pdf (object 5 0, offset 289): unknown token while reading object; treating as string
-WARNING: issue-100.pdf (object 5 0, offset 294): unknown token while reading object; treating as string
-WARNING: issue-100.pdf (object 5 0, offset 297): unknown token while reading object; treating as string
-WARNING: issue-100.pdf (object 5 0, offset 304): unknown token while reading object; treating as string
+WARNING: issue-100.pdf (object 5 0, offset 268): unknown token while reading object; treating as null
+WARNING: issue-100.pdf (object 5 0, offset 286): unknown token while reading object; treating as null
+WARNING: issue-100.pdf (object 5 0, offset 289): unknown token while reading object; treating as null
+WARNING: issue-100.pdf (object 5 0, offset 294): unknown token while reading object; treating as null
+WARNING: issue-100.pdf (object 5 0, offset 297): unknown token while reading object; treating as null
+WARNING: issue-100.pdf (object 5 0, offset 304): unknown token while reading object; treating as null
 WARNING: issue-100.pdf (object 5 0, offset 304): too many errors; giving up on reading object
 WARNING: issue-100.pdf (object 5 0, offset 308): expected endobj
 WARNING: issue-100.pdf (object 8 0, offset 107): invalid character ()) in hexstring

--- a/qpdf/qtest/qpdf/issue-101.out
+++ b/qpdf/qtest/qpdf/issue-101.out
@@ -1,12 +1,12 @@
 WARNING: issue-101.pdf: file is damaged
 WARNING: issue-101.pdf (offset 3526): xref not found
 WARNING: issue-101.pdf: Attempting to reconstruct cross-reference table
-WARNING: issue-101.pdf (object 11 0, offset 591): unknown token while reading object; treating as string
+WARNING: issue-101.pdf (object 11 0, offset 591): unknown token while reading object; treating as null
 WARNING: issue-101.pdf (object 11 0, offset 625): treating unexpected brace token as null
-WARNING: issue-101.pdf (object 11 0, offset 626): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (object 11 0, offset 637): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (object 11 0, offset 639): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (object 11 0, offset 644): unknown token while reading object; treating as string
+WARNING: issue-101.pdf (object 11 0, offset 626): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (object 11 0, offset 637): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (object 11 0, offset 639): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (object 11 0, offset 644): unknown token while reading object; treating as null
 WARNING: issue-101.pdf (object 11 0, offset 644): too many errors; giving up on reading object
 WARNING: issue-101.pdf (object 11 0, offset 647): expected endobj
 WARNING: issue-101.pdf (trailer, offset 4433): recovered trailer has no /Root entry
@@ -16,11 +16,9 @@ WARNING: issue-101.pdf (trailer, offset 3630): stream keyword found in trailer
 WARNING: issue-101.pdf (trailer, offset 3560): recovered trailer has no /Root entry
 WARNING: issue-101.pdf (trailer, offset 3409): stream keyword found in trailer
 WARNING: issue-101.pdf (trailer, offset 3339): recovered trailer has no /Root entry
-WARNING: issue-101.pdf (trailer, offset 2928): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (trailer, offset 2930): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (trailer, offset 2928): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-101.pdf (trailer, offset 2928): expected dictionary key but found non-name object; inserting key /QPDFFake2
-WARNING: issue-101.pdf (trailer, offset 2928): expected dictionary key but found non-name object; inserting key /QPDFFake3
+WARNING: issue-101.pdf (trailer, offset 2928): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (trailer, offset 2930): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (trailer, offset 2928): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-101.pdf (trailer, offset 2995): stream keyword found in trailer
 WARNING: issue-101.pdf (trailer, offset 2925): recovered trailer has no /Root entry
 WARNING: issue-101.pdf (trailer, offset 2683): stream keyword found in trailer
@@ -31,16 +29,16 @@ WARNING: issue-101.pdf (trailer, offset 1701): stream keyword found in trailer
 WARNING: issue-101.pdf (trailer, offset 1631): recovered trailer has no /Root entry
 WARNING: issue-101.pdf (trailer, offset 1508): stream keyword found in trailer
 WARNING: issue-101.pdf (trailer, offset 1438): recovered trailer has no /Root entry
-WARNING: issue-101.pdf (object 2 0, offset 244): unknown token while reading object; treating as string
+WARNING: issue-101.pdf (object 2 0, offset 244): unknown token while reading object; treating as null
 WARNING: issue-101.pdf (object 2 0, offset 29): dictionary has duplicated key /Parent; last occurrence overrides earlier ones
 WARNING: issue-101.pdf (object 5 0, offset 1242): dictionary ended prematurely; using null as value for last key
-WARNING: issue-101.pdf (object 5 0, offset 1242): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-101.pdf (object 7 0, offset 3855): unknown token while reading object; treating as string
+WARNING: issue-101.pdf (object 5 0, offset 1242): expected dictionary keys but found non-name objects; ignoring
+WARNING: issue-101.pdf (object 7 0, offset 3855): unknown token while reading object; treating as null
 WARNING: issue-101.pdf (object 7 0, offset 3863): treating unexpected brace token as null
-WARNING: issue-101.pdf (object 7 0, offset 3864): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (object 7 0, offset 3866): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (object 7 0, offset 3873): unknown token while reading object; treating as string
-WARNING: issue-101.pdf (object 7 0, offset 3879): unknown token while reading object; treating as string
+WARNING: issue-101.pdf (object 7 0, offset 3864): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (object 7 0, offset 3866): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (object 7 0, offset 3873): unknown token while reading object; treating as null
+WARNING: issue-101.pdf (object 7 0, offset 3879): unknown token while reading object; treating as null
 WARNING: issue-101.pdf (object 7 0, offset 3879): too many errors; giving up on reading object
 WARNING: issue-101.pdf (object 7 0, offset 3888): expected endobj
 WARNING: issue-101.pdf (object 8 0, offset 4067): invalid character ()) in hexstring

--- a/qpdf/qtest/qpdf/issue-146.out
+++ b/qpdf/qtest/qpdf/issue-146.out
@@ -3,6 +3,6 @@ WARNING: issue-146.pdf: can't find startxref
 WARNING: issue-146.pdf: Attempting to reconstruct cross-reference table
 WARNING: issue-146.pdf (trailer, offset 695): ignoring excessively deeply nested data structure
 WARNING: issue-146.pdf (object 1 0, offset 92): expected endobj
-WARNING: issue-146.pdf (object 7 0, offset 146): unknown token while reading object; treating as string
+WARNING: issue-146.pdf (object 7 0, offset 146): unknown token while reading object; treating as null
 WARNING: issue-146.pdf (object 7 0, offset 168): expected endobj
 qpdf: issue-146.pdf: unable to find trailer dictionary while recovering damaged file

--- a/qpdf/qtest/qpdf/issue-147.out
+++ b/qpdf/qtest/qpdf/issue-147.out
@@ -3,6 +3,6 @@ WARNING: issue-147.pdf: file is damaged
 WARNING: issue-147.pdf: can't find startxref
 WARNING: issue-147.pdf: Attempting to reconstruct cross-reference table
 WARNING: issue-147.pdf: ignoring object with impossibly large id 62
-WARNING: issue-147.pdf (trailer, offset 9): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-147.pdf (trailer, offset 9): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-147.pdf (trailer, offset 7): recovered trailer has no /Root entry
 qpdf: issue-147.pdf: unable to find trailer dictionary while recovering damaged file

--- a/qpdf/qtest/qpdf/issue-263.out
+++ b/qpdf/qtest/qpdf/issue-263.out
@@ -2,11 +2,11 @@ WARNING: issue-263.pdf: can't find PDF header
 WARNING: issue-263.pdf: file is damaged
 WARNING: issue-263.pdf: can't find startxref
 WARNING: issue-263.pdf: Attempting to reconstruct cross-reference table
-WARNING: issue-263.pdf (trailer, offset 66): unknown token while reading object; treating as string
-WARNING: issue-263.pdf (trailer, offset 75): unknown token while reading object; treating as string
-WARNING: issue-263.pdf (trailer, offset 79): unknown token while reading object; treating as string
+WARNING: issue-263.pdf (trailer, offset 66): unknown token while reading object; treating as null
+WARNING: issue-263.pdf (trailer, offset 75): unknown token while reading object; treating as null
+WARNING: issue-263.pdf (trailer, offset 79): unknown token while reading object; treating as null
 WARNING: issue-263.pdf (trailer, offset 82): unexpected )
-WARNING: issue-263.pdf (trailer, offset 83): unknown token while reading object; treating as string
+WARNING: issue-263.pdf (trailer, offset 83): unknown token while reading object; treating as null
 WARNING: issue-263.pdf (trailer, offset 87): unexpected >
 WARNING: issue-263.pdf (trailer, offset 87): too many errors; giving up on reading object
 qpdf: issue-263.pdf: unable to find trailer dictionary while recovering damaged file

--- a/qpdf/qtest/qpdf/issue-335a.out
+++ b/qpdf/qtest/qpdf/issue-335a.out
@@ -2,297 +2,284 @@ WARNING: issue-335a.pdf: can't find PDF header
 WARNING: issue-335a.pdf: file is damaged
 WARNING: issue-335a.pdf: can't find startxref
 WARNING: issue-335a.pdf: Attempting to reconstruct cross-reference table
-WARNING: issue-335a.pdf (trailer, offset 23508): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 23508): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 23513): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 23514): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 23516): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 23516): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 23518): invalid character (R) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 23525): unexpected >
 WARNING: issue-335a.pdf (trailer, offset 23525): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 23411): dictionary ended prematurely; using null as value for last key
 WARNING: issue-335a.pdf (object 5 0, offset 23451): invalid character (ÿ) in hexstring
-WARNING: issue-335a.pdf (object 5 0, offset 23458): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (object 5 0, offset 23444): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (object 5 0, offset 23444): expected dictionary key but found non-name object; inserting key /QPDFFake2
+WARNING: issue-335a.pdf (object 5 0, offset 23458): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (object 5 0, offset 23444): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (object 5 0, offset 23440): stream dictionary lacks /Length key
 WARNING: issue-335a.pdf (object 5 0, offset 23485): attempting to recover stream length
 WARNING: issue-335a.pdf (object 5 0, offset 23485): unable to recover stream data; treating stream as empty
 WARNING: issue-335a.pdf (object 5 0, offset 24974): expected endobj
 WARNING: issue-335a.pdf (object 5 0, offset 24974): EOF after endobj
 WARNING: issue-335a.pdf (trailer, offset 23407): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 23108): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23130): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23147): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23155): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23196): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23324): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 23108): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23130): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23147): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23155): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23196): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23324): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 23324): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 23098): invalid character (t) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 23101): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23108): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23130): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23147): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 23155): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 23101): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23108): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23130): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23147): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 23155): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 23155): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 22845): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22869): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22844): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22844): expected dictionary key but found non-name object; inserting key /QPDFFake2
-WARNING: issue-335a.pdf (trailer, offset 22844): expected dictionary key but found non-name object; inserting key /QPDFFake3
+WARNING: issue-335a.pdf (trailer, offset 22845): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22869): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22844): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 22880): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 22840): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 22702): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22701): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-335a.pdf (trailer, offset 22702): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22701): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 22746): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 22697): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 22687): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22690): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22702): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22701): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22740): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22748): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22761): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22791): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 22687): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22690): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22702): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22701): expected dictionary keys but found non-name objects; ignoring
+WARNING: issue-335a.pdf (trailer, offset 22740): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22748): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22761): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22791): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 22794): unexpected >
 WARNING: issue-335a.pdf (trailer, offset 22794): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 22650): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22656): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22675): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22687): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22690): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22702): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22701): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22740): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22748): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22761): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22791): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 22650): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22656): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22675): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22687): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22690): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22702): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22701): expected dictionary keys but found non-name objects; ignoring
+WARNING: issue-335a.pdf (trailer, offset 22740): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22748): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22761): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22791): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 22794): unexpected >
 WARNING: issue-335a.pdf (trailer, offset 22794): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 22437): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22436): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-335a.pdf (trailer, offset 22437): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22436): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 22482): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 22432): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 22327): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22336): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22338): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22355): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22360): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22326): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22326): expected dictionary key but found non-name object; inserting key /QPDFFake2
-WARNING: issue-335a.pdf (trailer, offset 22326): expected dictionary key but found non-name object; inserting key /QPDFFake3
-WARNING: issue-335a.pdf (trailer, offset 22326): expected dictionary key but found non-name object; inserting key /QPDFFake4
-WARNING: issue-335a.pdf (trailer, offset 22326): expected dictionary key but found non-name object; inserting key /QPDFFake5
+WARNING: issue-335a.pdf (trailer, offset 22327): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22336): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22338): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22355): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22360): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22326): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 22371): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 22322): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 22202): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22218): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22201): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22201): expected dictionary key but found non-name object; inserting key /QPDFFake2
+WARNING: issue-335a.pdf (trailer, offset 22202): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22218): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22201): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 22236): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 22197): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 22178): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22190): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22202): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22218): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22201): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22201): expected dictionary key but found non-name object; inserting key /QPDFFake2
-WARNING: issue-335a.pdf (trailer, offset 22230): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22238): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but found non-name object; inserting key /QPDFFake2
-WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but found non-name object; inserting key /QPDFFake3
-WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but found non-name object; inserting key /QPDFFake4
-WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary key but found non-name object; inserting key /QPDFFake5
+WARNING: issue-335a.pdf (trailer, offset 22178): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22190): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22202): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22218): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22201): expected dictionary keys but found non-name objects; ignoring
+WARNING: issue-335a.pdf (trailer, offset 22230): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22238): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22177): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 22275): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 22173): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 22088): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22087): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-335a.pdf (trailer, offset 22088): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22087): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 22134): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 22083): recovered trailer has no /Root entry
 WARNING: issue-335a.pdf (trailer, offset 22000): invalid character (t) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 21937): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21962): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21991): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21937): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21962): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21991): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 22000): invalid character (t) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 22003): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 22003): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21936): dictionary has duplicated key /Length; last occurrence overrides earlier ones
 WARNING: issue-335a.pdf (trailer, offset 22028): unexpected >
-WARNING: issue-335a.pdf (trailer, offset 22030): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 22038): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 22030): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 22038): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 22038): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21918): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21925): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21937): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21962): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21991): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21918): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21925): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21937): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21962): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21991): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 22000): invalid character (t) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 22003): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 22003): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21936): dictionary has duplicated key /Length; last occurrence overrides earlier ones
 WARNING: issue-335a.pdf (trailer, offset 22028): unexpected >
-WARNING: issue-335a.pdf (trailer, offset 22030): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 22030): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 22030): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21837): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21850): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-335a.pdf (trailer, offset 21892): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21900): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21903): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21906): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21918): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21925): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21837): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21850): expected dictionary keys but found non-name objects; ignoring
+WARNING: issue-335a.pdf (trailer, offset 21892): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21900): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21903): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21906): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21918): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21925): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21925): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 21452): invalid character (-) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 21436): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 21407): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 21287): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21287): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21389): unexpected dictionary close token; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21277): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21287): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21277): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21287): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21389): unexpected dictionary close token; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 21228): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 21229): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 21230): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21262): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21267): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21277): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21230): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21262): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21267): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21277): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21277): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21172): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21199): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21172): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21199): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21201): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21205): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 21207): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21207): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21207): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 21154): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 21155): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 21156): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21156): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21157): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 21158): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21202): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21132): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21138): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21156): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21132): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21138): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21156): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21157): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 21158): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21202): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21118): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21118): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21158): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21202): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21205): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 21207): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21212): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21207): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21212): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21212): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 21077): unexpected >
 WARNING: issue-335a.pdf (trailer, offset 21085): unexpected >
-WARNING: issue-335a.pdf (trailer, offset 21086): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21086): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21088): unexpected >
-WARNING: issue-335a.pdf (trailer, offset 21089): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 21089): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 21100): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 21101): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 21101): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 21042): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 21026): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-335a.pdf (trailer, offset 21042): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 21026): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 21055): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 21023): recovered trailer has no /Root entry
 WARNING: issue-335a.pdf (trailer, offset 20949): unexpected >
 WARNING: issue-335a.pdf (trailer, offset 20957): unexpected >
-WARNING: issue-335a.pdf (trailer, offset 20958): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20958): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20960): unexpected >
-WARNING: issue-335a.pdf (trailer, offset 20961): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20961): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20972): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 20973): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 20973): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 20914): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20898): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-335a.pdf (trailer, offset 20914): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20898): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 20927): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 20895): recovered trailer has no /Root entry
 WARNING: issue-335a.pdf (trailer, offset 20880): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 20851): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 20812): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20812): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20803): dictionary has duplicated key /Length; last occurrence overrides earlier ones
-WARNING: issue-335a.pdf (trailer, offset 20803): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-335a.pdf (trailer, offset 20803): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 20842): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 20800): recovered trailer has no /Root entry
 WARNING: issue-335a.pdf (trailer, offset 20785): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 20756): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 20684): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20683): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-335a.pdf (trailer, offset 20684): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20683): expected dictionary keys but found non-name objects; ignoring
 WARNING: issue-335a.pdf (trailer, offset 20747): stream keyword found in trailer
 WARNING: issue-335a.pdf (trailer, offset 20679): recovered trailer has no /Root entry
-WARNING: issue-335a.pdf (trailer, offset 20598): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20598): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20600): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 20601): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 20602): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20602): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20604): invalid character ({) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 20606): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 20606): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 20446): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20446): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20601): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 20602): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20602): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20604): invalid character ({) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 20606): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 20607): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 20607): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 20424): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20431): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20446): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20424): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20431): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20446): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20601): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 20602): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20602): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20604): invalid character ({) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 20604): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 20230): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20230): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20232): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 20233): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 20234): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20234): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20236): invalid character ({) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 20238): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 20238): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 20164): unexpected >
-WARNING: issue-335a.pdf (trailer, offset 20170): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20173): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20186): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20189): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20219): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 20170): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20173): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20186): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20189): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20219): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20219): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 19968): invalid character (t) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 19971): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20092): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20103): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20110): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 20114): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19971): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20092): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20103): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20110): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 20114): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 20114): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 19920): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19920): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19954): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19959): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19959): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19968): invalid character (t) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 19971): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19971): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19971): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 19904): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 19905): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19906): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19959): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19959): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19968): invalid character (t) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 19968): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 19890): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19890): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19906): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19959): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19959): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19968): invalid character (t) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 19971): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19971): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19971): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 19867): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 19868): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19869): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19869): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19870): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19871): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19872): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 19875): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19875): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 19852): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19869): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19852): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19869): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19870): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19871): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19872): name with stray # will not work with PDF >= 1.2
@@ -305,161 +292,161 @@ WARNING: issue-335a.pdf (trailer, offset 19871): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19872): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 19875): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19876): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19956): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16819): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16819): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16820): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16821): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19872): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 19875): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19875): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16806): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16806): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16821): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19872): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 19875): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19876): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19876): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16793): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16793): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19872): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 19875): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19876): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 19956): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19956): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16779): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 16782): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 16793): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16779): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 16782): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 16793): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19808): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 19810): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 19872): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 19875): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 19875): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16752): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 16761): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16752): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 16761): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16762): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16763): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16764): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16764): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16766): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 16766): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16732): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16732): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16733): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16734): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16739): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16763): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16764): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16764): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16764): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16715): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16715): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16716): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16718): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16734): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16734): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16700): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16700): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16701): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16702): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16718): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16719): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16687): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16687): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16702): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16718): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16734): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16734): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16674): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16674): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 16717): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16718): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16719): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16734): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16739): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16739): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16599): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 16613): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16599): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 16613): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16614): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16615): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16615): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16739): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16763): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 16763): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 16575): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 16561): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16561): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16562): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16763): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16764): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16764): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16766): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 16766): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16543): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16543): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16544): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16545): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16546): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16546): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16547): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16548): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16548): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16548): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16526): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16526): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16527): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16529): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16545): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16545): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16511): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16511): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16512): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16513): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16529): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16530): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16498): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16498): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16513): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16529): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16545): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 16545): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 16485): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16485): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 16528): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16529): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16530): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16545): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 16546): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 16546): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 16546): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 3585): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 3586): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3586): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3588): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 3589): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3602): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3610): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3602): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3610): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3610): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 2020): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 2021): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 2022): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3073): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3073): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3073): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 2006): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 2006): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 2022): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3073): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3073): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3073): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1976): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1977): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1978): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1978): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1979): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1986): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1986): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1961): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1978): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1961): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1978): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1979): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1986): invalid character (#) in hexstring
@@ -467,13 +454,13 @@ WARNING: issue-335a.pdf (trailer, offset 1988): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1988): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1943): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1944): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1945): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1945): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1946): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1927): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1945): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1927): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1945): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1946): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
@@ -486,14 +473,14 @@ WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1986): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1986): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1897): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1897): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1913): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1986): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1988): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1988): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1861): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1861): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1880): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
@@ -502,57 +489,57 @@ WARNING: issue-335a.pdf (trailer, offset 1988): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1988): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1843): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1844): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1845): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1845): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1846): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1847): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1947): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1827): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1845): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1827): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1845): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1846): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1847): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1809): invalid character (<) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 1795): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1795): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1947): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1986): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1988): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3064): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1779): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 1780): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1780): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1980): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1986): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1988): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1763): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1763): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1986): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1988): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3064): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1730): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1730): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1749): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3064): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1700): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1701): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1702): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1702): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1703): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1710): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1710): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1685): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1702): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1685): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1702): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1703): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1710): invalid character (#) in hexstring
@@ -560,13 +547,13 @@ WARNING: issue-335a.pdf (trailer, offset 1712): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1712): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1667): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1668): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1669): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1669): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1670): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1651): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1669): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1651): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1669): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1670): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
@@ -579,14 +566,14 @@ WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1710): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1710): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1621): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1621): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1637): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1710): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1712): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1712): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1585): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1585): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1604): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
@@ -595,20 +582,20 @@ WARNING: issue-335a.pdf (trailer, offset 1712): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1712): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1567): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1568): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1569): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1569): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1570): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1571): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1671): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1551): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1569): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1551): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1569): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1570): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1571): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1533): invalid character (<) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 1519): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1519): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1671): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1710): invalid character (#) in hexstring
@@ -617,36 +604,36 @@ WARNING: issue-335a.pdf (trailer, offset 1713): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1503): treating unexpected brace token as null
-WARNING: issue-335a.pdf (trailer, offset 1504): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1504): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1704): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1710): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1712): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1713): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1713): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1487): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1487): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1710): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1712): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1713): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3064): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1454): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1454): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1473): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1713): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1989): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 3057): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 3064): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 3064): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1424): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1425): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1426): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1426): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1427): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1428): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1434): invalid character (#) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1434): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1409): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1426): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1409): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1426): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1427): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1428): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1434): invalid character (#) in hexstring
@@ -654,13 +641,13 @@ WARNING: issue-335a.pdf (trailer, offset 1436): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1436): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1390): invalid character ({) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 1392): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1393): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1393): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1394): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1395): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1428): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1428): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1372): invalid character (<) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 1358): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1358): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1395): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1428): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1434): invalid character (#) in hexstring
@@ -669,14 +656,14 @@ WARNING: issue-335a.pdf (trailer, offset 1437): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1437): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1324): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1325): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1326): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1326): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1327): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1332): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1332): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1309): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1326): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1309): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1326): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1327): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work with PDF >= 1.2
@@ -691,7 +678,7 @@ WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work 
 WARNING: issue-335a.pdf (trailer, offset 1332): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1333): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1333): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1279): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1279): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1295): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work with PDF >= 1.2
@@ -701,20 +688,20 @@ WARNING: issue-335a.pdf (trailer, offset 1344): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1344): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1260): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1261): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1262): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1262): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1263): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1264): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1265): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1265): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1244): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1262): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1244): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1262): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1263): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1264): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1265): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1226): invalid character (<) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 1212): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1212): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1265): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work with PDF >= 1.2
@@ -730,7 +717,7 @@ WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work 
 WARNING: issue-335a.pdf (trailer, offset 1332): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1333): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1333): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1182): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1182): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1198): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1328): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1329): name with stray # will not work with PDF >= 1.2
@@ -740,7 +727,7 @@ WARNING: issue-335a.pdf (trailer, offset 1344): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1344): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1159): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1160): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1161): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1161): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1162): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1163): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1164): name with stray # will not work with PDF >= 1.2
@@ -754,7 +741,7 @@ WARNING: issue-335a.pdf (trailer, offset 1164): name with stray # will not work 
 WARNING: issue-335a.pdf (trailer, offset 1167): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1168): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1168): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 1033): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1033): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1049): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1163): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1164): name with stray # will not work with PDF >= 1.2
@@ -766,14 +753,14 @@ WARNING: issue-335a.pdf (trailer, offset 1332): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1332): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 1010): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 1011): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 1012): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 1012): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1013): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1014): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1015): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1018): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1018): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 995): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 1012): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 995): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 1012): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1013): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1014): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1015): name with stray # will not work with PDF >= 1.2
@@ -791,14 +778,14 @@ WARNING: issue-335a.pdf (trailer, offset 1163): too many errors; giving up on re
 WARNING: issue-335a.pdf (trailer, offset 950): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 951): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 952): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1015): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1018): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1019): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1019): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 936): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 936): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 952): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1015): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1018): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1019): unexpected )
@@ -806,21 +793,21 @@ WARNING: issue-335a.pdf (trailer, offset 1163): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1163): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 918): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 919): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 920): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 920): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 921): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 922): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 953): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 902): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 920): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 902): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 920): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 921): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 922): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1015): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1018): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1018): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 870): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 870): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 953): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 1015): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1018): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1019): unexpected )
@@ -836,7 +823,7 @@ WARNING: issue-335a.pdf (trailer, offset 1163): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1164): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 1167): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1167): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 840): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 840): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 856): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1019): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1163): unexpected )
@@ -846,14 +833,14 @@ WARNING: issue-335a.pdf (trailer, offset 1168): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1168): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 817): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 818): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 819): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 819): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 820): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 821): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 822): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 825): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 825): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 802): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 819): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 802): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 819): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 820): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 821): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 822): name with stray # will not work with PDF >= 1.2
@@ -868,7 +855,7 @@ WARNING: issue-335a.pdf (trailer, offset 822): name with stray # will not work w
 WARNING: issue-335a.pdf (trailer, offset 825): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 826): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 826): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 772): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 772): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 788): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 821): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 822): name with stray # will not work with PDF >= 1.2
@@ -878,13 +865,13 @@ WARNING: issue-335a.pdf (trailer, offset 1019): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1019): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 753): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 754): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 755): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 755): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 756): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 757): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 758): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 758): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 711): invalid character (<) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 697): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 697): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 758): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 821): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 822): name with stray # will not work with PDF >= 1.2
@@ -900,7 +887,7 @@ WARNING: issue-335a.pdf (trailer, offset 822): name with stray # will not work w
 WARNING: issue-335a.pdf (trailer, offset 825): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 826): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 826): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 667): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 667): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 683): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 821): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 822): name with stray # will not work with PDF >= 1.2
@@ -910,14 +897,14 @@ WARNING: issue-335a.pdf (trailer, offset 1019): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 1019): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 644): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 645): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 646): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 646): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 647): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 648): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 649): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 652): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 652): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 629): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 646): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 629): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 646): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 647): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 648): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 649): name with stray # will not work with PDF >= 1.2
@@ -926,14 +913,14 @@ WARNING: issue-335a.pdf (trailer, offset 653): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 653): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 592): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 593): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 594): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 594): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 595): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 600): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 600): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 577): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 594): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 577): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 594): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 595): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
@@ -942,13 +929,13 @@ WARNING: issue-335a.pdf (trailer, offset 601): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 601): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 559): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 560): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 561): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 561): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 562): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 543): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 561): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 543): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 561): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 562): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
@@ -963,7 +950,7 @@ WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 600): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 600): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 513): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 513): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 529): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
@@ -973,21 +960,21 @@ WARNING: issue-335a.pdf (trailer, offset 601): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 601): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 495): treating unexpected brace token as null
 WARNING: issue-335a.pdf (trailer, offset 496): unexpected )
-WARNING: issue-335a.pdf (trailer, offset 497): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 497): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 498): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 499): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 563): too many errors; giving up on reading object
-WARNING: issue-335a.pdf (trailer, offset 479): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 497): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 479): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 497): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 498): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 499): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 596): too many errors; giving up on reading object
 WARNING: issue-335a.pdf (trailer, offset 461): invalid character (<) in hexstring
-WARNING: issue-335a.pdf (trailer, offset 447): unknown token while reading object; treating as string
-WARNING: issue-335a.pdf (trailer, offset 450): unknown token while reading object; treating as string
+WARNING: issue-335a.pdf (trailer, offset 447): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 450): unknown token while reading object; treating as null
 WARNING: issue-335a.pdf (trailer, offset 461): invalid character (<) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 464): invalid character (¨) in hexstring
 WARNING: issue-335a.pdf (trailer, offset 499): unexpected )
@@ -1001,4 +988,19 @@ WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
 WARNING: issue-335a.pdf (trailer, offset 600): unexpected )
 WARNING: issue-335a.pdf (trailer, offset 600): too many errors; giving up on reading object
+WARNING: issue-335a.pdf (trailer, offset 417): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 433): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 597): name with stray # will not work with PDF >= 1.2
+WARNING: issue-335a.pdf (trailer, offset 600): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 601): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 601): too many errors; giving up on reading object
+WARNING: issue-335a.pdf (trailer, offset 395): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 401): unknown token while reading object; treating as null
+WARNING: issue-335a.pdf (trailer, offset 402): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 403): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 563): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 596): unexpected )
+WARNING: issue-335a.pdf (trailer, offset 596): too many errors; giving up on reading object
 qpdf: issue-335a.pdf: too many errors while reconstructing cross-reference table

--- a/qpdf/qtest/qpdf/issue-99.out
+++ b/qpdf/qtest/qpdf/issue-99.out
@@ -2,19 +2,19 @@ WARNING: issue-99.pdf: file is damaged
 WARNING: issue-99.pdf (offset 3526): xref not found
 WARNING: issue-99.pdf: Attempting to reconstruct cross-reference table
 WARNING: issue-99.pdf (trailer, offset 4613): recovered trailer has no /Root entry
-WARNING: issue-99.pdf (object 1 0, offset 775): unknown token while reading object; treating as string
-WARNING: issue-99.pdf (object 1 0, offset 795): unknown token while reading object; treating as string
-WARNING: issue-99.pdf (object 1 0, offset 815): unknown token while reading object; treating as string
-WARNING: issue-99.pdf (object 1 0, offset 835): unknown token while reading object; treating as string
-WARNING: issue-99.pdf (object 1 0, offset 855): unknown token while reading object; treating as string
+WARNING: issue-99.pdf (object 1 0, offset 775): unknown token while reading object; treating as null
+WARNING: issue-99.pdf (object 1 0, offset 795): unknown token while reading object; treating as null
+WARNING: issue-99.pdf (object 1 0, offset 815): unknown token while reading object; treating as null
+WARNING: issue-99.pdf (object 1 0, offset 835): unknown token while reading object; treating as null
+WARNING: issue-99.pdf (object 1 0, offset 855): unknown token while reading object; treating as null
 WARNING: issue-99.pdf (object 1 0, offset 855): too many errors; giving up on reading object
 WARNING: issue-99.pdf (object 1 0, offset 858): expected endobj
 WARNING: issue-99.pdf (object 2 0, offset 64): expected endobj
 WARNING: issue-99.pdf (object 5 0, offset 2452): unknown token while reading object; treating as string
 WARNING: issue-99.pdf (object 6 0, offset 2506): unexpected array close token; giving up on reading object
 WARNING: issue-99.pdf (object 6 0, offset 2507): expected endobj
-WARNING: issue-99.pdf (object 10 0, offset 3708): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: issue-99.pdf (object 11 0, offset 4485): unknown token while reading object; treating as string
+WARNING: issue-99.pdf (object 10 0, offset 3708): expected dictionary keys but found non-name objects; ignoring
+WARNING: issue-99.pdf (object 11 0, offset 4485): unknown token while reading object; treating as null
 WARNING: issue-99.pdf (object 11 0, offset 4497): unexpected array close token; giving up on reading object
 WARNING: issue-99.pdf (object 11 0, offset 4499): expected endobj
 WARNING: issue-99.pdf: unable to find trailer dictionary while recovering damaged file


### PR DESCRIPTION
Enhanced handling of unexpected tokens during xref table reconstruction. Adjusted logic for invalid tokens, ensuring better robustness during PDF parsing of corrupt PDF files.