### PR TITLE
ci: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "UTC"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: QPDF Build
 env:
   QTEST_COLOR: 1
+
+# Restrict default token permissions to read-only; individual jobs that
+# need write access must declare it explicitly.
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -20,34 +26,34 @@ jobs:
     # build on Linux. Also create the documentation distribution.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Run pre-build steps'
         run: build-scripts/prebuild
         env:
           GH_TOKEN: ${{ github.token }}
       - name: 'Upload documentation for later build steps'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: doc
           path: doc.zip
       - name: 'Upload external libs'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: distribution-vcpkg
           path: vcpkg.zip
       - name: 'Upload doc distribution'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: distribution-prebuild
           path: distribution
   Linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Generate, build, and test'
         run: build-scripts/build-linux
       - name: Upload distribution
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: distribution-linux
           path: distribution
@@ -64,22 +70,25 @@ jobs:
       - name: 'Disable git autocrlf'
         shell: bash
         run: git config --global core.autocrlf input
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Download documentation'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: doc
           path: .
       - name: 'Download vcpkg cache'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: distribution-vcpkg
           path: .
       - name: 'Build, test, generate binary distributions'
+        env:
+          WORDSIZE: ${{ matrix.wordsize }}
+          TOOL: ${{ matrix.tool }}
         shell: cmd
-        run: build-scripts/build-windows.bat ${{ matrix.wordsize }} ${{ matrix.tool }}
+        run: build-scripts/build-windows.bat %WORDSIZE% %TOOL%
       - name: 'Upload binary distributions'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: distribution-windows-${{ matrix.wordsize }}-${{ matrix.tool }}
           path: distribution
@@ -87,18 +96,18 @@ jobs:
     runs-on: macos-latest
     needs: Prebuild
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Mac build and test'
         run: build-scripts/build-mac
   AppImage:
     runs-on: ubuntu-latest
     needs: Prebuild
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Build AppImage'
         run: build-scripts/build-appimage
       - name: 'Upload AppImage'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: distribution-appimage
           path: distribution
@@ -111,39 +120,43 @@ jobs:
     runs-on: ubuntu-latest
     needs: Prebuild
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'pikepdf'
-        run: build-scripts/test-pikepdf ${{ matrix.future }}
+        env:
+          FUTURE: ${{ matrix.future }}
+        run: build-scripts/test-pikepdf $FUTURE
   Sanitizers:
     runs-on: ubuntu-latest
     needs: Prebuild
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Sanitizer Tests'
         run: build-scripts/test-sanitizers
   Zopfli:
     runs-on: ubuntu-latest
     needs: Prebuild
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Zopfli Tests'
         run: build-scripts/test-zopfli
   CodeCov:
     runs-on: ubuntu-latest
     needs: Prebuild
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: 'Code Coverage'
         run: build-scripts/test-coverage
       - id: set_branch
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$EVENT_NAME" = "push" ]; then
             echo "override_branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
           else
             echo "override_branch=" >> $GITHUB_OUTPUT
           fi
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           override_branch: ${{ steps.set_branch.outputs.override_branch }}
@@ -163,9 +176,11 @@ jobs:
           - test-c++-next
           - build-android-ndk
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: ${{ matrix.script }}
-        run: build-scripts/${{ matrix.script }}
+        env:
+          SCRIPT: ${{ matrix.script }}
+        run: build-scripts/$SCRIPT
   MergeArtifacts:
      runs-on: ubuntu-latest
      needs:
@@ -175,7 +190,7 @@ jobs:
        - AppImage
      steps:
        - name: Merge Artifacts
-         uses: actions/upload-artifact/merge@v7
+         uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
          with:
            name: distribution
            pattern: distribution-*

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,33 @@
+name: zizmor
+on:
+  push:
+    branches:
+      - main
+      - build
+      - build/*
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # required to upload SARIF to GitHub Security tab
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install zizmor
+        run: pip install zizmor==1.25.2
+
+      - name: Run zizmor
+        run: zizmor --format sarif .github/workflows/ > zizmor.sarif
+
+      - name: Upload SARIF results
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor


### PR DESCRIPTION
## Summary

This PR applies several GitHub Actions security hardening measures across three files.

---

### 1. Pin actions to commit SHAs (`main.yml`)

All `uses:` references changed from floating version tags to pinned commit SHAs with the version as a trailing comment. A compromised or force-pushed tag otherwise silently runs attacker-controlled code in CI with access to repository secrets.

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `@v6` | `@df4cb1c…` `# v6` |
| `actions/upload-artifact` | `@v7` | `@043fb46…` `# v7` |
| `actions/download-artifact` | `@v8` | `@3e5f45b…` `# v8` |
| `codecov/codecov-action` | `@v7` | `@fb8b358…` `# v7` |
| `actions/upload-artifact/merge` | `@v7` | `@043fb46…` `# v7` |

`codecov/codecov-action` is the highest-priority fix: it receives `CODECOV_TOKEN` and runs arbitrary code in the build environment.

### 2. Add `permissions: contents: read` (`main.yml`)

The default `GITHUB_TOKEN` permissions are broader than needed. A top-level `permissions: contents: read` constrains the token to read-only, limiting the blast radius if a compromised action tries to write to the repo, packages, or deployments.

### 3. Fix template-injection patterns in `run:` steps (`main.yml`)

`${{ ... }}` expressions are expanded at the YAML level _before_ the shell sees the script. Three jobs were affected:

- **`CodeCov`** — `${{ github.event_name }}` now passed via `EVENT_NAME` env var
- **`Windows`** — `${{ matrix.wordsize }}` / `${{ matrix.tool }}` now passed as `WORDSIZE` / `TOOL` env vars, referenced via `%WORDSIZE% %TOOL%` in cmd
- **`QuickJobs`** — `${{ matrix.script }}` now passed via `SCRIPT` env var
- **`pikepdf`** — `${{ matrix.future }}` now passed via `FUTURE` env var

The matrix values are currently hardcoded and unexploitable, but this is the pattern [zizmor](https://github.com/zizmorcore/zizmor) flags, and fixing it now prevents regressions if matrix inputs ever become user-supplied.

### 4. Add zizmor workflow (`.github/workflows/zizmor.yml`)

Runs [zizmor](https://github.com/zizmorcore/zizmor) (v1.25.2, pinned) on every push and PR to lint all workflow files for security issues. Findings are uploaded as SARIF to the GitHub Security tab via `github/codeql-action/upload-sarif` (pinned to SHA), and the job fails if any findings exist. The SARIF upload step uses `if: always()` so results appear in the Security tab even when the job fails.

### 5. Dependabot cooldown + monthly schedule (`dependabot.yml`)

- Schedule changed from `daily` to `monthly` (Monday 06:00 UTC)
- `cooldown: default-days: 7` added so new action versions must be published for at least 7 days before Dependabot opens a PR — this is the window most exploited in supply chain attacks (publish malicious patch → bots pick it up within hours)

## Test plan

- [ ] Confirm CI passes on this branch (same runner steps; only action references and shell variable patterns changed)
- [ ] Verify the Windows build still receives the correct `wordsize`/`tool` args via the `%WORDSIZE% %TOOL%` env-var approach
- [ ] Confirm zizmor workflow passes (it should, given the template-injection fixes in the same PR)
- [ ] Check GitHub Security tab shows zizmor SARIF results

🤖 Generated with [Claude Code](https://claude.com/claude-code)