### PR TITLE
Utilize the GNUTLS_FIPS140_LAX around MD5 initialization.

### DIFF
--- a/libqpdf/qpdf/QPDFCrypto_gnutls.hh
+++ b/libqpdf/qpdf/QPDFCrypto_gnutls.hh
@@ -53,6 +53,7 @@ class QPDFCrypto_gnutls: public QPDFCryptoImpl
     char digest[64];
     unsigned char const* aes_key_data;
     size_t aes_key_len;
+    unsigned fips_mode;
 };
 
 #endif // QPDFCRYPTO_GNUTLS_HH


### PR DESCRIPTION
Surrounding the gnutls_hash_init(&hash_ctx, GNUTLS_DIG_MD5) call with the convenience macros allows MD5 to be used internally even in FIPS 140 mode and should not affect at all systems not running FIPS.

Fixes #1566.