### PR TITLE
Add documentation for Inspection Mode

### DIFF
--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -38,6 +38,7 @@ SET(MANUAL_DEPS
   download.rst
   encryption.rst
   index.rst
+  inspection.rst
   installation.rst
   json.rst
   contributing.rst

--- a/manual/design.rst
+++ b/manual/design.rst
@@ -67,6 +67,9 @@ Inspection mode is intended for manual investigations and repairs. As such,
 stability is less of a concern than for other uses of qpdf. The exact effect
 of specifying inspection mode will evolve from version to version.
 
+Before using inspection mode, please read :ref:`inspection` for more details
+about its behavior.
+
 .. _design-goals:
 
 Design Goals

--- a/manual/index.rst
+++ b/manual/index.rst
@@ -39,6 +39,12 @@ documentation, please visit `https://qpdf.readthedocs.io
    release-notes
    acknowledgement
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Appendices:
+
+   inspection
+
 Indices
 =======
 

--- a/manual/inspection.rst
+++ b/manual/inspection.rst
@@ -1,0 +1,75 @@
+.. _inspection:
+
+Appendix 1: Inspection Mode
+===========================
+
+.. _inspection.intro:
+
+Introduction
+------------
+
+This appendix provides further detail about inspection mode.
+
+Inspection mode is primarily intended for manual investigation and
+analysis of PDF files. API stability is not a major concern and
+the details of what is and is not supported may change from version to
+version. Please check this section for updates with each new release of qpdf.
+
+**NOTE** Updates in the release notes may not apply to inspection mode
+despite wording such as "unconditionally" or "always." Look out for
+footnotes indicating that statements don't apply to inspection mode.
+
+**NOTE** Warning messages are not adapted for inspection mode. In
+particular, messages that state that an issue has been repaired may
+not apply.
+
+.. _inspection.supported:
+
+Supported Operations
+--------------------
+
+The only supported operations in inspection mode are the retrieval of
+objects with methods such as ``QPDF::getObject``, ``QPDF::getRoot`` and
+``QPDF::getTrailer`` and the use of accessor methods of
+``QPDFObjectHandle`` that do not require any modification of the object,
+including the ``unparse`` and ``writeJSON`` methods.
+
+Other operations not specifically flagged as unsupported may also work,
+but there are no guarantees and they may cause crashes or hang.
+
+.. _inspection.unsupported:
+
+Unsupported Operations
+----------------------
+
+The following operations are explicitly unsupported in inspection mode:
+
+- use of any document and object helper methods
+- use of any linearization methods, including check methods
+- creation of object streams
+- operations involving more than one ``QPDF`` object, such as copying objects
+  between documents
+
+If any of these operations are desired, inspection mode should be used
+to manually repair the files sufficiently to allow qpdf to successfully repair
+them in normal mode.
+
+.. _inspection.disabled:
+
+Disabled Operations
+-------------------
+
+The following operations are disabled and will throw a logic error:
+
+- retrieval of a document helper using static ``get`` methods
+
+.. _inspection.disabled_repairs:
+
+Disabled Automatic Repairs
+--------------------------
+
+The following automatic repairs are disabled in inspection mode:
+
+- root object:
+    - repairing missing or incorrect ``/Type`` attributes
+


### PR DESCRIPTION
- Introduce `inspection.rst` appendix detailing supported, unsupported, and disabled operations in inspection mode.
- Update `design.rst` to reference the new appendix.
- Add `inspection.rst` to the manual's table of contents in `CMakeLists.txt` and `index.rst`.