### PR TITLE
Refactor `QPDFObjectHandle::newArray` to delegate construction to `Ar…

### DIFF
--- a/include/qpdf/ObjectHandle.hh
+++ b/include/qpdf/ObjectHandle.hh
@@ -95,9 +95,9 @@ namespace qpdf
 
       protected:
         BaseHandle() = default;
-        BaseHandle(std::shared_ptr<QPDFObject> const& obj) :
+        explicit BaseHandle(std::shared_ptr<QPDFObject> const& obj) :
             obj(obj) {};
-        BaseHandle(std::shared_ptr<QPDFObject>&& obj) :
+        explicit BaseHandle(std::shared_ptr<QPDFObject>&& obj) :
             obj(std::move(obj)) {};
         BaseHandle(BaseHandle const&) = default;
         BaseHandle& operator=(BaseHandle const&) = default;

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -1706,18 +1706,6 @@ QPDFObjectHandle::newInlineImage(std::string const& value)
 }
 
 QPDFObjectHandle
-QPDFObjectHandle::newArray()
-{
-    return newArray(std::vector<QPDFObjectHandle>());
-}
-
-QPDFObjectHandle
-QPDFObjectHandle::newArray(std::vector<QPDFObjectHandle> const& items)
-{
-    return {QPDFObject::create<QPDF_Array>(items)};
-}
-
-QPDFObjectHandle
 QPDFObjectHandle::newArray(Rectangle const& rect)
 {
     return newArray({newReal(rect.llx), newReal(rect.lly), newReal(rect.urx), newReal(rect.ury)});

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -376,6 +376,18 @@ Array::erase(int at_i)
     return erase(to_s(at_i));
 }
 
+QPDFObjectHandle
+QPDFObjectHandle::newArray()
+{
+    return {Array()};
+}
+
+QPDFObjectHandle
+QPDFObjectHandle::newArray(std::vector<QPDFObjectHandle> const& items)
+{
+    return {Array(items)};
+}
+
 int
 QPDFObjectHandle::getArrayNItems() const
 {

--- a/libqpdf/qpdf/QPDFObjectHandle_private.hh
+++ b/libqpdf/qpdf/QPDFObjectHandle_private.hh
@@ -13,11 +13,11 @@ namespace qpdf
     {
       public:
         // Create an empty Array. If 'empty' is false, create a null Array.
-        Array(bool empty = true);
+        explicit Array(bool empty = true);
 
-        Array(std::vector<QPDFObjectHandle> const& items);
+        explicit Array(std::vector<QPDFObjectHandle> const& items);
 
-        Array(std::vector<QPDFObjectHandle>&& items);
+        explicit Array(std::vector<QPDFObjectHandle>&& items);
 
         Array(Array const& other) :
             BaseHandle(other.obj)


### PR DESCRIPTION
…ray` constructors, simplify logic, and reduce redundancy.