### PR TITLE
Make equivalent_to public and fix null stream_data handling

### DIFF
--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1309,6 +1309,18 @@ class QPDFObjectHandle: public qpdf::BaseHandle
     QPDF_DLL
     bool isImage(bool exclude_imagemask = true) const;
 
+    // Structural equivalence check with a recursion depth limit.
+    //
+    // Implements ISO 32000-2 Annex J recursive object equality with a
+    // bounded recursion depth.
+    //
+    // If the maximum depth is reached during comparison, the objects are
+    // considered not equivalent.
+    //
+    // Default depth is 10.
+    QPDF_DLL
+    bool equivalent_to(QPDFObjectHandle const& other, int depth = 10) const;
+
     // The following methods do not form part of the public API and are for internal use only.
 
     QPDFObjectHandle(std::shared_ptr<QPDFObject> const& obj) :

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -449,7 +449,10 @@ BaseHandle::equivalent_to(BaseHandle const& other, int depth) const
             if (!s1.m->stream_dict.equivalent_to(s2.m->stream_dict, depth - 1)) {
                 return false;
             }
-            return s1.m->stream_data->view() == s2.m->stream_data->view();
+            if (s1.m->stream_data && s2.m->stream_data) {
+                return s1.m->stream_data->view() == s2.m->stream_data->view();
+            }
+            return Stream{obj}.getRawStreamData() == Stream{other.obj}.getRawStreamData();
         }
     case ::ot_operator:
         throw std::logic_error("Internal error in BaseHandle::equivalent_to: found ot_operator");
@@ -2305,6 +2308,12 @@ QPDFObjectHandle::isImage(bool exclude_imagemask) const
         ((!exclude_imagemask) ||
          (!(getDict().getKey("/ImageMask").isBool() &&
             getDict().getKey("/ImageMask").getBoolValue()))));
+}
+
+bool
+QPDFObjectHandle::equivalent_to(QPDFObjectHandle const& other, int depth) const
+{
+    return qpdf::BaseHandle::equivalent_to(other, depth);
 }
 
 void

--- a/libtests/objects.cc
+++ b/libtests/objects.cc
@@ -597,6 +597,40 @@ test_3(QPDF& pdf, char const* arg2)
         assert(stale.raw_type_code() == ::ot_reference);
         assert(!stale.equivalent_to(Integer(42)));
     }
+    // Scenario 43: Round-trip streams through serialization
+    {
+        // 1. Build synthetic content in a fresh, valid PDF
+        QPDF tmp;
+        tmp.emptyPDF();
+        auto s1 = tmp.newStream("hello world");
+        auto s2 = tmp.newStream("hello world");
+        auto arr = QPDFObjectHandle::newArray({s1, s2});
+        tmp.getRoot().replaceKey("/Test", arr);
+
+        // 2. Serialize to memory, preserving raw stream data
+        QPDFWriter w(tmp, "mem.pdf");
+        w.setOutputMemory();
+        // Note: equivalent_to compares raw bytes. A stream created in-memory has raw
+        // bytes equal to its uncompressed content. After serialization with compression,
+        // the raw bytes change, so equivalent_to would correctly return false.
+        // setCompressStreams(false) ensures the on-disk raw bytes match the in-memory ones.
+        w.setCompressStreams(false); // write streams uncompressed
+        w.write();
+        std::unique_ptr<Buffer> buf(w.getBuffer());
+        std::string data(reinterpret_cast<const char*>(buf->getBuffer()), buf->getSize());
+
+        // 3. Reload into a fresh QPDF
+        QPDF pdf2;
+        pdf2.processMemoryFile("mem.pdf", data.data(), data.size());
+
+        // 4. Compare — fetch from each document's root independently
+        auto r1 = tmp.getRoot().getKey("/Test").getArrayItem(0);
+        auto r2 = pdf2.getRoot().getKey("/Test").getArrayItem(0);
+        auto r1b = tmp.getRoot().getKey("/Test").getArrayItem(1);
+        auto r2b = pdf2.getRoot().getKey("/Test").getArrayItem(1);
+        assert(r1.equivalent_to(r2));
+        assert(r1b.equivalent_to(r2b));
+    }
 }
 
 void


### PR DESCRIPTION
- Expose BaseHandle::equivalent_to() as a public QPDFObjectHandle API to allow structural equivalence checks from user code. This is intended for use by external bindings (pikepdf).

- Fix a potential null dereference when comparing stream objects, with a test. Stream comparison previously assumed stream_data was always present. When stream_data is not materialized, we now fall back to comparing raw stream data via getRawStreamData(). This was previously reviewed as part of https://github.com/qpdf/qpdf/pull/1663