### PR TITLE
Fix `Lin::readHintStream`

### DIFF
--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -545,12 +545,12 @@ Dictionary
 Lin::readHintStream(Pipeline& pl, qpdf_offset_t offset, size_t length)
 {
     auto H = m->objects.readObjectAtOffset(offset, "linearization hint stream", false);
-    ObjCache& oc = m->obj_cache[H];
-    qpdf_offset_t min_end_offset = oc.end_before_space;
-    qpdf_offset_t max_end_offset = oc.end_after_space;
     no_ci_stop_if(
         !H.isStream(), "hint table is not a stream", "linearization dictionary" //
     );
+    ObjCache& oc = m->obj_cache[H];
+    qpdf_offset_t min_end_offset = oc.end_before_space;
+    qpdf_offset_t max_end_offset = oc.end_after_space;
 
     Dictionary Hdict = H.getDict();
 


### PR DESCRIPTION
Reorder `no_ci_stop_if` call to avoid insertion of an invalid object into the object cache if the hint stream is invalid