### PR TITLE
Normalize page rotation to [0, 360) in XObject placement

### DIFF
--- a/libqpdf/QPDFPageObjectHelper.cc
+++ b/libqpdf/QPDFPageObjectHelper.cc
@@ -683,6 +683,10 @@ QPDFPageObjectHelper::getMatrixForTransformations(bool invert)
         }
 
         // Ignore invalid rotation angle
+        rotate %= 360;
+        if (rotate < 0) {
+            rotate += 360;
+        }
         switch (rotate) {
         case 90:
             matrix = QPDFObjectHandle::Matrix(0, -scale, scale, 0, 0, width * scale);
@@ -864,6 +868,10 @@ QPDFPageObjectHelper::flattenRotation(QPDFAcroFormDocumentHelper* afdh)
     int rotate = 0;
     if (rotate_oh.isInteger()) {
         rotate = rotate_oh.getIntValueAsInt();
+        rotate %= 360;
+        if (rotate < 0) {
+            rotate += 360;
+        }
     }
     if (!((rotate == 90) || (rotate == 180) || (rotate == 270))) {
         return;


### PR DESCRIPTION
The PDF spec asks for Rotation to be a multiple of 90. `QPDFPageObjectHelper.cc` checks for 90, 180, 270 only. This PR normalizes page rotation values to [0,360) so that, for example, pages with /Rotate = -90 are processed correctly. 

Fixes https://github.com/pikepdf/pikepdf/issues/717