### PR TITLE
Refactor `QPDFWriter`: remove unused `stream_decode_level` check in c…

### DIFF
--- a/libqpdf/QPDFWriter.cc
+++ b/libqpdf/QPDFWriter.cc
@@ -2179,7 +2179,7 @@ QPDFWriter::doWriteSetup()
         }
     }
 
-    if (m->qdf_mode || m->normalize_content || m->stream_decode_level) {
+    if (m->qdf_mode || m->normalize_content) {
         initializeSpecialStreams();
     }
 

--- a/qpdf/qtest/qpdf/fuzz-16214.out
+++ b/qpdf/qtest/qpdf/fuzz-16214.out
@@ -6,11 +6,6 @@ WARNING: fuzz-16214.pdf (xref stream, offset 116): Cross-reference stream data h
 WARNING: fuzz-16214.pdf: reported number of objects (6) is not one plus the highest object number (35)
 WARNING: fuzz-16214.pdf (object 14 0, offset 652): expected dictionary key but found non-name object; inserting key /QPDFFake1
 WARNING: fuzz-16214.pdf (object 14 0, offset 734): expected endobj
-WARNING: fuzz-16214.pdf (object 15 0, offset 869): unknown token while reading object; treating as string
-WARNING: fuzz-16214.pdf (object 15 0, offset 745): expected dictionary key but found non-name object; inserting key /QPDFFake1
-WARNING: fuzz-16214.pdf (object 15 0, offset 894): expected endobj
-WARNING: fuzz-16214.pdf, object 15 0 at offset 745: kid 0 (from 0) MediaBox is undefined; setting to letter / ANSI A
-WARNING: fuzz-16214.pdf, object 15 0 at offset 745: /Type key should be /Page but is not; overriding
 WARNING: fuzz-16214.pdf: file is damaged
 WARNING: fuzz-16214.pdf (object 1 0, offset 7189): expected n n obj
 WARNING: fuzz-16214.pdf: Attempting to reconstruct cross-reference table


### PR DESCRIPTION
…onditional logic in call to `initializeSpecialStreams`.