### PR TITLE
Improve error handling for common PDF anomalies.

### DIFF
--- a/libqpdf/QPDF_objects.cc
+++ b/libqpdf/QPDF_objects.cc
@@ -534,12 +534,20 @@ Objects::read_xref(qpdf_offset_t xref_offset, bool in_stream_recovery)
     if (!m->deleted_objects.empty()) {
         max_obj = std::max(max_obj, *(m->deleted_objects.rbegin()));
     }
-    if ((size < 1) || (size - 1 != max_obj)) {
-        warn(damagedPDF(
-            "",
-            -1,
-            ("reported number of objects (" + std::to_string(size) +
-             ") is not one plus the highest object number (" + std::to_string(max_obj) + ")")));
+    if (size < 1 || (size - 1) != max_obj) {
+        if ((size - 2) == max_obj ){//&& qpdf.getObject(max_obj, 0).isStreamOfType("/XRef")) {
+            warn(damagedPDF(
+                "",
+                -1,
+                "xref entry for the xref stream itself is missing - a common error handled "
+                "correctly by qpdf and most other applications"));
+        } else {
+            warn(damagedPDF(
+                "",
+                -1,
+                ("reported number of objects (" + std::to_string(size) +
+                 ") is not one plus the highest object number (" + std::to_string(max_obj) + ")")));
+        }
     }
 
     // We no longer need the deleted_objects table, so go ahead and clear it out to make sure we
@@ -1475,7 +1483,10 @@ Objects::readObjectAtOffset(
     // "0000000000 00000 n", which is not correct, but it won't hurt anything for us to ignore
     // these.
     if (offset == 0) {
-        warn(damagedPDF(-1, "object has offset 0"));
+        warn(damagedPDF(
+            -1,
+            "object has offset 0 - a common error handled correctly by qpdf and most other "
+            "applications"));
         return;
     }
 

--- a/qpdf/qtest/qpdf/bad12-recover.out
+++ b/qpdf/qtest/qpdf/bad12-recover.out
@@ -1,4 +1,4 @@
-WARNING: bad12.pdf: reported number of objects (9) is not one plus the highest object number (7)
+WARNING: bad12.pdf: xref entry for the xref stream itself is missing - a common error handled correctly by qpdf and most other applications
 WARNING: bad12.pdf (object 2 0, offset 128): expected endobj
 /QTest is implicit
 /QTest is direct and has type null (2)

--- a/qpdf/qtest/qpdf/bad12.out
+++ b/qpdf/qtest/qpdf/bad12.out
@@ -1,4 +1,4 @@
-WARNING: bad12.pdf: reported number of objects (9) is not one plus the highest object number (7)
+WARNING: bad12.pdf: xref entry for the xref stream itself is missing - a common error handled correctly by qpdf and most other applications
 WARNING: bad12.pdf (object 2 0, offset 128): expected endobj
 /QTest is implicit
 /QTest is direct and has type null (2)

--- a/qpdf/qtest/qpdf/issue-150.out
+++ b/qpdf/qtest/qpdf/issue-150.out
@@ -3,5 +3,5 @@ WARNING: issue-150.pdf (xref stream: object 8 0, offset 56): treating object as 
 WARNING: issue-150.pdf: file is damaged
 WARNING: issue-150.pdf (offset 4): xref not found
 WARNING: issue-150.pdf: Attempting to reconstruct cross-reference table
-WARNING: issue-150.pdf (object 8 0): object has offset 0
+WARNING: issue-150.pdf (object 8 0): object has offset 0 - a common error handled correctly by qpdf and most other applications
 qpdf: issue-150.pdf: unable to find trailer dictionary while recovering damaged file

--- a/qpdf/qtest/qpdf/zero-offset.out
+++ b/qpdf/qtest/qpdf/zero-offset.out
@@ -2,5 +2,5 @@ checking zero-offset.pdf
 PDF Version: 1.3
 File is not encrypted
 File is not linearized
-WARNING: zero-offset.pdf (object 6 0): object has offset 0
+WARNING: zero-offset.pdf (object 6 0): object has offset 0 - a common error handled correctly by qpdf and most other applications
 qpdf: operation succeeded with warnings


### PR DESCRIPTION
- Updated warning messages to provide clearer descriptions of common issues ("object has offset 0", "xref entry missing") and note that these are handled gracefully by qpdf.
- Adjusted logic in `QPDF_objects.cc` to identify and process `xref` stream-specific anomalies accurately.

Fixes #1594
Fixes #1292