### PR TITLE
Fix misleading warning/error messages in `pushInheritedAttributesToPa…

### DIFF
--- a/qpdf/qtest/qpdf/issue-99.out
+++ b/qpdf/qtest/qpdf/issue-99.out
@@ -19,6 +19,5 @@ WARNING: issue-99.pdf (object 11 0, offset 4497): unexpected array close token; 
 WARNING: issue-99.pdf (object 11 0, offset 4499): expected endobj
 WARNING: issue-99.pdf: unable to find trailer dictionary while recovering damaged file
 WARNING: object 1 0: Pages tree includes non-dictionary object; ignoring
-WARNING: object 1 0: operation for dictionary attempted on object of type null: returning false for a key containment request
 WARNING: object 1 0: operation for dictionary attempted on object of type null: ignoring key replacement request
 qpdf: issue-99.pdf: unable to find any pages while recovering damaged file

--- a/qpdf/qtest/qpdf/pages-warning.out
+++ b/qpdf/qtest/qpdf/pages-warning.out
@@ -1,2 +1,2 @@
-WARNING: lin-special.pdf (Pages object: object 6 0): Unknown key /Quack in /Pages object is being discarded as a result of flattening the /Pages tree
+WARNING: lin-special.pdf (Pages object: object 6 0, offset 1857): Unknown key /Quack in /Pages object is being discarded as a result of flattening the /Pages tree
 test 23 done


### PR DESCRIPTION
…ge`: the existing code used 'last_object_description' and reported the error against a random unrelated object.