### PR TITLE
Maintain C++-17 compatibility for public header files

### DIFF
--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -16,7 +16,10 @@ more detail.
 12.3.0: not yet released
   - Build changes
 
-    - A C++-20 compiler is now required.
+    - A C++-20 compiler is now required to build or test ``qpdf``. All public header
+      files remain C++-17 compatible. Until further notice, any future header files
+      that require C++-20 will be flagged in the release notes and their use will be
+      optional.
 
     - The AppImage and Linux standalone binary distributions are now
       built with Ubuntu 22.04 to support C++-20, which means they will

--- a/pkg-test/CMakeLists.txt
+++ b/pkg-test/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
 project(qpdf-version LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 20)
 find_package(qpdf)
 add_executable(qpdf-version qpdf-version.cc)
 target_link_libraries(qpdf-version qpdf::libqpdf)

--- a/pkg-test/qpdf-version.cc
+++ b/pkg-test/qpdf-version.cc
@@ -1,9 +1,72 @@
+#include <qpdf/Buffer.hh>
+#include <qpdf/BufferInputSource.hh>
+#include <qpdf/ClosedFileInputSource.hh>
+#include <qpdf/Constants.h>
+#include <qpdf/DLL.h>
+#include <qpdf/FileInputSource.hh>
+#include <qpdf/InputSource.hh>
+#include <qpdf/JSON.hh>
+#include <qpdf/ObjectHandle.hh>
+#include <qpdf/PDFVersion.hh>
+#include <qpdf/Pipeline.hh>
+#include <qpdf/Pl_Buffer.hh>
+#include <qpdf/Pl_Concatenate.hh>
+#include <qpdf/Pl_Count.hh>
+#include <qpdf/Pl_DCT.hh>
+#include <qpdf/Pl_Discard.hh>
+#include <qpdf/Pl_Flate.hh>
+#include <qpdf/Pl_Function.hh>
+#include <qpdf/Pl_OStream.hh>
+#include <qpdf/Pl_QPDFTokenizer.hh>
+#include <qpdf/Pl_RunLength.hh>
+#include <qpdf/Pl_StdioFile.hh>
+#include <qpdf/Pl_String.hh>
+#include <qpdf/PointerHolder.hh>
+#include <qpdf/QIntC.hh>
 #include <qpdf/QPDF.hh>
+#include <qpdf/QPDFAcroFormDocumentHelper.hh>
+#include <qpdf/QPDFAnnotationObjectHelper.hh>
+#include <qpdf/QPDFCryptoImpl.hh>
+#include <qpdf/QPDFCryptoProvider.hh>
+#include <qpdf/QPDFDocumentHelper.hh>
+#include <qpdf/QPDFEFStreamObjectHelper.hh>
+#include <qpdf/QPDFEmbeddedFileDocumentHelper.hh>
+#include <qpdf/QPDFExc.hh>
+#include <qpdf/QPDFFileSpecObjectHelper.hh>
+#include <qpdf/QPDFFormFieldObjectHelper.hh>
+#include <qpdf/QPDFJob.hh>
+#include <qpdf/QPDFLogger.hh>
+#include <qpdf/QPDFMatrix.hh>
+#include <qpdf/QPDFNameTreeObjectHelper.hh>
+#include <qpdf/QPDFNumberTreeObjectHelper.hh>
+#include <qpdf/QPDFObjGen.hh>
+// do not include obsolete QPDFObject.hh
+#include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFObjectHelper.hh>
+#include <qpdf/QPDFOutlineDocumentHelper.hh>
+#include <qpdf/QPDFOutlineObjectHelper.hh>
+#include <qpdf/QPDFPageDocumentHelper.hh>
+#include <qpdf/QPDFPageLabelDocumentHelper.hh>
+#include <qpdf/QPDFPageObjectHelper.hh>
+#include <qpdf/QPDFStreamFilter.hh>
+#include <qpdf/QPDFSystemError.hh>
+#include <qpdf/QPDFTokenizer.hh>
+#include <qpdf/QPDFUsage.hh>
+#include <qpdf/QPDFWriter.hh>
+#include <qpdf/QPDFXRefEntry.hh>
+#include <qpdf/QTC.hh>
+#include <qpdf/QUtil.hh>
+#include <qpdf/RandomDataProvider.hh>
+#include <qpdf/Types.h>
+#include <qpdf/qpdf-c.h>
+#include <qpdf/qpdfjob-c.h>
+#include <qpdf/qpdflogger-c.h>
+
 #include <iostream>
 
 int
 main()
 {
-    std::cout << QPDF::QPDFVersion() << std::endl;
+    std::cout << QPDF::QPDFVersion() << '\n';
     return 0;
 }


### PR DESCRIPTION
Continued from #1490 .

@jberkenbilt , I agree that bumping the requirement for pkg-test to C++-20 was not a good idea, especially in view of the points made by  @bhennion in #1543. I think it makes sense to maintain C++-17 compatibility for public header files for as long as possible, and at the moment I don't have anything on my radar that would significantly benefit from C++-20 in public headers.

I have updated the release notes accordingly.

If we are committing to C++-17 compatibility for public header files for the time being then we should test for it in CI. I have updated `qpdf-version.cc` to pull in all public header files and required C++-17 compliance in the CMake file. I don't know how pkg-test is used by Debian and whether this has repercussions there - if it does, or if you feel that the change interferes with the purpose of testing that qpdflib works with a minimal CMake file we can leave pkg-test unchanged and implement this as a separate CI test.
