### PR TITLE
Fix PATH override on Windows for perl

### DIFF
--- a/build-scripts/build-windows
+++ b/build-scripts/build-windows
@@ -8,7 +8,7 @@ declare -a cmake_xargs
 declare -a ctest_xargs
 config=Release
 if [[ $tool == mingw ]]; then
-    pacman -Sy --noconfirm make base-devel tar zip unzip
+    pacman -Sy --noconfirm make base-devel tar zip unzip perl
     if [ ! -x /c/msys64/mingw$wordsize/bin/g++.exe ]; then
         if [[ $wordsize == 64 ]]; then
             pacman -Sy --noconfirm mingw-w64-x86_64-toolchain
@@ -16,7 +16,7 @@ if [[ $tool == mingw ]]; then
             pacman -Sy --noconfirm mingw-w64-i686-toolchain
         fi
     fi
-    PATH="/c/msys64/mingw$wordsize/bin:$PATH"
+    PATH="/c/msys64/mingw$wordsize/bin:/c/msys64/mingw$wordsize/usr/bin:$PATH"
     cmake_xargs=(-- -k)
     g++ -v
 elif [[ $tool == msvc ]]; then


### PR DESCRIPTION
Perl should be in /usr/bin, not /bin, and the old code seemed to rely on the two being the same. Without this, CI may pick the wrong perl, like Strawberry perl, which can't run the test suite.