### PR TITLE
Refactor `QPDFAcroFormDocumentHelper`: simplify `traverseField`, remo…

### DIFF
--- a/include/qpdf/QPDFAcroFormDocumentHelper.hh
+++ b/include/qpdf/QPDFAcroFormDocumentHelper.hh
@@ -226,8 +226,7 @@ class QPDFAcroFormDocumentHelper: public QPDFDocumentHelper
 
   private:
     void analyze();
-    void traverseField(
-        QPDFObjectHandle field, QPDFObjectHandle parent, int depth, QPDFObjGen::set& visited);
+    void traverseField(QPDFObjectHandle const& field, QPDFObjectHandle const& parent, int depth);
     QPDFObjectHandle getOrCreateAcroForm();
     void adjustInheritedFields(
         QPDFObjectHandle obj,

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -204,11 +204,6 @@ QPDFAnnotationObjectHelper AP stream 0
 QPDFAnnotationObjectHelper AP dictionary 0
 QPDFAnnotationObjectHelper AP sub stream 0
 QPDFAnnotationObjectHelper AP null 0
-QPDFAcroFormDocumentHelper fields not array 0
-QPDFAcroFormDocumentHelper orphaned widget 0
-QPDFAcroFormDocumentHelper direct field 0
-QPDFAcroFormDocumentHelper non-dictionary field 0
-QPDFAcroFormDocumentHelper loop 0
 QPDFAcroFormDocumentHelper field found 1
 QPDFAcroFormDocumentHelper annotation found 1
 QPDFJob automatically set keep files open 1


### PR DESCRIPTION
…ve `visited` parameter, update conditional checks, and streamline logic for field and annotation handling.

Tighten validation of the PDF spec requirements that form fields form a tree and that widget annotations have a single parent by utilizing `field_to_annotations` and `annotation_to_field` in the loop detection check.