### PR TITLE
Prevent construction of direct object cycles (fixes #1730)

### DIFF
--- a/include/qpdf/ObjectHandle.hh
+++ b/include/qpdf/ObjectHandle.hh
@@ -137,6 +137,8 @@ namespace qpdf
         inline void assign(qpdf_object_type_e required, BaseHandle&& other);
         inline void nullify();
 
+        void check_insertion(QPDFObjectHandle const& item) const;
+
         std::string description() const;
         inline QPDFObjectHandle const& get(std::string const& key) const;
 

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -21,6 +21,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>
+#include <unordered_set>
+#include <vector>
 
 using namespace std::literals;
 using namespace qpdf;
@@ -675,6 +677,98 @@ BaseHandle::write_json(int json_version, JSON::Writer& p) const
         break;
     default:
         throw std::logic_error("attempted to write an unsuitable object as JSON");
+    }
+}
+
+/// @brief Validate whether an object may be inserted into this container.
+///
+/// This method performs several checks before permitting insertion of `item` as a child of this
+/// container:
+///
+/// - Ensures `item` is initialized.
+/// - If both this container and `item` are associated with a `QPDF` instance, they must refer to
+///   the same `QPDF` object.
+/// - Scans the direct (non-indirect) array and dictionary children of `item` to detect whether
+///   inserting `item` would create a cycle of direct objects. The traversal is bounded by a depth
+///   limit and deduplicates shared containers, so it runs in time linear in the number of distinct
+///   direct containers reachable from `item`. Indirect objects terminate the scan because they
+///   serialize as object references and cannot be part of a direct cycle.
+///
+/// @param item The object proposed for insertion.
+/// @throws std::logic_error If `item` is uninitialized, belongs to a different `QPDF`, or inserting
+///                          it would create a cycle of direct objects.
+void
+BaseHandle::check_insertion(QPDFObjectHandle const& item) const
+{
+    if (!item) {
+        throw std::logic_error("Attempting to add an uninitialized object to a QPDF_Array.");
+    }
+    if (qpdf() && item.qpdf() && qpdf() != item.qpdf()) {
+        throw std::logic_error(
+            "Attempting to add an object from a different QPDF. Use QPDF::copyForeignObject to add "
+            "objects from another file.");
+    }
+
+    // After inserting `item` as a child of this container, a cycle among direct objects exists if
+    // and only if this container is reachable from `item` by following direct (non-indirect)
+    // array and dictionary children. Indirect objects serialize as "N 0 R" and terminate the
+    // recursion in unparse(), write_json() and disconnect(), so they can never be part of a
+    // direct cycle: the scan stops at them. Because every object read from a PDF is indirect,
+    // this costs nothing for parsed documents and is bounded by the size of any in-memory direct
+    // subgraph being inserted. The container is always a valid array or dictionary, so its
+    // underlying object pointer is the target we look for while traversing.
+    //
+    // The depth limit alone is enough to terminate on a cycle, but a direct object may be shared
+    // by many parents without forming a cycle (a DAG). Re-walking such shared sub-graphs along
+    // every path would be exponential, so already-visited containers are recorded and skipped.
+    // This keeps the scan linear in the number of distinct direct containers reachable from
+    // `item`. Only containers are recorded; scalars are never pushed, so the set stays small for
+    // typical objects.
+
+    std::unordered_set<QPDFObject*> seen;
+    std::vector<std::pair<QPDFObjectHandle const&, size_t>> stack;
+    auto push = [&stack](QPDFObjectHandle const& oh, size_t depth) {
+        // Indirect children break the cycle, so they are not traversed. Scalars have no children,
+        // and streams are always indirect so are never pushed.
+        if ((oh.raw_type_code() == ::ot_array || oh.raw_type_code() == ::ot_dictionary) &&
+            !oh.indirect()) {
+            stack.emplace_back(oh, depth - 1);
+        }
+    };
+    push(item, Limits::parser_max_nesting() + 3);
+    while (!stack.empty()) {
+        auto const [node, depth] = stack.back();
+        stack.pop_back();
+        if (depth == 0 || node.obj == obj) {
+            throw std::logic_error(
+                "Attempting to create a cycle of direct objects. A direct (non-indirect) object "
+                "may not contain itself, directly or indirectly. Make one of the objects indirect "
+                "with QPDF::makeIndirectObject to create a reference cycle.");
+        }
+        if (!seen.insert(node.obj.get()).second) {
+            // This direct container is shared by more than one parent; it and its descendants
+            // have already been checked.
+            continue;
+        }
+
+        if (node.raw_type_code() == ::ot_array) {
+            auto& a = std::get<QPDF_Array>(node.obj->value);
+            if (a.sp) {
+                for (auto& entry: a.sp->elements) {
+                    push(entry.second, depth);
+                }
+            } else {
+                for (auto& oh: a.elements) {
+                    push(oh, depth);
+                }
+            }
+            continue;
+        }
+
+        qpdf_assert_debug(node.raw_type_code() == ::ot_dictionary);
+        for (auto& iter: std::get<QPDF_Dictionary>(node.obj->value).items) {
+            push(iter.second, depth);
+        }
     }
 }
 

--- a/libqpdf/QPDF_Array.cc
+++ b/libqpdf/QPDF_Array.cc
@@ -22,19 +22,6 @@ to_i(size_t n)
     return static_cast<int>(n);
 }
 
-inline void
-Array::checkOwnership(QPDFObjectHandle const& item) const
-{
-    if (!item) {
-        throw std::logic_error("Attempting to add an uninitialized object to a QPDF_Array.");
-    }
-    if (qpdf() && item.qpdf() && qpdf() != item.qpdf()) {
-        throw std::logic_error(
-            "Attempting to add an object from a different QPDF. Use "
-            "QPDF::copyForeignObject to add objects from another file.");
-    }
-}
-
 QPDF_Array::QPDF_Array(std::vector<QPDFObjectHandle>&& v, bool sparse)
 {
     if (sparse) {
@@ -255,7 +242,7 @@ Array::set(size_t at, QPDFObjectHandle const& oh)
         return false;
     }
     auto a = array();
-    checkOwnership(oh);
+    check_insertion(oh);
     if (a->sp) {
         a->sp->elements[at] = oh;
     } else {
@@ -280,7 +267,7 @@ Array::setFromVector(std::vector<QPDFObjectHandle> const& v)
     a->elements.resize(0);
     a->elements.reserve(v.size());
     for (auto const& item: v) {
-        checkOwnership(item);
+        check_insertion(item);
         a->elements.emplace_back(item);
     }
 }
@@ -293,7 +280,7 @@ Array::insert(size_t at, QPDFObjectHandle const& item)
     if (at > sz) {
         return false;
     }
-    checkOwnership(item);
+    check_insertion(item);
     if (at == sz) {
         // As special case, also allow insert beyond the end
         push_back(item);
@@ -332,7 +319,7 @@ void
 Array::push_back(QPDFObjectHandle const& item)
 {
     auto a = array();
-    checkOwnership(item);
+    check_insertion(item);
     if (a->sp) {
         a->sp->elements[(a->sp->size)++] = item;
     } else {

--- a/libqpdf/QPDF_Dictionary.cc
+++ b/libqpdf/QPDF_Dictionary.cc
@@ -146,6 +146,7 @@ BaseHandle::replace(std::string const& key, QPDFObjectHandle value)
             d->items.erase(key);
         } else {
             // add or replace value
+            check_insertion(value);
             d->items[key] = value;
         }
         return true;
@@ -189,18 +190,6 @@ Dictionary
 Dictionary::empty()
 {
     return Dictionary(std::map<std::string, QPDFObjectHandle>());
-}
-
-void
-QPDFObjectHandle::checkOwnership(QPDFObjectHandle const& item) const
-{
-    auto qpdf = getOwningQPDF();
-    auto item_qpdf = item.getOwningQPDF();
-    if (qpdf && item_qpdf && qpdf != item_qpdf) {
-        throw std::logic_error(
-            "Attempting to add an object from a different QPDF. Use "
-            "QPDF::copyForeignObject to add objects from another file.");
-    }
 }
 
 bool
@@ -261,12 +250,9 @@ QPDFObjectHandle::getDictAsMap() const
 void
 QPDFObjectHandle::replaceKey(std::string const& key, QPDFObjectHandle const& value)
 {
-    if (auto dict = as_dictionary(strict)) {
-        checkOwnership(value);
-        dict.replace(key, value);
-        return;
+    if (!replace(key, value)) {
+        typeWarning("dictionary", "ignoring key replacement request");
     }
-    typeWarning("dictionary", "ignoring key replacement request");
 }
 
 QPDFObjectHandle

--- a/libqpdf/qpdf/QPDFObjectHandle_private.hh
+++ b/libqpdf/qpdf/QPDFObjectHandle_private.hh
@@ -114,7 +114,6 @@ namespace qpdf
 
       private:
         QPDF_Array* array() const;
-        void checkOwnership(QPDFObjectHandle const& item) const;
         QPDFObjectHandle null() const;
 
         std::unique_ptr<std::vector<QPDFObjectHandle>> sp_elements{};

--- a/libtests/objects.cc
+++ b/libtests/objects.cc
@@ -599,6 +599,115 @@ test_3(QPDF& pdf, char const* arg2)
     }
 }
 
+// Test that the container mutators refuse to create a cycle among direct objects. Such a cycle
+// cannot be loaded from a PDF (every backward pointer in a file is an indirect reference) but can
+// be assembled in memory, where it would send unparse(), writeJSON() and disconnect() into
+// unbounded recursion. See https://github.com/qpdf/qpdf/issues/1730.
+static void
+test_4(QPDF& pdf, char const* arg2)
+{
+    using namespace qpdf;
+
+    // A dictionary may not be made to contain itself.
+    {
+        auto a = QPDFObjectHandle::newDictionary();
+        assert(throws<std::logic_error>([&]() { a.replaceKey("/Self", a); }));
+    }
+    // A dictionary may not contain itself indirectly through a direct array.
+    {
+        auto a = QPDFObjectHandle::newDictionary();
+        assert(throws<std::logic_error>([&]() {
+            a.replaceKey("/Kids", QPDFObjectHandle::newArray({a}));
+        }));
+    }
+    // The mutual cycle from issue #1730: a -> b -> a, closed by the second replaceKey.
+    {
+        auto a = QPDFObjectHandle::newDictionary();
+        auto b = QPDFObjectHandle::newDictionary();
+        a.replaceKey("/Kids", QPDFObjectHandle::newArray({b})); // a -> b: fine, no cycle yet
+        assert(throws<std::logic_error>([&]() {
+            b.replaceKey("/Kids", QPDFObjectHandle::newArray({a}));
+        }));
+    }
+    // An array may not be made to contain itself, through any of its mutators.
+    {
+        auto a = QPDFObjectHandle::newArray();
+        assert(throws<std::logic_error>([&]() { a.appendItem(a); }));
+        assert(throws<std::logic_error>([&]() { a.insertItem(0, a); }));
+        a.appendItem(QPDFObjectHandle::newNull());
+        assert(throws<std::logic_error>([&]() { a.setArrayItem(0, a); }));
+        assert(throws<std::logic_error>([&]() {
+            a.setArrayFromVector({QPDFObjectHandle::newNull(), a});
+        }));
+    }
+    // An array may not contain itself indirectly through a nested direct container.
+    {
+        auto outer = QPDFObjectHandle::newArray();
+        auto inner = QPDFObjectHandle::newArray();
+        outer.appendItem(inner);
+        assert(throws<std::logic_error>([&]() { inner.appendItem(outer); }));
+    }
+    // Sharing a direct object on two paths is fine as long as it does not form a cycle (a DAG,
+    // not a cycle, must still be accepted).
+    {
+        auto shared = QPDFObjectHandle::newDictionary();
+        shared.replaceKey("/Leaf", Integer(1));
+        auto a = QPDFObjectHandle::newArray();
+        a.appendItem(shared);
+        a.appendItem(shared); // diamond: same direct object twice, no cycle
+        auto d = QPDFObjectHandle::newDictionary();
+        d.replaceKey("/First", shared);
+        d.replaceKey("/Second", QPDFObjectHandle::newArray({shared}));
+        // Reachable without crashing.
+        assert(!a.unparse().empty());
+        assert(!d.unparse().empty());
+        // A single insertion whose subtree reaches the same direct object by two paths is also
+        // accepted: the cycle check visits each object once and does not mistake sharing for a
+        // cycle.
+        auto two_paths = QPDFObjectHandle::newArray({shared, QPDFObjectHandle::newArray({shared})});
+        auto e = QPDFObjectHandle::newArray();
+        e.appendItem(two_paths);
+        assert(!e.unparse().empty());
+    }
+    // A heavily shared (but acyclic) direct DAG must be validated in time linear in the number of
+    // distinct objects. Each level is an array whose two elements are the SAME direct object from
+    // the level below, so the graph has `depth` levels but 2^depth distinct root-to-leaf paths.
+    // Deduplicating shared containers keeps the cycle check O(depth); without dedup, building this
+    // would take exponential time and this test would hang.
+    {
+        auto node = QPDFObjectHandle::newDictionary();
+        for (int i = 0; i < 200; ++i) {
+            auto next = QPDFObjectHandle::newArray();
+            next.appendItem(node); // both elements are the same shared direct object
+            next.appendItem(node);
+            node = next;
+        }
+        assert(node.isArray() && node.getArrayNItems() == 2);
+    }
+    // A cycle is detected even when the path passes through a sparse array. qpdf stores arrays
+    // with more than 100 null elements in a different internal representation, exercised here.
+    {
+        std::string text = "[";
+        for (int i = 0; i < 101; ++i) {
+            text += " null";
+        }
+        text += " ]";
+        auto sparse = QPDFObjectHandle::parse(text);
+        auto d = QPDFObjectHandle::newDictionary();
+        sparse.appendItem(d);
+        assert(throws<std::logic_error>([&]() { d.replaceKey("/Loop", sparse); }));
+    }
+    // Indirect references break a cycle (they serialize as "N 0 R"), so qpdf continues to allow
+    // cyclic structures built from indirect objects, exactly as before.
+    {
+        auto a = pdf.makeIndirectObject(QPDFObjectHandle::newDictionary());
+        auto b = pdf.makeIndirectObject(QPDFObjectHandle::newDictionary());
+        a.replaceKey("/Other", b);
+        b.replaceKey("/Other", a); // indirect cycle: allowed
+        assert(a.unparse() == a.getObjGen().unparse(' ') + " R");
+    }
+}
+
 void
 runtest(int n, char const* filename1, char const* arg2)
 {
@@ -606,7 +715,7 @@ runtest(int n, char const* filename1, char const* arg2)
     // the test suite to see how the test is invoked to find the file
     // that the test is supposed to operate on.
 
-    std::set<int> ignore_filename = {1, 3};
+    std::set<int> ignore_filename = {1, 3, 4};
 
     QPDF pdf;
     std::shared_ptr<char> file_buf;
@@ -620,7 +729,7 @@ runtest(int n, char const* filename1, char const* arg2)
     }
 
     std::map<int, void (*)(QPDF&, char const*)> test_functions = {
-        {0, test_0}, {1, test_1}, {3, test_3}};
+        {0, test_0}, {1, test_1}, {3, test_3}, {4, test_4}};
 
     auto fn = test_functions.find(n);
     if (fn == test_functions.end()) {

--- a/libtests/qtest/objects.test
+++ b/libtests/qtest/objects.test
@@ -11,7 +11,7 @@ require TestDriver;
 
 my $td = new TestDriver('objects');
 
-my $n_tests = 3;
+my $n_tests = 4;
 
 $td->runtest("integer type checks",
              {$td->COMMAND => "objects 0 minimal.pdf"},
@@ -26,6 +26,11 @@ $td->runtest("dictionary checks",
 $td->runtest("equivalent_to structural comparisons",
              {$td->COMMAND => "objects 3 -"},
              {$td->STRING => "test 3 done\n", $td->EXIT_STATUS => 0},
+             $td->NORMALIZE_NEWLINES);
+
+$td->runtest("direct object cycle prevention",
+             {$td->COMMAND => "objects 4 -"},
+             {$td->STRING => "test 4 done\n", $td->EXIT_STATUS => 0},
              $td->NORMALIZE_NEWLINES);
 
 $td->report($n_tests);

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -43,6 +43,14 @@ more detail.
     - To reduce the risk of excessive recursion and stack overflows when processing damaged or
       malicious PDF files, qpdf now enforces conservative limits on the depth of the pages tree.
 
+    - The container mutators (``QPDFObjectHandle::replaceKey``, ``appendItem``, ``insertItem``,
+      ``setArrayItem``, and ``setArrayFromVector``) now throw ``std::logic_error`` if the
+      requested change would create a cycle among direct (non-indirect) objects. Such a structure
+      cannot occur in a PDF file, since every backward reference in a file is indirect, but it
+      could previously be constructed in memory through the API, after which ``unparse``,
+      ``writeJSON``, or ``disconnect`` would recurse without bound and crash. Reference cycles
+      built from indirect objects are unaffected and remain supported.
+
     - Detect some duplicate entries in the AcroForm field hierarchy earlier in order to avoid very
       large runtimes in specially constructed invalid PDF files.
 


### PR DESCRIPTION
A cycle built from direct (non-indirect) objects cannot occur in a PDF file, since every backward reference in a file is indirect, but could be assembled in memory through the API. unparse(), writeJSON(), and disconnect() then recurse without bound and crash with a stack overflow.

The container mutators (replaceKey, appendItem, insertItem, setArrayItem, setArrayFromVector) now call BaseHandle::checkForCycle alongside the existing checkOwnership check and throw std::logic_error if the change would close a direct cycle. The scan stops at indirect objects, so it costs nothing for objects read from a file, and gating every mutator is sufficient because any cycle must be closed by some mutator call. Reference cycles built from indirect objects are unaffected.