### PR TITLE
Refactor error handling across codebase with `util::assertion` and `u…

### DIFF
--- a/libqpdf/Pl_ASCIIHexDecoder.cc
+++ b/libqpdf/Pl_ASCIIHexDecoder.cc
@@ -1,17 +1,18 @@
 #include <qpdf/Pl_ASCIIHexDecoder.hh>
 
 #include <qpdf/QTC.hh>
+#include <qpdf/Util.hh>
+
 #include <cctype>
 #include <stdexcept>
 
+using namespace qpdf;
 using namespace std::literals;
 
 Pl_ASCIIHexDecoder::Pl_ASCIIHexDecoder(char const* identifier, Pipeline* next) :
     Pipeline(identifier, next)
 {
-    if (!next) {
-        throw std::logic_error("Attempt to create Pl_ASCIIHexDecoder with nullptr as next");
-    }
+    util::assertion(next, "Attempt to create Pl_ASCIIHexDecoder with nullptr as next");
 }
 
 void

--- a/libqpdf/Pl_Buffer.cc
+++ b/libqpdf/Pl_Buffer.cc
@@ -1,9 +1,13 @@
 #include <qpdf/Pl_Buffer.hh>
 
+#include <qpdf/Util.hh>
+
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>
+
+using namespace qpdf;
 
 class Pl_Buffer::Members
 {
@@ -50,9 +54,7 @@ Pl_Buffer::finish()
 Buffer*
 Pl_Buffer::getBuffer()
 {
-    if (!m->ready) {
-        throw std::logic_error("Pl_Buffer::getBuffer() called when not ready");
-    }
+    util::assertion(m->ready, "Pl_Buffer::getBuffer() called when not ready");
     auto* b = new Buffer(std::move(m->data));
     m->data.clear();
     return b;
@@ -61,9 +63,7 @@ Pl_Buffer::getBuffer()
 std::string
 Pl_Buffer::getString()
 {
-    if (!m->ready) {
-        throw std::logic_error("Pl_Buffer::getString() called when not ready");
-    }
+    util::assertion(m->ready, "Pl_Buffer::getString() called when not ready");
     auto s = std::move(m->data);
     m->data.clear();
     return s;
@@ -78,9 +78,7 @@ Pl_Buffer::getBufferSharedPointer()
 void
 Pl_Buffer::getMallocBuffer(unsigned char** buf, size_t* len)
 {
-    if (!m->ready) {
-        throw std::logic_error("Pl_Buffer::getMallocBuffer() called when not ready");
-    }
+    util::assertion(m->ready, "Pl_Buffer::getMallocBuffer() called when not ready");
     auto size = m->data.size();
     *len = size;
     if (size > 0) {

--- a/libqpdf/Pl_Concatenate.cc
+++ b/libqpdf/Pl_Concatenate.cc
@@ -1,13 +1,13 @@
 #include <qpdf/Pl_Concatenate.hh>
 
-#include <stdexcept>
+#include <qpdf/Util.hh>
+
+using namespace qpdf;
 
 Pl_Concatenate::Pl_Concatenate(char const* identifier, Pipeline* next) :
     Pipeline(identifier, next)
 {
-    if (!next) {
-        throw std::logic_error("Attempt to create Pl_Concatenate with nullptr as next");
-    }
+    util::assertion(next, "Attempt to create Pl_Concatenate with nullptr as next");
 }
 
 // Must be explicit and not inline -- see QPDF_DLL_CLASS in README-maintainer

--- a/libqpdf/Pl_Count.cc
+++ b/libqpdf/Pl_Count.cc
@@ -1,6 +1,9 @@
 #include <qpdf/Pl_Count.hh>
 
 #include <qpdf/QIntC.hh>
+#include <qpdf/Util.hh>
+
+using namespace qpdf;
 
 class Pl_Count::Members
 {
@@ -18,15 +21,11 @@ Pl_Count::Pl_Count(char const* identifier, Pipeline* next) :
     Pipeline(identifier, next),
     m(std::make_unique<Members>())
 {
-    if (!next) {
-        throw std::logic_error("Attempt to create Pl_Count with nullptr as next");
-    }
+    util::assertion(next, "Attempt to create Pl_Count with nullptr as next");
 }
 
-Pl_Count::~Pl_Count() // NOLINT (modernize-use-equals-default)
-{
-    // Must be explicit and not inline -- see QPDF_DLL_CLASS in README-maintainer
-}
+Pl_Count::~Pl_Count() = default;
+// Must be explicit and not inline -- see QPDF_DLL_CLASS in README-maintainer
 
 void
 Pl_Count::write(unsigned char const* buf, size_t len)

--- a/libqpdf/Pl_RC4.cc
+++ b/libqpdf/Pl_RC4.cc
@@ -1,24 +1,23 @@
 #include <qpdf/Pl_RC4.hh>
 
 #include <qpdf/QUtil.hh>
+#include <qpdf/Util.hh>
+
+using namespace qpdf;
 
 Pl_RC4::Pl_RC4(char const* identifier, Pipeline* next, std::string key, size_t out_bufsize) :
     Pipeline(identifier, next),
     out_bufsize(out_bufsize),
     rc4(reinterpret_cast<unsigned char const*>(key.data()), static_cast<int>(key.size()))
 {
-    if (!next) {
-        throw std::logic_error("Attempt to create Pl_RC4 with nullptr as next");
-    }
+    util::assertion(next, "Attempt to create Pl_RC4 with nullptr as next");
     this->outbuf = QUtil::make_shared_array<unsigned char>(out_bufsize);
 }
 
 void
 Pl_RC4::write(unsigned char const* data, size_t len)
 {
-    if (this->outbuf == nullptr) {
-        throw std::logic_error(this->identifier + ": Pl_RC4: write() called after finish() called");
-    }
+    util::assertion(outbuf.get(), "Pl_RC4: write() called after finish() called");
 
     size_t bytes_left = len;
     unsigned char const* p = data;
@@ -26,7 +25,6 @@ Pl_RC4::write(unsigned char const* data, size_t len)
     while (bytes_left > 0) {
         size_t bytes = (bytes_left < this->out_bufsize ? bytes_left : out_bufsize);
         bytes_left -= bytes;
-        // lgtm[cpp/weak-cryptographic-algorithm]
         rc4.process(p, bytes, outbuf.get());
         p += bytes;
         next()->write(outbuf.get(), bytes);

--- a/libqpdf/Pl_SHA2.cc
+++ b/libqpdf/Pl_SHA2.cc
@@ -2,8 +2,9 @@
 
 #include <qpdf/QPDFCryptoProvider.hh>
 #include <qpdf/QUtil.hh>
+#include <qpdf/Util.hh>
 
-#include <stdexcept>
+using namespace qpdf;
 
 Pl_SHA2::Pl_SHA2(int bits, Pipeline* next) :
     Pipeline("sha2", next)
@@ -49,9 +50,7 @@ Pl_SHA2::finish()
 void
 Pl_SHA2::resetBits(int bits)
 {
-    if (in_progress) {
-        throw std::logic_error("bit reset requested for in-progress SHA2 Pipeline");
-    }
+    util::assertion(!in_progress, "bit reset requested for in-progress SHA2 Pipeline");
     crypto = QPDFCryptoProvider::getImpl();
     crypto->SHA2_init(bits);
 }
@@ -59,17 +58,13 @@ Pl_SHA2::resetBits(int bits)
 std::string
 Pl_SHA2::getRawDigest()
 {
-    if (in_progress) {
-        throw std::logic_error("digest requested for in-progress SHA2 Pipeline");
-    }
+    util::assertion(!in_progress, "digest requested for in-progress SHA2 Pipeline");
     return crypto->SHA2_digest();
 }
 
 std::string
 Pl_SHA2::getHexDigest()
 {
-    if (in_progress) {
-        throw std::logic_error("digest requested for in-progress SHA2 Pipeline");
-    }
+    util::assertion(!in_progress, "digest requested for in-progress SHA2 Pipeline");
     return QUtil::hex_encode(getRawDigest());
 }

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -672,10 +672,7 @@ QPDF::getXRefTable()
 std::map<QPDFObjGen, QPDFXRefEntry> const&
 Objects::xref_table()
 {
-    if (!m->parsed) {
-        throw std::logic_error("QPDF::getXRefTable called before parsing.");
-    }
-
+    util::assertion(m->parsed, "QPDF::getXRefTable called before parsing");
     return m->xref_table;
 }
 

--- a/libqpdf/QPDFArgParser.cc
+++ b/libqpdf/QPDFArgParser.cc
@@ -56,7 +56,6 @@ QPDFArgParser::selectOptionTable(std::string const& name)
 {
     auto t = m->option_tables.find(name);
     if (t == m->option_tables.end()) {
-        QTC::TC("libtests", "QPDFArgParser select unregistered table");
         throw std::logic_error("QPDFArgParser: selecting unregistered option table " + name);
     }
     m->option_table = &(t->second);
@@ -67,7 +66,6 @@ void
 QPDFArgParser::registerOptionTable(std::string const& name, bare_arg_handler_t end_handler)
 {
     if (m->option_tables.contains(name)) {
-        QTC::TC("libtests", "QPDFArgParser register registered table");
         throw std::logic_error(
             "QPDFArgParser: registering already registered option table " + name);
     }
@@ -80,7 +78,6 @@ QPDFArgParser::OptionEntry&
 QPDFArgParser::registerArg(std::string const& arg)
 {
     if (m->option_table->contains(arg)) {
-        QTC::TC("libtests", "QPDFArgParser duplicate handler");
         throw std::logic_error(
             "QPDFArgParser: adding a duplicate handler for option " + arg + " in " +
             m->option_table_name + " option table");
@@ -138,7 +135,6 @@ QPDFArgParser::addInvalidChoiceHandler(std::string const& arg, param_arg_handler
 {
     auto i = m->option_table->find(arg);
     if (i == m->option_table->end()) {
-        QTC::TC("libtests", "QPDFArgParser invalid choice handler to unknown");
         throw std::logic_error(
             "QPDFArgParser: attempt to add invalid choice handler to unknown argument");
     }
@@ -448,11 +444,9 @@ QPDFArgParser::parseArgs()
             // Special case for -- option, which is used to break out of subparsers.
             oep = m->option_table->find("--");
             end_option = true;
-            if (oep == m->option_table->end()) {
-                // This is registered automatically, so this can't happen.
-                throw std::logic_error("QPDFArgParser: -- handler not registered");
-            }
-        } else if ((arg[0] == '-') && (strcmp(arg, "-") != 0)) {
+            util::internal_error_if(
+                oep == m->option_table->end(), "QPDFArgParser: -- handler not registered");
+        } else if (arg[0] == '-' && strcmp(arg, "-") != 0) {
             ++arg;
             if (arg[0] == '-') {
                 // Be lax about -arg vs --arg
@@ -678,15 +672,12 @@ QPDFArgParser::addHelpTopic(
     std::string const& topic, std::string const& short_text, std::string const& long_text)
 {
     if (topic == "all") {
-        QTC::TC("libtests", "QPDFArgParser add reserved help topic");
         throw std::logic_error("QPDFArgParser: can't register reserved help topic " + topic);
     }
     if (topic.empty() || topic.at(0) == '-') {
-        QTC::TC("libtests", "QPDFArgParser bad topic for help");
         throw std::logic_error("QPDFArgParser: help topics must not start with -");
     }
     if (m->help_topics.contains(topic)) {
-        QTC::TC("libtests", "QPDFArgParser add existing topic");
         throw std::logic_error("QPDFArgParser: topic " + topic + " has already been added");
     }
 
@@ -701,17 +692,14 @@ QPDFArgParser::addOptionHelp(
     std::string const& short_text,
     std::string const& long_text)
 {
-    if (!((option_name.length() > 2) && (option_name.at(0) == '-') && (option_name.at(1) == '-'))) {
-        QTC::TC("libtests", "QPDFArgParser bad option for help");
+    if (!(option_name.length() > 2 && option_name.starts_with("--"))) {
         throw std::logic_error("QPDFArgParser: options for help must start with --");
     }
     if (m->option_help.contains(option_name)) {
-        QTC::TC("libtests", "QPDFArgParser duplicate option help");
         throw std::logic_error("QPDFArgParser: option " + option_name + " already has help");
     }
     auto ht = m->help_topics.find(topic);
     if (ht == m->help_topics.end()) {
-        QTC::TC("libtests", "QPDFArgParser add to unknown topic");
         throw std::logic_error(
             "QPDFArgParser: unable to add option " + option_name + " to unknown help topic " +
             topic);

--- a/libqpdf/qpdf/Util.hh
+++ b/libqpdf/qpdf/Util.hh
@@ -35,6 +35,14 @@ namespace qpdf::util
         }
     }
 
+    inline void
+    no_ci_rt_error_if(bool cond, std::string const& msg)
+    {
+        if (cond) {
+            throw std::runtime_error(msg);
+        }
+    }
+
     inline constexpr char
     hex_decode_char(char digit)
     {

--- a/libtests/libtests.testcov
+++ b/libtests/libtests.testcov
@@ -1,9 +1,6 @@
 ignored-scope: qpdf
 Pl_LZWDecoder intermediate reset 0
-Pl_LZWDecoder last was table size 0
 Pl_ASCII85Decoder ignore space 0
-Pl_ASCII85Decoder read z 0
-Pl_ASCII85Decoder no-op flush 0
 Pl_ASCII85Decoder partial flush 1
 bits leftover 1
 bits bit_offset 2
@@ -41,22 +38,12 @@ QPDFArgParser read args from stdin 0
 QPDFArgParser read args from file 0
 QPDFArgParser required choices 0
 QPDFArgParser required parameter 0
-QPDFArgParser select unregistered table 0
-QPDFArgParser register registered table 0
-QPDFArgParser duplicate handler 0
 QPDFArgParser missing -- 0
 QPDFArgParser single dash 0
 QPDFArgParser help option 0
 QPDFArgParser positional 0
 QPDFArgParser unrecognized 0
 QPDFArgParser complete choices 0
-QPDFArgParser add reserved help topic 0
-QPDFArgParser add existing topic 0
-QPDFArgParser add to unknown topic 0
-QPDFArgParser duplicate option help 0
-QPDFArgParser bad option for help 0
-QPDFArgParser bad topic for help 0
-QPDFArgParser invalid choice handler to unknown 0
 JSON parse junk after object 0
 JSON parse invalid keyword 0
 JSON parse expected colon 0

--- a/libtests/qtest/qutil/qutil.out
+++ b/libtests/qtest/qutil/qutil.out
@@ -137,3 +137,8 @@ D:20210209191925Z
 done
 ---- memory usage
 memory usage okay
+---- error handlers
+caught exception: msg2
+caught exception: INTERNAL ERROR: msg4
+This is a qpdf bug. Please report at https://github.com/qpdf/qpdf/issues
+caught exception: msg6

--- a/libtests/qutil.cc
+++ b/libtests/qutil.cc
@@ -3,6 +3,8 @@
 #include <qpdf/Pl_Buffer.hh>
 #include <qpdf/QPDFSystemError.hh>
 #include <qpdf/QUtil.hh>
+#include <qpdf/Util.hh>
+
 #include <climits>
 #include <cstdio>
 #include <cstring>
@@ -743,6 +745,29 @@ memory_usage_test()
     std::cout << "memory usage okay" << '\n';
 }
 
+void
+error_handler_test()
+{
+    qpdf::util::assertion(true, "msg1");
+    try {
+        qpdf::util::assertion(false, "msg2");
+    } catch (std::logic_error const& e) {
+        std::cout << "caught exception: " << e.what() << '\n';
+    }
+    qpdf::util::internal_error_if(false, "msg3");
+    try {
+        qpdf::util::internal_error_if(true, "msg4");
+    } catch (std::logic_error const& e) {
+        std::cout << "caught exception: " << e.what() << '\n';
+    }
+    qpdf::util::no_ci_rt_error_if(false, "msg5");
+    try {
+        qpdf::util::no_ci_rt_error_if(true, "msg6");
+    } catch (std::runtime_error const& e) {
+        std::cout << "caught exception: " << e.what() << '\n';
+    }
+}
+
 int
 main(int argc, char* argv[])
 {
@@ -782,6 +807,8 @@ main(int argc, char* argv[])
         is_long_long_test();
         std::cout << "---- memory usage" << '\n';
         memory_usage_test();
+        std::cout << "---- error handlers" << '\n';
+        error_handler_test();
     } catch (std::exception& e) {
         std::cout << "unexpected exception: " << e.what() << '\n';
     }


### PR DESCRIPTION
…til::no_ci_rt_error_if`.

- Standardize error handling by replacing repetitive throw statements with helper functions.
- Add test coverage for new helper functions in error handling.
- Enhance maintainability and readability with concise utilities.