### PR TITLE
Refactor linearization checks: change `checkLinearizationInternal` to…

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1001,7 +1001,7 @@ class QPDF
 
     // methods to support linearization checking -- implemented in QPDF_linearization.cc
     void readLinearizationData();
-    bool checkLinearizationInternal();
+    void checkLinearizationInternal();
     void dumpLinearizationDataInternal();
     void linearizationWarning(std::string_view);
     QPDFObjectHandle readHintStream(Pipeline&, qpdf_offset_t offset, size_t length);

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -77,15 +77,15 @@ QPDF::linearizationWarning(std::string_view msg)
 bool
 QPDF::checkLinearization()
 {
-    bool result = false;
     try {
         readLinearizationData();
-        result = checkLinearizationInternal();
+        checkLinearizationInternal();
+        return !m->linearization_warnings;
     } catch (std::runtime_error& e) {
         linearizationWarning(
             "error encountered while checking linearization data: " + std::string(e.what()));
+        return false;
     }
-    return result;
 }
 
 bool
@@ -404,7 +404,7 @@ QPDF::readHGeneric(BitStream h, HGeneric& t)
     t.group_length = h.getBitsInt(32);        // 4
 }
 
-bool
+void
 QPDF::checkLinearizationInternal()
 {
     // All comments referring to the PDF spec refer to the spec for version 1.4.
@@ -521,8 +521,6 @@ QPDF::checkLinearizationInternal()
     checkHSharedObject(pages, shared_idx_to_obj);
     checkHPageOffset(pages, shared_idx_to_obj);
     checkHOutlines();
-
-    return !m->linearization_warnings;
 }
 
 qpdf_offset_t

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -519,7 +519,7 @@ class QPDF::Members
     // Linearization data
     qpdf_offset_t first_xref_item_offset{0}; // actual value from file
     bool uncompressed_after_compressed{false};
-    bool linearization_warnings{false};
+    bool linearization_warnings{false}; // set by linearizationWarning, used by checkLinearization
 
     // Linearization parameter dictionary and hint table data: may be read from file or computed
     // prior to writing a linearized file


### PR DESCRIPTION
… `void`, simplify control flow, and update method returns.