### PR TITLE
Add script to validate private header files in isolation

### DIFF
--- a/build-scripts/build-linux
+++ b/build-scripts/build-linux
@@ -20,6 +20,9 @@ done
 cd ..
 # Perform additional tests on header files.
 ./build-scripts/check-headers
+# Perform additional tests on private header files.
+./build-scripts/check-private-headers
+# Create distribution
 export TMPDIR=$PWD/dist-tmp
 rm -rf $TMPDIR
 ./make_dist --ci

--- a/build-scripts/check-private-headers
+++ b/build-scripts/check-private-headers
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eo pipefail
+cd "$(dirname $0)/.."
+
+trap "rm -f a.cc" EXIT
+declare -a pheaders
+cd libqpdf
+for i in qpdf/*.hh; do
+    if [[ ! $i =~ .*auto_.* ]] && ! grep -q >/dev/null 2>&1 QPDFOBJECT_OLD_HH $i; then
+        pheaders+=($i)
+    fi
+done
+cd ..
+# Make sure each header file can be included in isolation and that the
+# result can be compiled with the version of the C++ standard used by the qpdf project, currently C++-20.
+declare -a perrors
+for i in "${pheaders[@]}"; do
+    rm -f a.cc
+    cat > a.cc <<EOF
+#include "$i"
+int main() { return 0; }
+EOF
+    echo "Checking $i"
+    if ! g++ -std=c++20 -pedantic-errors -c -Iinclude -Ilibqpdf -Ibuild/libqpdf a.cc -o /dev/null; then
+        perrors+=("$i doesn't compile")
+    fi
+done
+if [[ ${#perrors[@]} -gt 0 ]]; then
+    echo ""
+    echo "Some header files had errors"
+    for i in "${perrors[@]}"; do
+        echo "$i"
+    done
+    exit 2
+fi

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -1,7 +1,6 @@
 .. _ticket: https://issues.qpdf.org
 .. _shared null: https://wiki.qpdf.org/PDF-null-objects-vs-qpdf-null-objects
 
-
 .. _release-notes:
 
 Release Notes
@@ -79,8 +78,8 @@ more detail.
 
   - Build fixes
 
-    - Attempt to detect if any > C++-17 changes snuck into any public
-      headers.
+    - Attempt to detect if any > C++17 changes snuck into any public
+      headers and check all private headers compile stand-alone.
 
   - CLI Enhancements
 


### PR DESCRIPTION
Introduce `check-private-headers` script to ensure all private headers compile independently. Update `build-linux` script to include this new validation step. Adjust release notes to reflect the additional header checks.

Addresses the issue raised #1465