### PR TITLE
Disallow `--deterministic-id` with encrypted output and improve error…

### DIFF
--- a/include/qpdf/QPDFWriter.hh
+++ b/include/qpdf/QPDFWriter.hh
@@ -495,7 +495,7 @@ class QPDFWriter
     void preserveObjectStreams();
     void generateObjectStreams();
     std::string getOriginalID1();
-    void generateID();
+    void generateID(bool encrypted);
     void interpretR3EncryptionParameters(
         bool allow_accessibility,
         bool allow_extract,

--- a/libqpdf/QPDFJob_config.cc
+++ b/libqpdf/QPDFJob_config.cc
@@ -149,6 +149,9 @@ QPDFJob::Config::jpegQuality(std::string const& parameter)
 QPDFJob::Config*
 QPDFJob::Config::copyEncryption(std::string const& parameter)
 {
+    if (o.m->deterministic_id) {
+        usage("the deterministic-id option is incompatible with encrypted output files");
+    }
     o.m->encryption_file = parameter;
     o.m->copy_encryption = true;
     o.m->encrypt = false;
@@ -168,6 +171,9 @@ QPDFJob::Config::decrypt()
 QPDFJob::Config*
 QPDFJob::Config::deterministicId()
 {
+    if (o.m->encrypt || o.m->copy_encryption) {
+        usage("the deterministic-id option is incompatible with encrypted output files");
+    }
     o.m->deterministic_id = true;
     return this;
 }
@@ -1116,6 +1122,9 @@ std::shared_ptr<QPDFJob::EncConfig>
 QPDFJob::Config::encrypt(
     int keylen, std::string const& user_password, std::string const& owner_password)
 {
+    if (o.m->deterministic_id) {
+        usage("the deterministic-id option is incompatible with encrypted output files");
+    }
     o.m->keylen = keylen;
     if (keylen == 256) {
         o.m->use_aes = true;

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -23,6 +23,13 @@ more detail.
       not work on some older Linux distributions. If you need support
       for an older distribution, please use version 12.2.0 or below.
 
+  - CLI Enhancements
+
+   - Disallow option :qpdf:ref:`--deterministic-id` to be used together
+     with the incompatible options :qpdf:ref:`--encrypt` or
+     :qpdf:ref:`--copy-encryption`.
+
+
   - Other enhancements
 
     - ``QPDFWriter`` will no longer add filters when writing empty streams.

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -254,7 +254,6 @@ QPDFJob npages 0
 QPDF already reserved object 0
 QPDFWriter standard deterministic ID 1
 QPDFWriter linearized deterministic ID 1
-QPDFWriter deterministic with no data 0
 qpdf-c called qpdf_set_deterministic_ID 0
 QPDFParser invalid objgen 0
 QPDF object id 0 0

--- a/qpdf/qtest/arg-parsing.test
+++ b/qpdf/qtest/arg-parsing.test
@@ -15,7 +15,7 @@ cleanup();
 
 my $td = new TestDriver('arg-parsing');
 
-my $n_tests = 26;
+my $n_tests = 30;
 
 $td->runtest("required argument",
              {$td->COMMAND => "qpdf --password minimal.pdf"},
@@ -136,6 +136,26 @@ $td->runtest("empty and replace-input",
 $td->runtest("missing key length",
              {$td->COMMAND => "qpdf --encrypt --"},
              {$td->REGEXP => ".*encryption key length is required",
+                  $td->EXIT_STATUS => 2},
+             $td->NORMALIZE_NEWLINES);
+$td->runtest("encrypt and deterministic-id 1",
+             {$td->COMMAND => "qpdf --deterministic-id --encrypt --"},
+             {$td->REGEXP => ".*the deterministic-id option is incompatible with encrypted output files",
+                  $td->EXIT_STATUS => 2},
+             $td->NORMALIZE_NEWLINES);
+$td->runtest("encrypt and deterministic-id 2",
+             {$td->COMMAND => "qpdf --deterministic-id --encrypt --bits=256 -- --deterministic-id"},
+             {$td->REGEXP => ".*the deterministic-id option is incompatible with encrypted output files",
+                  $td->EXIT_STATUS => 2},
+             $td->NORMALIZE_NEWLINES);
+$td->runtest("copy-encryption and deterministic-id 1",
+             {$td->COMMAND => "qpdf --deterministic-id --copy-encryption=missing.pdf"},
+             {$td->REGEXP => ".*the deterministic-id option is incompatible with encrypted output files",
+                  $td->EXIT_STATUS => 2},
+             $td->NORMALIZE_NEWLINES);
+$td->runtest("copy-encryption and deterministic-id 2",
+             {$td->COMMAND => "qpdf --copy-encryption=missing.pdf --deterministic-id"},
+             {$td->REGEXP => ".*the deterministic-id option is incompatible with encrypted output files",
                   $td->EXIT_STATUS => 2},
              $td->NORMALIZE_NEWLINES);
 

--- a/qpdf/qtest/deterministic-id.test
+++ b/qpdf/qtest/deterministic-id.test
@@ -54,11 +54,10 @@ foreach my $d ('nn', 'ny', 'yn', 'yy')
 
 $td->runtest("deterministic ID with encryption",
              {$td->COMMAND => "qpdf -deterministic-id encrypted-with-images.pdf a.pdf"},
-             {$td->STRING => "qpdf: INTERNAL ERROR: QPDFWriter::generateID" .
-                  " has no data for deterministic ID." .
-                  "  This may happen if deterministic ID and" .
-                  " file encryption are requested together.\n",
-              $td->EXIT_STATUS => 2},
+             {$td->STRING => "qpdf: QPDFWriter: unable to generated a deterministic ID " .
+                    "because the file to be written is encrypted (even though the file " .
+                    "may not require a password)\n",
+             $td->EXIT_STATUS => 2},
              $td->NORMALIZE_NEWLINES);
 $td->runtest("deterministic ID (C API)",
              {$td->COMMAND =>


### PR DESCRIPTION
… handling for deterministic ID generation (fixes #1235).