### PR TITLE
Refactor object reading logic in `QPDF` for clarity and improved main…

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -795,13 +795,14 @@ class QPDF
         std::shared_ptr<InputSource> input, QPDFObjGen og, qpdf_offset_t stream_offset);
     QPDFTokenizer::Token readToken(InputSource&, size_t max_len = 0);
 
-    QPDFObjectHandle readObjectAtOffset(
+    QPDFObjGen read_object_start(qpdf_offset_t offset);
+    void readObjectAtOffset(
         bool attempt_recovery,
         qpdf_offset_t offset,
         std::string const& description,
-        QPDFObjGen exp_og,
-        QPDFObjGen& og,
-        bool skip_cache_if_in_xref);
+        QPDFObjGen exp_og);
+    QPDFObjectHandle readObjectAtOffset(
+        qpdf_offset_t offset, std::string const& description, bool skip_cache_if_in_xref);
     std::shared_ptr<QPDFObject> const& resolve(QPDFObjGen og);
     void resolveObjectsInStream(int obj_stream_number);
     void stopOnError(std::string const& message);

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -274,10 +274,8 @@ QPDF::readLinearizationData()
 QPDFObjectHandle
 QPDF::readHintStream(Pipeline& pl, qpdf_offset_t offset, size_t length)
 {
-    QPDFObjGen og;
-    QPDFObjectHandle H =
-        readObjectAtOffset(false, offset, "linearization hint stream", QPDFObjGen(0, 0), og, false);
-    ObjCache& oc = m->obj_cache[og];
+    auto H = readObjectAtOffset(offset, "linearization hint stream", false);
+    ObjCache& oc = m->obj_cache[H];
     qpdf_offset_t min_end_offset = oc.end_before_space;
     qpdf_offset_t max_end_offset = oc.end_after_space;
     if (!H.isStream()) {


### PR DESCRIPTION
…tainability

Simplify `readObjectAtOffset` by splitting responsibilities into separate functions: `read_object_start` and a streamlined `readObjectAtOffset`. Remove redundant parameters and improve code readability, ensuring better modularity for object reading operations.