### PR TITLE
Preserve metadata with --remove-info

### DIFF
--- a/libqpdf/QPDFJob.cc
+++ b/libqpdf/QPDFJob.cc
@@ -450,7 +450,6 @@ QPDFJob::createQPDF()
             trailer.replaceKey(
                 "/Info", pdf.makeIndirectObject(Dictionary({{"/ModDate", mod_date}})));
         }
-        root.erase("/Metadata");
     }
     if (m->remove_metadata) {
         root.erase("/Metadata");

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -18,6 +18,9 @@ more detail.
 
     - Avoid generating JSON with leading zeroes when converting real numbers.
 
+    - Preserve document-level XMP metadata when using :qpdf:ref:`--remove-info`. Metadata is
+      removed only when :qpdf:ref:`--remove-metadata` is specified.
+
     - Detect and warn in check linearization when the xref stream reports the object containing a
       compressed object to itself be a compressed object.
 

--- a/qpdf/qtest/merge-and-split.test
+++ b/qpdf/qtest/merge-and-split.test
@@ -14,7 +14,7 @@ cleanup();
 
 my $td = new TestDriver('merge-and-split');
 
-my $n_tests = 36;
+my $n_tests = 38;
 
 # Select pages from the same file multiple times including selecting
 # twice from an encrypted file and specifying the password only the
@@ -124,6 +124,17 @@ $td->runtest("remove info (with moddate)",
 $td->runtest("check output",
              {$td->FILE => "a.pdf"},
              {$td->FILE => "remove-info.pdf"});
+
+$td->runtest("remove info without removing metadata",
+             {$td->COMMAND =>
+                  "qpdf metadata-crypt-filter.pdf a.pdf" .
+                  " --remove-info" .
+                  " --decrypt" .
+                  " --static-id"},
+             {$td->STRING => "", $td->EXIT_STATUS => 0});
+$td->runtest("check metadata retained",
+             {$td->COMMAND => "qpdf --show-object=1 a.pdf"},
+             {$td->REGEXP => ".* /Metadata [0-9]+ 0 R .*", $td->EXIT_STATUS => 0});
 
 $td->runtest("remove info (without moddate)",
              {$td->COMMAND =>


### PR DESCRIPTION
`--remove-info` is documented to remove entries from the trailer's `/Info` dictionary while preserving `/ModDate`. It also erased the catalog's `/Metadata` entry, making it behave like `--remove-metadata` for document-level XMP metadata.

This removes that extra catalog mutation and adds a regression using `metadata-crypt-filter.pdf`. The existing test used `remove-metadata.pdf` as its input, so the metadata had already been removed before `--remove-info` ran and could not expose the behavior.

The release notes now clarify the corrected separation between the two options.

Tests:

- `TESTS=merge-and-split ctest --test-dir cmake-build-maintainer -R '^qpdf$' --output-on-failure` (38/38)
- full qpdf qtest suite (2,890 tests: 2,886 passed, 4 expected failures)
- remaining maintainer ctest suites (6/6 passed, including 1,439/1,439 fuzz tests)
- maintainer warning-as-error build
- `./format-code`
- `git diff --check`
