### PR TITLE
Avoid unnecessary re-compression in QPDFJob::doCheck

### DIFF
--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -793,6 +793,11 @@ QPDFJob::doCheck(QPDF& pdf)
         Pl_Discard discard;
         w.setOutputPipeline(&discard);
         w.setDecodeLevel(qpdf_dl_all);
+        // Disable compression of streams, since we only need to confirm we can decode them. This
+        // avoids JPEG DCT -> Flate recompression of all images.
+        w.setCompressStreams(false);
+        // Also disable recompression of Flate streams since are only checking.
+        w.setRecompressFlate(false);
         w.write();
 
         // Parse all content streams


### PR DESCRIPTION
While investigating https://github.com/ocrmypdf/OCRmyPDF/issues/1570, I discovered that QPDFJob::doCheck does some unnecessary work by re-compressing some streams to Flate. This is mostly noticeable on larger PDFs that contain a lot of JPEGs where DCT decode -> Flate encode uses a lot CPU time and memory. 

Recompressing in this way should not affect the quality of checks, since we only need to confirm we can decode all present streams.