### PR TITLE
Add private-API subscript operators to `QPDFObjectHandle`

### DIFF
--- a/include/qpdf/ObjectHandle.hh
+++ b/include/qpdf/ObjectHandle.hh
@@ -73,6 +73,10 @@ namespace qpdf
             return size() == 0;
         }
 
+        QPDFObjectHandle operator[](size_t n) const;
+
+        QPDFObjectHandle operator[](int n) const;
+
         std::shared_ptr<QPDFObject> copy(bool shallow = false) const;
         // Recursively remove association with any QPDF object. This method may only be called
         // during final destruction.

--- a/libqpdf/NNTree.cc
+++ b/libqpdf/NNTree.cc
@@ -87,28 +87,22 @@ NNTreeIterator::PathElement::PathElement(QPDFObjectHandle const& node, int kid_n
 QPDFObjectHandle
 NNTreeIterator::getNextKid(PathElement& pe, bool backward)
 {
-    QPDFObjectHandle result;
-    bool found = false;
-    while (!found) {
+    while (true) {
         pe.kid_number += backward ? -1 : 1;
         auto kids = pe.node.getKey("/Kids");
-        if ((pe.kid_number >= 0) && (pe.kid_number < kids.getArrayNItems())) {
-            result = kids.getArrayItem(pe.kid_number);
+        if (pe.kid_number >= 0 && std::cmp_less(pe.kid_number, kids.size())) {
+            auto result = kids[pe.kid_number];
             if (result.isDictionary() &&
                 (result.hasKey("/Kids") || result.hasKey(impl.details.itemsKey()))) {
-                found = true;
+                return result;
             } else {
-                QTC::TC("qpdf", "NNTree skip invalid kid");
                 impl.warn(
-                    pe.node,
-                    ("skipping over invalid kid at index " + std::to_string(pe.kid_number)));
+                    pe.node, "skipping over invalid kid at index " + std::to_string(pe.kid_number));
             }
         } else {
-            result = QPDFObjectHandle::newNull();
-            found = true;
+            return QPDFObjectHandle::newNull();
         }
     }
-    return result;
 }
 
 bool

--- a/libqpdf/NNTree.cc
+++ b/libqpdf/NNTree.cc
@@ -57,25 +57,21 @@ NNTreeIterator::updateIValue(bool allow_invalid)
     // we must call updateIValue as well. These cases are handled, and for good measure, we also
     // call updateIValue in operator* and operator->.
 
-    bool okay = false;
-    if (item_number >= 0 && node.isDictionary()) {
-        auto items = node.getKey(impl.details.itemsKey());
-        if (item_number + 1 < items.getArrayNItems()) {
-            okay = true;
-            ivalue.first = items.getArrayItem(item_number);
-            ivalue.second = items.getArrayItem(1 + item_number);
-        } else {
-            impl.error(node, "update ivalue: items array is too short");
-        }
-    }
-    if (!okay) {
+    if (item_number < 0 || !node.isDictionary()) {
         if (!allow_invalid) {
             throw std::logic_error(
                 "attempt made to dereference an invalid name/number tree iterator");
         }
         ivalue.first = QPDFObjectHandle();
         ivalue.second = QPDFObjectHandle();
+        return;
     }
+    auto items = node.getKey(impl.details.itemsKey());
+    if (!std::cmp_less(item_number + 1, items.size())) {
+        impl.error(node, "update ivalue: items array is too short");
+    }
+    ivalue.first = items[item_number];
+    ivalue.second = items[1 + item_number];
 }
 
 NNTreeIterator::PathElement::PathElement(QPDFObjectHandle const& node, int kid_number) :

--- a/libqpdf/NNTree.cc
+++ b/libqpdf/NNTree.cc
@@ -766,23 +766,19 @@ NNTreeImpl::binarySearch(
 int
 NNTreeImpl::compareKeyItem(QPDFObjectHandle& key, QPDFObjectHandle& items, int idx)
 {
-    if (!((items.isArray() && (items.getArrayNItems() > (2 * idx)) &&
-           details.keyValid(items.getArrayItem(2 * idx))))) {
-        QTC::TC("qpdf", "NNTree item is wrong type");
+    if (!(std::cmp_greater(items.size(), 2 * idx) && details.keyValid(items[2 * idx]))) {
         error(oh, ("item at index " + std::to_string(2 * idx) + " is not the right type"));
     }
-    return details.compareKeys(key, items.getArrayItem(2 * idx));
+    return details.compareKeys(key, items[2 * idx]);
 }
 
 int
 NNTreeImpl::compareKeyKid(QPDFObjectHandle& key, QPDFObjectHandle& kids, int idx)
 {
-    if (!(kids.isArray() && (idx < kids.getArrayNItems()) &&
-          kids.getArrayItem(idx).isDictionary())) {
-        QTC::TC("qpdf", "NNTree kid is invalid");
+    if (!(std::cmp_less(idx, kids.size()) && kids[idx].isDictionary())) {
         error(oh, "invalid kid at index " + std::to_string(idx));
     }
-    return withinLimits(key, kids.getArrayItem(idx));
+    return withinLimits(key, kids[idx]);
 }
 
 void

--- a/libqpdf/NNTree.cc
+++ b/libqpdf/NNTree.cc
@@ -390,7 +390,7 @@ NNTreeIterator::lastPathElement()
 }
 
 void
-NNTreeIterator::insertAfter(QPDFObjectHandle key, QPDFObjectHandle value)
+NNTreeIterator::insertAfter(QPDFObjectHandle const& key, QPDFObjectHandle const& value)
 {
     if (!valid()) {
         QTC::TC("qpdf", "NNTree insertAfter inserts first");
@@ -400,10 +400,11 @@ NNTreeIterator::insertAfter(QPDFObjectHandle key, QPDFObjectHandle value)
     }
 
     auto items = node.getKey(impl.details.itemsKey());
-    if (!items.isArray()) {
-        impl.error(node, "node contains no items array");
-    }
-    if (items.getArrayNItems() < item_number + 2) {
+
+    if (std::cmp_less(items.size(), item_number + 2)) {
+        if (!items.isArray()) {
+            impl.error(node, "node contains no items array");
+        }
         impl.error(node, "insert: items array is too short");
     }
     items.insertItem(item_number + 2, key);

--- a/libqpdf/NNTree.cc
+++ b/libqpdf/NNTree.cc
@@ -866,15 +866,14 @@ NNTreeImpl::findInternal(QPDFObjectHandle const& key, bool return_prev_if_not_fo
 }
 
 NNTreeImpl::iterator
-NNTreeImpl::insertFirst(QPDFObjectHandle key, QPDFObjectHandle value)
+NNTreeImpl::insertFirst(QPDFObjectHandle const& key, QPDFObjectHandle const& value)
 {
     auto iter = begin();
     QPDFObjectHandle items;
     if (iter.node.isDictionary()) {
         items = iter.node.getKey(details.itemsKey());
     }
-    if (!(items.isArray())) {
-        QTC::TC("qpdf", "NNTree no valid items node in insertFirst");
+    if (!items.isArray()) {
         error(oh, "unable to find a valid items node");
     }
     items.insertItem(0, key);
@@ -886,30 +885,26 @@ NNTreeImpl::insertFirst(QPDFObjectHandle key, QPDFObjectHandle value)
 }
 
 NNTreeImpl::iterator
-NNTreeImpl::insert(QPDFObjectHandle key, QPDFObjectHandle value)
+NNTreeImpl::insert(QPDFObjectHandle const& key, QPDFObjectHandle const& value)
 {
     auto iter = find(key, true);
     if (!iter.valid()) {
-        QTC::TC("qpdf", "NNTree insert inserts first");
         return insertFirst(key, value);
     } else if (details.compareKeys(key, iter->first) == 0) {
-        QTC::TC("qpdf", "NNTree insert replaces");
         auto items = iter.node.getKey(details.itemsKey());
         items.setArrayItem(iter.item_number + 1, value);
         iter.updateIValue();
     } else {
-        QTC::TC("qpdf", "NNTree insert inserts after");
         iter.insertAfter(key, value);
     }
     return iter;
 }
 
 bool
-NNTreeImpl::remove(QPDFObjectHandle key, QPDFObjectHandle* value)
+NNTreeImpl::remove(QPDFObjectHandle const& key, QPDFObjectHandle* value)
 {
     auto iter = find(key, false);
     if (!iter.valid()) {
-        QTC::TC("qpdf", "NNTree remove not found");
         return false;
     }
     if (value) {

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -528,3 +528,47 @@ BaseHandle::size() const
         return 0;                                               // unreachable
     }
 }
+
+QPDFObjectHandle
+BaseHandle::operator[](size_t n) const
+{
+    switch (resolved_type_code()) {
+    case ::ot_array:
+        {
+            auto a = as<QPDF_Array>();
+            if (n >= a->size()) {
+                return {};
+            }
+            return Array(obj).at(static_cast<int>(n)).second;
+        }
+    case ::ot_uninitialized:
+    case ::ot_reserved:
+    case ::ot_null:
+    case ::ot_destroyed:
+    case ::ot_unresolved:
+    case ::ot_reference:
+        return {};
+    case ::ot_boolean:
+    case ::ot_integer:
+    case ::ot_real:
+    case ::ot_string:
+    case ::ot_name:
+    case ::ot_dictionary:
+    case ::ot_stream:
+    case ::ot_inlineimage:
+    case ::ot_operator:
+        return {obj};
+    default:
+        throw std::logic_error("Unexpected type code in size"); // unreachable
+        return {};                                              // unreachable
+    }
+}
+
+QPDFObjectHandle
+BaseHandle::operator[](int n) const
+{
+    if (n < 0) {
+        return {};
+    }
+    return (*this)[static_cast<size_t>(n)];
+}

--- a/libqpdf/qpdf/NNTree.hh
+++ b/libqpdf/qpdf/NNTree.hh
@@ -111,7 +111,7 @@ class NNTreeImpl
   private:
     void repair();
     iterator findInternal(QPDFObjectHandle const& key, bool return_prev_if_not_found = false);
-    int withinLimits(QPDFObjectHandle key, QPDFObjectHandle node);
+    int withinLimits(QPDFObjectHandle const& key, QPDFObjectHandle const& node);
     int binarySearch(
         QPDFObjectHandle key,
         QPDFObjectHandle items,
@@ -120,8 +120,8 @@ class NNTreeImpl
         int (NNTreeImpl::*compare)(QPDFObjectHandle& key, QPDFObjectHandle& arr, int item));
     int compareKeyItem(QPDFObjectHandle& key, QPDFObjectHandle& items, int idx);
     int compareKeyKid(QPDFObjectHandle& key, QPDFObjectHandle& items, int idx);
-    void warn(QPDFObjectHandle& node, std::string const& msg);
-    void error(QPDFObjectHandle& node, std::string const& msg);
+    void warn(QPDFObjectHandle const& node, std::string const& msg);
+    void error(QPDFObjectHandle const& node, std::string const& msg);
 
     NNTreeDetails const& details;
     QPDF& qpdf;

--- a/libqpdf/qpdf/NNTree.hh
+++ b/libqpdf/qpdf/NNTree.hh
@@ -56,7 +56,7 @@ class NNTreeIterator
         return !operator==(other);
     }
 
-    void insertAfter(QPDFObjectHandle key, QPDFObjectHandle value);
+    void insertAfter(QPDFObjectHandle const& key, QPDFObjectHandle const& value);
     void remove();
 
   private:

--- a/libqpdf/qpdf/NNTree.hh
+++ b/libqpdf/qpdf/NNTree.hh
@@ -110,12 +110,12 @@ class NNTreeImpl
 
   private:
     void repair();
-    iterator findInternal(QPDFObjectHandle key, bool return_prev_if_not_found = false);
+    iterator findInternal(QPDFObjectHandle const& key, bool return_prev_if_not_found = false);
     int withinLimits(QPDFObjectHandle key, QPDFObjectHandle node);
     int binarySearch(
         QPDFObjectHandle key,
         QPDFObjectHandle items,
-        int num_items,
+        size_t num_items,
         bool return_prev_if_not_found,
         int (NNTreeImpl::*compare)(QPDFObjectHandle& key, QPDFObjectHandle& arr, int item));
     int compareKeyItem(QPDFObjectHandle& key, QPDFObjectHandle& items, int idx);

--- a/libqpdf/qpdf/NNTree.hh
+++ b/libqpdf/qpdf/NNTree.hh
@@ -100,9 +100,9 @@ class NNTreeImpl
     iterator end();
     iterator last();
     iterator find(QPDFObjectHandle key, bool return_prev_if_not_found = false);
-    iterator insertFirst(QPDFObjectHandle key, QPDFObjectHandle value);
-    iterator insert(QPDFObjectHandle key, QPDFObjectHandle value);
-    bool remove(QPDFObjectHandle key, QPDFObjectHandle* value = nullptr);
+    iterator insertFirst(QPDFObjectHandle const& key, QPDFObjectHandle const& value);
+    iterator insert(QPDFObjectHandle const& key, QPDFObjectHandle const& value);
+    bool remove(QPDFObjectHandle const& key, QPDFObjectHandle* value = nullptr);
 
     // Change the split threshold for easier testing. There's no real reason to expose this to
     // downstream tree helpers, but it has to be public so we can call it from the test suite.

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -524,13 +524,6 @@ NNTree skip item at end of short items 0
 NNTree skip invalid key 0
 NNTree unable to determine limits 0
 NNTree repair 0
-NNTree split root + leaf 0
-NNTree split root + !leaf 0
-NNTree split kids 0
-NNTree split items 0
-NNTree split second half item 0
-NNTree split parent 0
-NNTree split second half kid 0
 NNTree limits didn't change 0
 NNTree increment end() 0
 NNTree insertAfter inserts first 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -534,17 +534,7 @@ NNTree split second half kid 0
 NNTree limits didn't change 0
 NNTree increment end() 0
 NNTree insertAfter inserts first 0
-NNTree remove reset limits 0
-NNTree erased last item 0
-NNTree erased non-last item 0
-NNTree items is empty after remove 0
-NNTree erased all items on leaf/root 0
-NNTree erased first or last kid 0
-NNTree erased last kid 0
-NNTree erased non-last kid 0
-NNTree non-flat tree is empty after remove 0
-NNTree remove walking up tree 0
-NNTree erased last item in tree 0
+NNTree erased last kid/item in tree 1
 NNTree remove limits from root 0
 QPDFPageObjectHelper unresolved names 0
 QPDFPageObjectHelper resolving unresolved 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -519,15 +519,10 @@ qpdf-c called qpdf_oh_unparse_resolved 0
 qpdf-c called qpdf_oh_unparse_binary 0
 QPDFWriter getFilterOnWrite false 0
 QPDFPageObjectHelper::forEachXObject 3
-NNTree deepen: invalid node 0
-NNTree deepen: loop 0
 NNTree skip invalid kid 0
 NNTree skip item at end of short items 0
 NNTree skip invalid key 0
-NNTree deepen found empty 0
 NNTree unable to determine limits 0
-NNTree warn indirect kid 0
-NNTree fix indirect kid 0
 NNTree repair 0
 NNTree split root + leaf 0
 NNTree split root + !leaf 0
@@ -536,7 +531,6 @@ NNTree split items 0
 NNTree split second half item 0
 NNTree split parent 0
 NNTree split second half kid 0
-NNTree node is not a dictionary 0
 NNTree limits didn't change 0
 NNTree increment end() 0
 NNTree insertAfter inserts first 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -536,7 +536,6 @@ NNTree split items 0
 NNTree split second half item 0
 NNTree split parent 0
 NNTree split second half kid 0
-NNTree missing limits 0
 NNTree node is not a dictionary 0
 NNTree limits didn't change 0
 NNTree increment end() 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -543,9 +543,6 @@ NNTree split second half kid 0
 NNTree missing limits 0
 NNTree item is wrong type 0
 NNTree kid is invalid 0
-NNTree loop in find 0
-NNTree -1 in binary search 0
-NNTree bad node during find 0
 NNTree node is not a dictionary 0
 NNTree limits didn't change 0
 NNTree increment end() 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -519,7 +519,6 @@ qpdf-c called qpdf_oh_unparse_resolved 0
 qpdf-c called qpdf_oh_unparse_binary 0
 QPDFWriter getFilterOnWrite false 0
 QPDFPageObjectHelper::forEachXObject 3
-NNTree skip invalid kid 0
 NNTree repair 0
 NNTree insertAfter inserts first 0
 NNTree erased last kid/item in tree 1

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -537,8 +537,6 @@ NNTree split second half item 0
 NNTree split parent 0
 NNTree split second half kid 0
 NNTree missing limits 0
-NNTree item is wrong type 0
-NNTree kid is invalid 0
 NNTree node is not a dictionary 0
 NNTree limits didn't change 0
 NNTree increment end() 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -524,11 +524,7 @@ NNTree deepen: loop 0
 NNTree skip invalid kid 0
 NNTree skip item at end of short items 0
 NNTree skip invalid key 0
-NNTree no valid items node in insertFirst 0
 NNTree deepen found empty 0
-NNTree insert inserts first 0
-NNTree insert replaces 0
-NNTree insert inserts after 0
 NNTree unable to determine limits 0
 NNTree warn indirect kid 0
 NNTree fix indirect kid 0
@@ -547,7 +543,6 @@ NNTree node is not a dictionary 0
 NNTree limits didn't change 0
 NNTree increment end() 0
 NNTree insertAfter inserts first 0
-NNTree remove not found 0
 NNTree remove reset limits 0
 NNTree erased last item 0
 NNTree erased non-last item 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -522,13 +522,10 @@ QPDFPageObjectHelper::forEachXObject 3
 NNTree skip invalid kid 0
 NNTree skip item at end of short items 0
 NNTree skip invalid key 0
-NNTree unable to determine limits 0
 NNTree repair 0
-NNTree limits didn't change 0
 NNTree increment end() 0
 NNTree insertAfter inserts first 0
 NNTree erased last kid/item in tree 1
-NNTree remove limits from root 0
 QPDFPageObjectHelper unresolved names 0
 QPDFPageObjectHelper resolving unresolved 0
 QPDFFileSpecObjectHelper empty compat_name 0

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -520,10 +520,7 @@ qpdf-c called qpdf_oh_unparse_binary 0
 QPDFWriter getFilterOnWrite false 0
 QPDFPageObjectHelper::forEachXObject 3
 NNTree skip invalid kid 0
-NNTree skip item at end of short items 0
-NNTree skip invalid key 0
 NNTree repair 0
-NNTree increment end() 0
 NNTree insertAfter inserts first 0
 NNTree erased last kid/item in tree 1
 QPDFPageObjectHelper unresolved names 0


### PR DESCRIPTION
Refactor `NNTree` for cleaner item access and conditionals; leverage `operator[]` and update error handling