### PR TITLE
Improve JSON schema validation and error reporting

### DIFF
--- a/include/qpdf/JSON.hh
+++ b/include/qpdf/JSON.hh
@@ -363,7 +363,7 @@ class JSON
 
     JSON(std::unique_ptr<JSON_value>);
 
-    static bool checkSchemaInternal(
+    static void checkSchemaInternal(
         JSON_value* this_v,
         JSON_value* sch_v,
         unsigned long flags,

--- a/libtests/libtests.testcov
+++ b/libtests/libtests.testcov
@@ -31,9 +31,6 @@ Pl_PNGFilter decodeUp 0
 Pl_PNGFilter decodeAverage 0
 Pl_PNGFilter decodePaeth 0
 Pl_TIFFPredictor processRow 1
-JSON wanted dictionary 0
-JSON key missing in object 0
-JSON key extra in object 0
 QPDFArgParser read args from stdin 0
 QPDFArgParser read args from file 0
 QPDFArgParser required choices 0
@@ -72,10 +69,7 @@ JSON parse ls premature end of input 0
 JSON parse bad hex after u 0
 JSONHandler unhandled value 0
 JSONHandler unexpected key 0
-JSON schema other type 0
 JSON optional key 0
 JSON 16 high high 0
 JSON 16 low not after high 0
 JSON 16 dangling high 0
-JSON schema array for single item 0
-JSON schema array length mismatch 0


### PR DESCRIPTION
- Add null pointer checks for schema objects.
- Refactor `checkSchemaInternal` for better readability and maintainability.
- Replace redundant error construction logic with lambda-based approach.
- Simplify array and dictionary schema handling.
- Remove unused test coverage statistics.