### PR TITLE
Tighten named destination validation in `QPDFOutlineDocumentHelper::r…

### DIFF
--- a/libqpdf/QPDFOutlineDocumentHelper.cc
+++ b/libqpdf/QPDFOutlineDocumentHelper.cc
@@ -119,7 +119,7 @@ QPDFOutlineDocumentHelper::resolveNamedDest(QPDFObjectHandle name)
                     dests,
                     qpdf,
                     [](QPDFObjectHandle const& o) -> bool {
-                        return o.isArray() || o.isDictionary();
+                        return o.isArray() || o.contains("/D");
                     },
                     true);
                 m->names_dest->validate();


### PR DESCRIPTION
…esolveNamedDest: instead of accepting any Dictionary require a `/D` entry.