### PR TITLE
Skip out-of-range object ids in Objects::compressible

### DIFF
--- a/libqpdf/QPDF_objects.cc
+++ b/libqpdf/QPDF_objects.cc
@@ -2073,8 +2073,10 @@ Objects::compressible()
             QPDFObjGen og = obj.getObjGen();
             const size_t id = toS(og.getObj() - 1);
             if (id >= max_obj) {
-                throw std::logic_error(
-                    "unexpected object id encountered in getCompressibleObjGens");
+                // Object id is outside the xref-derived max. Can occur on damaged input with
+                // dangling references or after helpers mutate the graph. Skip rather than throwing
+                // an internal logic_error that escapes QPDFWriter::write.
+                continue;
             }
             if (visited[id]) {
                 continue;


### PR DESCRIPTION
compressible() caches max_obj = qpdf.getObjectCount() and bounds-checks every object id during the graph walk. Any id outside that range triggered a std::logic_error that escaped QPDFWriter::write, outside the documented throw set.

Dangling xref references and helper-mutated graphs both produce this case on malformed input. Consistent with the position in #514 that "assertions belong in test code", skip the object instead of throwing. The existing warning path already reports the underlying data loss.

Fixes #1702.