### PR TITLE
Fix annotation handling in `QPDFAcroFormDocumentHelper::fixCopiedAnno…

### DIFF
--- a/libqpdf/QPDFAcroFormDocumentHelper.cc
+++ b/libqpdf/QPDFAcroFormDocumentHelper.cc
@@ -1085,8 +1085,8 @@ AcroForm::transformAnnotations(
 
     QPDFObjGen::set added_new_fields;
     for (auto annot: old_annots) {
-        if (annot.isStream()) {
-            annot.warn("ignoring annotation that's a stream");
+        if (!annot.isDictionary()) {
+            annot.warn("ignoring annotation that is not a dictionary");
             continue;
         }
         auto [top_field, have_field, have_parent] = transform_annotation(annot);
@@ -1180,8 +1180,17 @@ AcroForm::fixCopiedAnnotations(
     AcroForm& from_afdh,
     std::set<QPDFObjGen>* added_fields)
 {
-    auto const& old_annots = from_page.getKey("/Annots");
-    if (old_annots.empty() || !old_annots.isArray()) {
+    auto const& old_annots = from_page["/Annots"];
+    if (!old_annots) {
+        return;
+    }
+    if (!old_annots.isArray()) {
+        from_page.warn("removing non-array /Annots");
+        from_page.erase("/Annots");
+        return;
+    }
+    if (old_annots.empty()) {
+        from_page.erase("/Annots");
         return;
     }
 
@@ -1198,7 +1207,7 @@ AcroForm::fixCopiedAnnotations(
         &from_afdh,
         &to_page);
 
-    to_page.replaceKey("/Annots", QPDFObjectHandle::newArray(new_annots));
+    to_page.replace("/Annots", Array(std::move(new_annots)));
     addAndRenameFormFields(new_fields);
     if (added_fields) {
         for (auto const& f: new_fields) {

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -18,6 +18,11 @@ more detail.
 
     - Fix error message when :qpdf:ref:`--check` encounters a file without any pages.
 
+    - In ``QPDFAcroFormDocumentHelper::fixCopiedAnnotations`` remove non-array and empty
+      ``/Annots`` entries from copied pages as well as non-dictionary annotations. Fixes a bug
+      that could cause qpdf to throw a logic error when error when copying pages with damaged
+      annotations.
+
 12.3.2: January 24, 2026
   - Bug fixes
 


### PR DESCRIPTION
…tations` to ignore non-dictionary types and handle non-array /Annots (fixes #1701)