### PR TITLE
Allow README change to trigger CI (for 12.3.0)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,6 @@ on:
       - main
       - build
       - build/*
-    paths-ignore:
-      - 'ChangeLog'
-      - 'README*'
-      - 'TODO*'
   pull_request:
   schedule:
     # Building regularly with cron makes it safe for us to use


### PR DESCRIPTION
Virtually all changes are merged through PRs now. The exclusions would prevent a README change from being the last commit before a release.