### PR TITLE
Update release process instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ is https://qpdf.sourceforge.io. The source code repository is hosted at GitHub: 
 
 # Verifying Distributions
 
-Official qpdf releases are signed using [cosign](https://docs.sigstore.dev/quickstart/quickstart-cosign/). Each release includes a `sha256` file containing sha256 checksums of all the release files. To verify a release, use `cosign verify-blob`. Example:
+Official qpdf releases are signed using [cosign](https://docs.sigstore.dev/quickstart/quickstart-cosign/). Each release includes a `sha256` file containing sha256 checksums of all the release files. To verify a release, use `sha256sum file`, or similar, to generate the checksum of the file you want to verify and check to make sure it matches what's in the sha256 file. You can verify the sha256 file itself with gpg or with `cosign verify-blob`. Example:
 
 ```
 cosign verify-blob qpdf-x.y.z.sha256 --bundle qpdf-x.y.z.sha256.sigstore \
@@ -28,7 +28,7 @@ The identity `signer-identity@qpdf.org` should be replaced with the name of the 
 * Jay Berkenbilt <ejb@ql.org>
 * Manfred Holger <m.holger@qpdf.org>
 
-qpdf versions prior to version 13 were also signed using Jay Berkenbilt's GPG key, which has fingerprint `C2C9 6B10 011F E009 E6D1  DF82 8A75 D109 9801 2C7E` and can be found at https://q.ql.org/pubkey.asc or downloaded from a public key server. Starting with qpdf 13, releases are signed only using cosign.
+You can also verify qpdf releases using Jay Berkenbilt's GPG key, which has fingerprint `C2C9 6B10 011F E009 E6D1  DF82 8A75 D109 9801 2C7E` and can be found at https://q.ql.org/pubkey.asc or downloaded from a public key server.
 
 # Copyright, License
 

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -31,11 +31,9 @@ more detail.
 12.3.0: January 10, 2026
   - Release changes
 
-    - Starting with version 12.3.0, we use
-      `cosign <https://docs.sigstore.dev/cosign/>`__, rather than GPG,
-      to sign releases. See the top-level README.md for instructions.
-      We will continue to use GPG for the 12.x series. Starting with
-      qpdf version 13, only cosign will be used.
+    - Starting with version 12.3.0, we use `cosign
+      <https://docs.sigstore.dev/cosign/>`__, in addition to GPG, to
+      sign releases. See the top-level README.md for instructions.
 
   - Build changes
 


### PR DESCRIPTION
* Based on feedback, keep gpg as well as cosign for the indefinite future
* Streamline release creation process by using the `gh` command-line tool (GitHub's official CLI) rather than old-school curl directly against the GitHub API, a procedure that predates the `gh` command.
@m-holger FYI -- I also tweaked previous release notes, which I don't usually do. I didn't think to do this until after I had already cut the release, so these changes will go in for whatever's next.