### PR TITLE
Fix bug in `QPDFObjectHandle::getNumericValue` (fixes #1676)

### DIFF
--- a/libqpdf/CMakeLists.txt
+++ b/libqpdf/CMakeLists.txt
@@ -107,6 +107,7 @@ include(FindPkgConfig)
 include(CheckTypeSize)
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
 include(CheckCSourceRuns)
 include(CheckSymbolExists)
 
@@ -313,6 +314,17 @@ list(REMOVE_DUPLICATES dep_link_libraries)
 
 check_type_size(size_t SIZEOF_SIZE_T)
 check_include_file("inttypes.h" HAVE_INTTYPES_H)
+check_cxx_source_compiles(
+"#include <charconv>
+int main(int argc, char* argv[]) {
+    double value = 0.0;
+    char const* p = \"12.5\";
+    auto [tail, ec] =
+        std::from_chars(p, p + 4, value, std::chars_format::fixed);
+    (void)tail;
+    (void)ec;
+}"
+    HAVE_FROM_CHARS_DOUBLE)
 check_symbol_exists(localtime_r "time.h" HAVE_LOCALTIME_R)
 check_symbol_exists(random "stdlib.h" HAVE_RANDOM)
 

--- a/libqpdf/CMakeLists.txt
+++ b/libqpdf/CMakeLists.txt
@@ -107,6 +107,7 @@ include(FindPkgConfig)
 include(CheckTypeSize)
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
 include(CheckCSourceRuns)
 include(CheckSymbolExists)
 
@@ -327,6 +328,17 @@ list(REMOVE_DUPLICATES dep_link_libraries)
 
 check_type_size(size_t SIZEOF_SIZE_T)
 check_include_file("inttypes.h" HAVE_INTTYPES_H)
+check_cxx_source_compiles(
+"#include <charconv>
+int main(int argc, char* argv[]) {
+    double value = 0.0;
+    char const* p = \"12.5\";
+    auto [tail, ec] =
+        std::from_chars(p, p + 4, value, std::chars_format::fixed);
+    (void)tail;
+    (void)ec;
+}"
+    HAVE_FROM_CHARS_DOUBLE)
 check_symbol_exists(localtime_r "time.h" HAVE_LOCALTIME_R)
 check_symbol_exists(random "stdlib.h" HAVE_RANDOM)
 

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -15,6 +15,7 @@
 #include <qpdf/QTC.hh>
 #include <qpdf/Util.hh>
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <climits>
@@ -812,13 +813,17 @@ QPDFObjectHandle::getNumericValue() const
 {
     if (isInteger()) {
         return static_cast<double>(getIntValue());
-    } else if (isReal()) {
-        return atof(getRealValue().c_str());
-    } else {
-        typeWarning("number", "returning 0");
-        QTC::TC("qpdf", "QPDFObjectHandle numeric non-numeric");
-        return 0;
     }
+    if (auto* real = as<QPDF_Real>()) {
+        auto [valid, result] = util::str_to_double(real->val);
+        if (!valid) {
+            warnIfPossible(
+                "QPDFObjectHandle::getNumericValue: found invalid real value");
+        }
+        return result;
+    }
+    typeWarning("number", "returning 0");
+    return 0;
 }
 
 bool
@@ -1870,7 +1875,20 @@ QPDFObjectHandle::newNull()
 QPDFObjectHandle
 QPDFObjectHandle::newReal(std::string const& value)
 {
-    return {QPDFObject::create<QPDF_Real>(value)};
+    if (!(value.empty() || std::isspace(value.front()) || std::isspace(value.back()))) {
+        return {QPDFObject::create<QPDF_Real>(value)};
+    }
+    *QPDFLogger::defaultLogger()->getError()
+        << "newReal called with empty string or extra white-space\n";
+    auto cs = value;
+
+    cs.erase(
+        std::remove_if(cs.begin(), cs.end(), [](unsigned char x) { return std::isspace(x); }),
+        cs.end());
+    if (cs.empty()) {
+        cs = "0.0";
+    }
+    return {QPDFObject::create<QPDF_Real>(cs)};
 }
 
 QPDFObjectHandle

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -15,6 +15,7 @@
 #include <qpdf/QTC.hh>
 #include <qpdf/Util.hh>
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <climits>
@@ -821,13 +822,16 @@ QPDFObjectHandle::getNumericValue() const
 {
     if (isInteger()) {
         return static_cast<double>(getIntValue());
-    } else if (isReal()) {
-        return atof(getRealValue().c_str());
-    } else {
-        typeWarning("number", "returning 0");
-        QTC::TC("qpdf", "QPDFObjectHandle numeric non-numeric");
-        return 0;
     }
+    if (auto* real = as<QPDF_Real>()) {
+        auto [valid, result] = util::str_to_double(real->val);
+        if (!valid) {
+            warnIfPossible("QPDFObjectHandle::getNumericValue: found invalid real value");
+        }
+        return result;
+    }
+    typeWarning("number", "returning 0");
+    return 0;
 }
 
 bool
@@ -1899,7 +1903,20 @@ QPDFObjectHandle::newNull()
 QPDFObjectHandle
 QPDFObjectHandle::newReal(std::string const& value)
 {
-    return {QPDFObject::create<QPDF_Real>(value)};
+    if (!(value.empty() || std::isspace(value.front()) || std::isspace(value.back()))) {
+        return {QPDFObject::create<QPDF_Real>(value)};
+    }
+    *QPDFLogger::defaultLogger()->getError()
+        << "newReal called with empty string or extra white-space\n";
+    auto cs = value;
+
+    cs.erase(
+        std::remove_if(cs.begin(), cs.end(), [](unsigned char x) { return std::isspace(x); }),
+        cs.end());
+    if (cs.empty()) {
+        cs = "0.0";
+    }
+    return {QPDFObject::create<QPDF_Real>(cs)};
 }
 
 QPDFObjectHandle

--- a/libqpdf/qpdf/Util.hh
+++ b/libqpdf/qpdf/Util.hh
@@ -3,6 +3,10 @@
 
 #include <qpdf/assert_debug.h>
 
+#include <qpdf/qpdf-config.h>
+
+#include <charconv>
+#include <clocale>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -112,6 +116,55 @@ namespace qpdf::util
     }
 
     std::string random_string(size_t len);
+
+    /// @brief Convert a PDF numeric token to double.
+    ///
+    /// Uses `std::from_chars` for strict parsing when floating-point overloads are available.
+    /// In fallback builds, uses `std::atof` and normalizes `.` to the current locale decimal point
+    /// before conversion.
+    ///
+    /// @param val input numeric token
+    /// @return `{true, value}` if conversion succeeds (`from_chars` path) or always in fallback
+    /// mode; `{false, value}` on strict-parse failure
+    inline std::pair<bool, double>
+    str_to_double(std::string const& val)
+    {
+#ifdef HAVE_FROM_CHARS_DOUBLE
+        size_t skip = val.starts_with('+') ? 1 : 0;
+        if (val.size() <= skip) {
+            return {false, 0};
+        }
+        double result = 0.0;
+        auto end = val.data() + val.size();
+        auto [tail, ec] = std::from_chars(val.data() + skip, end, result, std::chars_format::fixed);
+        if (ec == std::errc() && tail == end) {
+            return {true, result};
+        }
+        (void)std::from_chars(val.data() + skip, end, result, std::chars_format::general);
+        return {false, result};
+#else
+        // Use atof if floating point std::from_chars is not available
+        auto locale_decimal_point = []() {
+            if (auto* lconv = std::localeconv();
+                lconv && lconv->decimal_point && lconv->decimal_point[0] != '\0') {
+                return lconv->decimal_point[0];
+            }
+            return '.';
+        };
+        static char const decimal_point = locale_decimal_point();
+        if (decimal_point == '.') {
+            return {true, std::atof(val.data())};
+        }
+        auto copy_str = val;
+        for (char& ch: copy_str) {
+            if (ch == '.') {
+                ch = decimal_point;
+                break;
+            }
+        }
+        return {true, std::atof(copy_str.data())};
+#endif
+    }
 
 } // namespace qpdf::util
 

--- a/libqpdf/qpdf/Util.hh
+++ b/libqpdf/qpdf/Util.hh
@@ -3,6 +3,10 @@
 
 #include <qpdf/assert_debug.h>
 
+#include <qpdf/qpdf-config.h>
+
+#include <charconv>
+#include <clocale>
 #include <concepts>
 #include <cstdint>
 #include <limits>
@@ -158,6 +162,55 @@ namespace qpdf::util
     }
 
     std::string random_string(size_t len);
+
+    /// @brief Convert a PDF numeric token to double.
+    ///
+    /// Uses `std::from_chars` for strict parsing when floating-point overloads are available.
+    /// In fallback builds, uses `std::atof` and normalizes `.` to the current locale decimal point
+    /// before conversion.
+    ///
+    /// @param val input numeric token
+    /// @return `{true, value}` if conversion succeeds (`from_chars` path) or always in fallback
+    /// mode; `{false, value}` on strict-parse failure
+    inline std::pair<bool, double>
+    str_to_double(std::string const& val)
+    {
+#ifdef HAVE_FROM_CHARS_DOUBLE
+        size_t skip = val.starts_with('+') ? 1 : 0;
+        if (val.size() <= skip) {
+            return {false, 0};
+        }
+        double result = 0.0;
+        auto end = val.data() + val.size();
+        auto [tail, ec] = std::from_chars(val.data() + skip, end, result, std::chars_format::fixed);
+        if (ec == std::errc() && tail == end) {
+            return {true, result};
+        }
+        (void)std::from_chars(val.data() + skip, end, result, std::chars_format::general);
+        return {false, result};
+#else
+        // Use atof if floating point std::from_chars is not available
+        auto locale_decimal_point = []() {
+            if (auto* lconv = std::localeconv();
+                lconv && lconv->decimal_point && lconv->decimal_point[0] != '\0') {
+                return lconv->decimal_point[0];
+            }
+            return '.';
+        };
+        static char const decimal_point = locale_decimal_point();
+        if (decimal_point == '.') {
+            return {true, std::atof(val.data())};
+        }
+        auto copy_str = val;
+        for (char& ch: copy_str) {
+            if (ch == '.') {
+                ch = decimal_point;
+                break;
+            }
+        }
+        return {true, std::atof(copy_str.data())};
+#endif
+    }
 
     // Test helpers
 

--- a/libqpdf/qpdf/qpdf-config.h.in
+++ b/libqpdf/qpdf/qpdf-config.h.in
@@ -16,6 +16,7 @@
 #cmakedefine HAVE_STDINT_H 1
 
 /* OS functions and symbols */
+#cmakedefine HAVE_FROM_CHARS_DOUBLE 1
 #cmakedefine HAVE_EXTERN_LONG_TIMEZONE 1
 #cmakedefine HAVE_FSEEKO 1
 #cmakedefine HAVE_FSEEKO64 1

--- a/libtests/objects.cc
+++ b/libtests/objects.cc
@@ -12,8 +12,8 @@
 #include <qpdf/global.hh>
 
 #include <climits>
+#include <clocale>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <map>
@@ -756,6 +756,64 @@ test_3(QPDF& pdf, char const* arg2)
     }
 }
 
+// Test getNumericValue real number conversion
+static void
+test_4(QPDF&, char const* comma)
+{
+    // Disable warnings because the code using std::from_chars and
+    auto log = QPDFLogger::defaultLogger();
+    log->setError(log->discard());
+
+    const std::vector<std::tuple<std::string, QPDFObjectHandle, double>> numbers({
+        {"1.0", "1.0"_qpdf, 1.0},
+        {"+1.5", "+1.5"_qpdf, 1.5},
+        {"-2.5", "-2.5"_qpdf, -2.5},
+        {".314159", ".314159"_qpdf, .314159},
+        {"-.314159", "-.314159"_qpdf, -.314159},
+        {"+.314159", "+.314159"_qpdf, +.314159},
+        {"0", "0"_qpdf, 0},
+        {"-0", "-0"_qpdf, 0},
+        {"+0", "+0"_qpdf, 0},
+        {"1.2 ", "1.2 "_qpdf, 1.2},
+        {" 1.3 ", " 1.3 "_qpdf, 1.3},
+        {"-.2", "-.2 "_qpdf, -0.2},
+        {"+7.", "+7. "_qpdf, 7.0},
+        // The remaining items would generate parser errors
+        {"1.4junk", "1.4"_qpdf, 1.4},
+        {"6.73e1", " 67.3"_qpdf, 67.3},
+        // {"+", "0"_qpdf, 0},
+        {"-", "0"_qpdf, 0},
+        {"", "0"_qpdf, 0},
+    });
+    if (std::string_view(comma) == "comma") {
+        for (auto locale:
+             {"de_DE.UTF-8",
+              "de_DE.utf8",
+              "de_DE",
+              "fr_FR.UTF-8",
+              "fr_FR.utf8",
+              "fr_FR",
+              "it_IT.UTF-8",
+              "it_IT.utf8"}) {
+            if (std::setlocale(LC_NUMERIC, locale) != nullptr) {
+                auto* lconv = std::localeconv();
+                if (lconv && lconv->decimal_point && (lconv->decimal_point[0] == ',')) {
+                    break;
+                }
+            }
+        }
+    }
+    for (auto const& [s, oh, d]: numbers) {
+        assert(QPDFObjectHandle::newReal(s).getNumericValue() == d);
+        assert(oh.getNumericValue() == d);
+    }
+    assert(QPDFObjectHandle::newReal("").getRealValue() == "0.0");
+    assert(QPDFObjectHandle::newReal("    1.3").getRealValue() == "1.3");
+    assert(QPDFObjectHandle::newReal("3.1   ").getRealValue() == "3.1");
+    assert(QPDFObjectHandle::newReal("2.4").getRealValue() == "2.4");
+    assert(QPDFObjectHandle::newReal("  4.2   ").getRealValue() == "4.2");
+}
+
 void
 runtest(int n, char const* filename1, char const* arg2)
 {
@@ -763,7 +821,7 @@ runtest(int n, char const* filename1, char const* arg2)
     // the test suite to see how the test is invoked to find the file
     // that the test is supposed to operate on.
 
-    std::set<int> ignore_filename = {1, 2, 3};
+    std::set<int> ignore_filename = {1, 2, 3, 4};
 
     QPDF pdf;
     std::shared_ptr<char> file_buf;
@@ -777,7 +835,7 @@ runtest(int n, char const* filename1, char const* arg2)
     }
 
     std::map<int, void (*)(QPDF&, char const*)> test_functions = {
-        {0, test_0}, {1, test_1}, {2, test_2}, {3, test_3}};
+        {0, test_0}, {1, test_1}, {2, test_2}, {3, test_3}, {4, test_4}};
 
     auto fn = test_functions.find(n);
     if (fn == test_functions.end()) {

--- a/libtests/objects.cc
+++ b/libtests/objects.cc
@@ -12,14 +12,14 @@
 #include <qpdf/Util.hh>
 #include <qpdf/global.hh>
 
-using namespace qpdf::util;
-
 #include <climits>
+#include <clocale>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <map>
+
+using namespace qpdf::util;
 
 static char const* whoami = nullptr;
 
@@ -145,6 +145,64 @@ test_1(QPDF& pdf, char const* arg2)
     d.replace("/C", Integer(42));
     assert(Integer(d["/C"]) == 42);
     assert(QPDFObjectHandle(d).getDictAsMap().size() == 4);
+}
+
+// Test getNumericValue real number conversion
+static void
+test_2(QPDF&, char const* comma)
+{
+    // Disable warnings because the code using std::from_chars and
+    auto log = QPDFLogger::defaultLogger();
+    log->setError(log->discard());
+
+    const std::vector<std::tuple<std::string, QPDFObjectHandle, double>> numbers({
+        {"1.0", "1.0"_qpdf, 1.0},
+        {"+1.5", "+1.5"_qpdf, 1.5},
+        {"-2.5", "-2.5"_qpdf, -2.5},
+        {".314159", ".314159"_qpdf, .314159},
+        {"-.314159", "-.314159"_qpdf, -.314159},
+        {"+.314159", "+.314159"_qpdf, +.314159},
+        {"0", "0"_qpdf, 0},
+        {"-0", "-0"_qpdf, 0},
+        {"+0", "+0"_qpdf, 0},
+        {"1.2 ", "1.2 "_qpdf, 1.2},
+        {" 1.3 ", " 1.3 "_qpdf, 1.3},
+        {"-.2", "-.2 "_qpdf, -0.2},
+        {"+7.", "+7. "_qpdf, 7.0},
+        // The remaining items would generate parser errors
+        {"1.4junk", "1.4"_qpdf, 1.4},
+        {"6.73e1", " 67.3"_qpdf, 67.3},
+        // {"+", "0"_qpdf, 0},
+        {"-", "0"_qpdf, 0},
+        {"", "0"_qpdf, 0},
+    });
+    if (std::string_view(comma) == "comma") {
+        for (auto locale:
+             {"de_DE.UTF-8",
+              "de_DE.utf8",
+              "de_DE",
+              "fr_FR.UTF-8",
+              "fr_FR.utf8",
+              "fr_FR",
+              "it_IT.UTF-8",
+              "it_IT.utf8"}) {
+            if (std::setlocale(LC_NUMERIC, locale) != nullptr) {
+                auto* lconv = std::localeconv();
+                if (lconv && lconv->decimal_point && (lconv->decimal_point[0] == ',')) {
+                    break;
+                }
+            }
+        }
+    }
+    for (auto const& [s, oh, d]: numbers) {
+        assert(QPDFObjectHandle::newReal(s).getNumericValue() == d);
+        assert(oh.getNumericValue() == d);
+    }
+    assert(QPDFObjectHandle::newReal("").getRealValue() == "0.0");
+    assert(QPDFObjectHandle::newReal("    1.3").getRealValue() == "1.3");
+    assert(QPDFObjectHandle::newReal("3.1   ").getRealValue() == "3.1");
+    assert(QPDFObjectHandle::newReal("2.4").getRealValue() == "2.4");
+    assert(QPDFObjectHandle::newReal("  4.2   ").getRealValue() == "4.2");
 }
 
 // test equivalent_to
@@ -599,6 +657,64 @@ test_3(QPDF& pdf, char const* arg2)
     }
 }
 
+// // Test getNumericValue real number conversion
+// static void
+// test_4(QPDF&, char const* comma)
+// {
+//     // Disable warnings because the code using std::from_chars and
+//     auto log = QPDFLogger::defaultLogger();
+//     log->setError(log->discard());
+//
+//     const std::vector<std::tuple<std::string, QPDFObjectHandle, double>> numbers({
+//         {"1.0", "1.0"_qpdf, 1.0},
+//         {"+1.5", "+1.5"_qpdf, 1.5},
+//         {"-2.5", "-2.5"_qpdf, -2.5},
+//         {".314159", ".314159"_qpdf, .314159},
+//         {"-.314159", "-.314159"_qpdf, -.314159},
+//         {"+.314159", "+.314159"_qpdf, +.314159},
+//         {"0", "0"_qpdf, 0},
+//         {"-0", "-0"_qpdf, 0},
+//         {"+0", "+0"_qpdf, 0},
+//         {"1.2 ", "1.2 "_qpdf, 1.2},
+//         {" 1.3 ", " 1.3 "_qpdf, 1.3},
+//         {"-.2", "-.2 "_qpdf, -0.2},
+//         {"+7.", "+7. "_qpdf, 7.0},
+//         {"1.4junk", "1.4"_qpdf, 1.4},
+//         {"6.73e1", " 67.3"_qpdf, 67.3},
+//         {"-", "0"_qpdf, 0},
+//         {"", "0"_qpdf, 0},
+//         // The remaining items would generate parser errors
+//         // {"+", "0"_qpdf, 0},
+//     });
+//     if (std::string_view(comma) == "comma") {
+//         for (auto locale:
+//              {"de_DE.UTF-8",
+//               "de_DE.utf8",
+//               "de_DE",
+//               "fr_FR.UTF-8",
+//               "fr_FR.utf8",
+//               "fr_FR",
+//               "it_IT.UTF-8",
+//               "it_IT.utf8"}) {
+//             if (std::setlocale(LC_NUMERIC, locale) != nullptr) {
+//                 auto* lconv = std::localeconv();
+//                 if (lconv && lconv->decimal_point && (lconv->decimal_point[0] == ',')) {
+//                     break;
+//                 }
+//             }
+//         }
+//     }
+//     for (auto const& [s, oh, d]: numbers) {
+//         assert(QPDFObjectHandle::newReal(s).getNumericValue() == d);
+//         assert(oh.getNumericValue() == d);
+//     }
+//     assert(QPDFObjectHandle::newReal("").getRealValue() == "0.0");
+//     assert(QPDFObjectHandle::newReal("    1.3").getRealValue() == "1.3");
+//     assert(QPDFObjectHandle::newReal("3.1   ").getRealValue() == "3.1");
+//     assert(QPDFObjectHandle::newReal("2.4").getRealValue() == "2.4");
+//     assert(QPDFObjectHandle::newReal("  4.2   ").getRealValue() == "4.2");
+// }
+
 void
 runtest(int n, char const* filename1, char const* arg2)
 {
@@ -606,7 +722,7 @@ runtest(int n, char const* filename1, char const* arg2)
     // the test suite to see how the test is invoked to find the file
     // that the test is supposed to operate on.
 
-    std::set<int> ignore_filename = {1, 3};
+    std::set<int> ignore_filename = {1, 2, 3};
 
     QPDF pdf;
     std::shared_ptr<char> file_buf;
@@ -620,7 +736,7 @@ runtest(int n, char const* filename1, char const* arg2)
     }
 
     std::map<int, void (*)(QPDF&, char const*)> test_functions = {
-        {0, test_0}, {1, test_1}, {3, test_3}};
+        {0, test_0}, {1, test_1}, {2, test_2}, {3, test_3}};
 
     auto fn = test_functions.find(n);
     if (fn == test_functions.end()) {

--- a/libtests/qtest/objects.test
+++ b/libtests/qtest/objects.test
@@ -11,7 +11,7 @@ require TestDriver;
 
 my $td = new TestDriver('objects');
 
-my $n_tests = 4;
+my $n_tests = 6;
 
 $td->runtest("integer type checks",
              {$td->COMMAND => "objects 0 minimal.pdf"},
@@ -31,6 +31,16 @@ $td->runtest("global limits",
 $td->runtest("equivalent_to structural comparisons",
              {$td->COMMAND => "objects 3 -"},
              {$td->STRING => "test 3 done\n", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
+
+$td->runtest("getNumericValue real number conversion",
+             {$td->COMMAND => "objects 4 -"},
+             {$td->STRING => "test 4 done\n", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
+
+$td->runtest("getNumericValue real number conversion using locale with comma",
+             {$td->COMMAND => "objects 4 - comma"},
+             {$td->STRING => "test 4 done\n", $td->EXIT_STATUS => 0},
              $td->NORMALIZE_NEWLINES);
 
 $td->report($n_tests);

--- a/libtests/qtest/objects.test
+++ b/libtests/qtest/objects.test
@@ -11,7 +11,7 @@ require TestDriver;
 
 my $td = new TestDriver('objects');
 
-my $n_tests = 3;
+my $n_tests = 5;
 
 $td->runtest("integer type checks",
              {$td->COMMAND => "objects 0 minimal.pdf"},
@@ -21,6 +21,16 @@ $td->runtest("integer type checks",
 $td->runtest("dictionary checks",
              {$td->COMMAND => "objects 1 -"},
              {$td->STRING => "test 1 done\n", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
+
+$td->runtest("getNumericValue real number conversion",
+             {$td->COMMAND => "objects 2 -"},
+             {$td->STRING => "test 2 done\n", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
+
+$td->runtest("getNumericValue real number conversion using locale with comma",
+             {$td->COMMAND => "objects 2 - comma"},
+             {$td->STRING => "test 2 done\n", $td->EXIT_STATUS => 0},
              $td->NORMALIZE_NEWLINES);
 
 $td->runtest("equivalent_to structural comparisons",

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -16,6 +16,10 @@ more detail.
 12.3.3: not yet released
   - Bug fixes
 
+    - Fix bug in ``QPDFObjectHandle::getNumericValue`` that caused it to
+      return incorrect values for real number when run using a locale
+      with a decimal point other than '.'.
+
     - Fix error message when :qpdf:ref:`--check` encounters a file without any pages.
 
 12.3.2: January 24, 2026

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -57,6 +57,9 @@ more detail.
       system error. Reading a line whose end-of-line run reaches the end of the file left the
       input source one byte before the start of that line, which at offset 0 is a seek to -1.
 
+    - Fix bug in ``QPDFObjectHandle::getNumericValue`` that caused it to return incorrect values
+      for real numbers when run using a locale with a decimal point other than '.'.
+
   - Build changes
 
     - Create binary release for additional platforms: Windows arm64.
@@ -76,6 +79,10 @@ more detail.
 
 12.4.0: August 9, 2026
   - Bug fixes
+
+    - Fix bug in ``QPDFObjectHandle::getNumericValue`` that caused it to
+      return incorrect values for real number when run using a locale
+      with a decimal point other than '.'.
 
     - Fix error message when :qpdf:ref:`--check` encounters a file without any pages.
 

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -168,7 +168,6 @@ QPDFObjectHandle array ignoring erase item 0
 QPDFObjectHandle dictionary false for hasKey 0
 QPDFObjectHandle dictionary empty set for getKeys 0
 QPDFObjectHandle dictionary empty map for asMap 0
-QPDFObjectHandle numeric non-numeric 0
 QPDFObjectHandle erase array bounds 0
 qpdf-c called qpdf_check_pdf 0
 QPDFFormFieldObjectHelper Q present 1

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -163,7 +163,6 @@ QPDFObjectHandle array ignoring erase item 0
 QPDFObjectHandle dictionary false for hasKey 0
 QPDFObjectHandle dictionary empty set for getKeys 0
 QPDFObjectHandle dictionary empty map for asMap 0
-QPDFObjectHandle numeric non-numeric 0
 QPDFObjectHandle erase array bounds 0
 qpdf-c called qpdf_check_pdf 0
 QPDFFormFieldObjectHelper Q present 1

--- a/qpdf/test_driver.cc
+++ b/qpdf/test_driver.cc
@@ -368,6 +368,7 @@ test_4(QPDF& pdf, char const* arg2)
     exit(0);
 }
 
+// Numeric and string tests
 static void
 test_5(QPDF& pdf, char const* arg2)
 {


### PR DESCRIPTION
When run using a locale that does not use "."  as the decimal point (e.g. one that uses "," instead) real number were incorrectly parsed.