### PR TITLE
Allow null `callbacks` in content stream handling

### DIFF
--- a/fuzz/qpdf_crypt_fuzzer.cc
+++ b/fuzz/qpdf_crypt_fuzzer.cc
@@ -13,20 +13,6 @@
 
 #include <cstdlib>
 
-class DiscardContents: public QPDFObjectHandle::ParserCallbacks
-{
-  public:
-    ~DiscardContents() override = default;
-    void
-    handleObject(QPDFObjectHandle) override
-    {
-    }
-    void
-    handleEOF() override
-    {
-    }
-};
-
 class FuzzHelper
 {
   public:

--- a/fuzz/qpdf_crypt_insecure_fuzzer.cc
+++ b/fuzz/qpdf_crypt_insecure_fuzzer.cc
@@ -12,20 +12,6 @@
 #include <qpdf/QUtil.hh>
 #include <cstdlib>
 
-class DiscardContents: public QPDFObjectHandle::ParserCallbacks
-{
-  public:
-    ~DiscardContents() override = default;
-    void
-    handleObject(QPDFObjectHandle) override
-    {
-    }
-    void
-    handleEOF() override
-    {
-    }
-};
-
 class FuzzHelper
 {
   public:

--- a/fuzz/qpdf_fuzzer.cc
+++ b/fuzz/qpdf_fuzzer.cc
@@ -12,20 +12,6 @@
 #include <qpdf/QUtil.hh>
 #include <cstdlib>
 
-class DiscardContents: public QPDFObjectHandle::ParserCallbacks
-{
-  public:
-    ~DiscardContents() override = default;
-    void
-    handleObject(QPDFObjectHandle) override
-    {
-    }
-    void
-    handleEOF() override
-    {
-    }
-};
-
 class FuzzHelper
 {
   public:

--- a/fuzz/qpdf_lin_fuzzer.cc
+++ b/fuzz/qpdf_lin_fuzzer.cc
@@ -12,20 +12,6 @@
 #include <qpdf/QUtil.hh>
 #include <cstdlib>
 
-class DiscardContents: public QPDFObjectHandle::ParserCallbacks
-{
-  public:
-    ~DiscardContents() override = default;
-    void
-    handleObject(QPDFObjectHandle) override
-    {
-    }
-    void
-    handleEOF() override
-    {
-    }
-};
-
 class FuzzHelper
 {
   public:

--- a/fuzz/qpdf_outlines_fuzzer.cc
+++ b/fuzz/qpdf_outlines_fuzzer.cc
@@ -12,20 +12,6 @@
 #include <qpdf/QUtil.hh>
 #include <cstdlib>
 
-class DiscardContents: public QPDFObjectHandle::ParserCallbacks
-{
-  public:
-    ~DiscardContents() override = default;
-    void
-    handleObject(QPDFObjectHandle) override
-    {
-    }
-    void
-    handleEOF() override
-    {
-    }
-};
-
 class FuzzHelper
 {
   public:

--- a/fuzz/qpdf_page_fuzzer.cc
+++ b/fuzz/qpdf_page_fuzzer.cc
@@ -17,20 +17,6 @@
 #include <cstdlib>
 #include <iostream>
 
-class DiscardContents: public QPDFObjectHandle::ParserCallbacks
-{
-  public:
-    ~DiscardContents() override = default;
-    void
-    handleObject(QPDFObjectHandle) override
-    {
-    }
-    void
-    handleEOF() override
-    {
-    }
-};
-
 class FuzzHelper
 {
   public:
@@ -92,7 +78,6 @@ FuzzHelper::testPages()
     info("generateAppearancesIfNeeded done");
     pdh.flattenAnnotations();
     info("flattenAnnotations done");
-    DiscardContents discard_contents;
     int pageno = 0;
     for (auto& page: pdh.getAllPages()) {
         ++pageno;
@@ -100,7 +85,7 @@ FuzzHelper::testPages()
             info("start page", pageno);
             page.coalesceContentStreams();
             info("coalesceContentStreams done");
-            page.parseContents(&discard_contents);
+            page.parseContents(nullptr);
             info("parseContents done");
             page.getImages();
             info("getImages done");

--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -62,20 +62,6 @@ namespace
         std::shared_ptr<Pl_DCT::CompressConfig> config;
     };
 
-    class DiscardContents: public QPDFObjectHandle::ParserCallbacks
-    {
-      public:
-        ~DiscardContents() override = default;
-        void
-        handleObject(QPDFObjectHandle) override
-        {
-        }
-        void
-        handleEOF() override
-        {
-        }
-    };
-
     struct QPDFPageData
     {
         QPDFPageData(std::string const& filename, QPDF* qpdf, std::string const& range);
@@ -810,12 +796,11 @@ QPDFJob::doCheck(QPDF& pdf)
         w.write();
 
         // Parse all content streams
-        DiscardContents discard_contents;
         int pageno = 0;
         for (auto& page: QPDFPageDocumentHelper(pdf).getAllPages()) {
             ++pageno;
             try {
-                page.parseContents(&discard_contents);
+                page.parseContents(nullptr);
             } catch (QPDFExc& e) {
                 okay = false;
                 *m->log->getError() << "ERROR: page " << pageno << ": " << e.what() << "\n";

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1549,13 +1549,17 @@ QPDFObjectHandle::parseContentStream_internal(
     pl::String buf(stream_data);
     std::string all_description;
     pipeContentStreams(&buf, description, all_description);
-    callbacks->contentSize(stream_data.size());
+    if (callbacks) {
+        callbacks->contentSize(stream_data.size());
+    }
     try {
         parseContentStream_data(stream_data, all_description, callbacks, getOwningQPDF());
     } catch (TerminateParsing&) {
         return;
     }
-    callbacks->handleEOF();
+    if (callbacks) {
+        callbacks->handleEOF();
+    }
 }
 
 void
@@ -1583,8 +1587,9 @@ QPDFObjectHandle::parseContentStream_data(
             break;
         }
         size_t length = QIntC::to_size(input.tell() - offset);
-
-        callbacks->handleObject(obj, QIntC::to_size(offset), length);
+        if (callbacks) {
+            callbacks->handleObject(obj, QIntC::to_size(offset), length);
+        }
         if (obj.isOperator() && (obj.getOperatorValue() == "ID")) {
             // Discard next character; it is the space after ID that terminated the token.  Read
             // until end of inline image.
@@ -1606,10 +1611,12 @@ QPDFObjectHandle::parseContentStream_data(
                         "EOF found while reading inline image"));
             } else {
                 QTC::TC("qpdf", "QPDFObjectHandle inline image token");
-                callbacks->handleObject(
-                    QPDFObjectHandle::newInlineImage(tokenizer.getValue()),
-                    QIntC::to_size(offset),
-                    length);
+                if (callbacks) {
+                    callbacks->handleObject(
+                        QPDFObjectHandle::newInlineImage(tokenizer.getValue()),
+                        QIntC::to_size(offset),
+                        length);
+                }
             }
         }
     }


### PR DESCRIPTION
Introduce null checks for `callbacks` in `QPDFObjectHandle` to allow content streams to be parsed without ParserCallbacks. Update `QPDFJob` to pass `nullptr` instead of `DiscardContents` for parsing.