### PR TITLE
Clear Copier scratch state on unwind in copyForeignObject

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -479,6 +479,23 @@ Objects::Foreign::Copier::copied(QPDFObjectHandle const& foreign)
     // Note that we explicitly allow use of copyForeignObject on page objects. It is a documented
     // use case to copy pages this way if the intention is to not update the pages tree.
 
+    // Ensure per-call scratch state (visiting, to_copy) is cleared on unwind so that an exception
+    // thrown inside reserve_objects or replace_indirect_object cannot leave the Copier in a state
+    // that trips the assertion below on the next call. Without this guard a first
+    // copyForeignObject that fails mid-walk (for example with QPDFExc "Too many warnings") makes
+    // every subsequent copyForeignObject on the same destination throw std::logic_error, which
+    // is outside the documented throw set and terminates the caller.
+    struct ScopeClear
+    {
+        QPDFObjGen::set& v;
+        std::vector<QPDFObjectHandle>& tc;
+        ~ScopeClear()
+        {
+            v.clear();
+            tc.clear();
+        }
+    } _guard{visiting, to_copy};
+
     util::assertion(
         visiting.empty(), "obj_copier.visiting is not empty at the beginning of copyForeignObject");
 


### PR DESCRIPTION
Close #1700:
Copier::copied asserts visiting is empty on entry and relies on reserve_objects to leave it empty on normal exit. If any inner step throws (QPDFExc "Too many warnings - file is too badly damaged" during a damaged foreign dictionary walk is the easy repro), the matching visiting.erase calls are skipped and the set stays dirty. The next copyForeignObject on the same destination QPDF hits util::assertion(visiting.empty(), ...) and throws std::logic_error, which is outside the documented throw set (QPDFExc / runtime_error).

Consumers that loop copyForeignObject / addPage and catch QPDFExc between iterations (pikepdf, PDFArranger, and QPDFJob.cc:1889/2083/2324 internally) therefore terminate via std::terminate on a second call.

Fix with a small RAII guard that clears visiting and to_copy on unwind so the Copier is always reusable after a partial call. The assertion is left in place as documentation.

Same family of bug as #514; different state-leak path.