### PR TITLE
Reject suffixes in bounded numeric options

### DIFF
--- a/libqpdf/QPDFJob_config.cc
+++ b/libqpdf/QPDFJob_config.cc
@@ -24,8 +24,9 @@ to_int(std::string_view option, std::string const& value, int max, int min)
 {
     qpdf_expect(min < max);
     try {
-        int result = std::stoi(value);
-        if (result < min || result > max) {
+        std::size_t pos = 0;
+        int result = std::stoi(value, &pos);
+        if (pos != value.size() || result < min || result > max) {
             int_usage(option, max, min);
         }
         return result;
@@ -43,8 +44,9 @@ to_uint32(
 {
     qpdf_expect(min < max);
     try {
-        auto result = std::stoll(value);
-        if (std::cmp_less(result, min) || std::cmp_greater(result, max)) {
+        std::size_t pos = 0;
+        auto result = std::stoll(value, &pos);
+        if (pos != value.size() || std::cmp_less(result, min) || std::cmp_greater(result, max)) {
             int_usage(option, max, min);
         }
         return static_cast<uint32_t>(result);

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -18,6 +18,9 @@ more detail.
 
     - Avoid generating JSON with leading zeroes when converting real numbers.
 
+    - Reject trailing characters in bounded numeric command-line option values instead of
+      silently accepting their numeric prefixes.
+
     - Detect and warn in check linearization when the xref stream reports the object containing a
       compressed object to itself be a compressed object.
 

--- a/qpdf/qtest/arg-parsing.test
+++ b/qpdf/qtest/arg-parsing.test
@@ -15,7 +15,7 @@ cleanup();
 
 my $td = new TestDriver('arg-parsing');
 
-my $n_tests = 35;
+my $n_tests = 37;
 
 $td->runtest("required argument",
              {$td->COMMAND => "qpdf --password minimal.pdf"},
@@ -191,6 +191,12 @@ $td->runtest("bad compression-level",
                   $td->EXIT_STATUS => 2},
              $td->NORMALIZE_NEWLINES);
 
+$td->runtest("compression-level with trailing characters",
+             {$td->COMMAND => "qpdf --compression-level=9junk minimal.pdf"},
+             {$td->REGEXP => "invalid compression-level: must be a number between 1 and 9",
+                  $td->EXIT_STATUS => 2},
+             $td->NORMALIZE_NEWLINES);
+
 $td->runtest("bad jpeg-quality",
              {$td->COMMAND => "qpdf --jpeg-quality=101 minimal.pdf"},
              {$td->REGEXP => "invalid jpeg-quality: must be a number between 0 and 100",
@@ -201,6 +207,13 @@ $td->runtest("bad objects-container-max-container-size",
              {$td->COMMAND => "qpdf --global --parser-max-container-size=-1 -- minimal.pdf"},
              {$td->REGEXP =>
                 "invalid parser-max-container-size: must be a number between 0 and 4294967295",
+                  $td->EXIT_STATUS => 2},
+             $td->NORMALIZE_NEWLINES);
+
+$td->runtest("parser-max-errors with trailing characters",
+             {$td->COMMAND => "qpdf --global --parser-max-errors=2junk -- --check minimal.pdf"},
+             {$td->REGEXP =>
+                "invalid parser-max-errors: must be a number between 0 and 4294967295",
                   $td->EXIT_STATUS => 2},
              $td->NORMALIZE_NEWLINES);
 


### PR DESCRIPTION
Bounded numeric command-line options that use the shared `to_int` and `to_uint32` validators check the value returned by `std::stoi` or `std::stoll`, but not how much of the argument was consumed. As a result, values such as `--compression-level=9junk` and `--parser-max-errors=2junk` are accepted as `9` and `2`.

This checks the conversion position in both bounded numeric helpers and routes partially parsed values through the existing usage-error path. Valid values, range validation, and diagnostic text are unchanged.

The regression covers both helper paths with signed-integer and `uint32_t` options, and the release notes record the user-visible validation change.

Tests:

- `TESTS=arg-parsing ctest --test-dir cmake-build-maintainer -R '^qpdf$' --output-on-failure` (37/37)
- full qpdf qtest suite (2,890 tests: 2,886 passed, 4 expected failures)
- remaining maintainer ctest suites (6/6 passed, including 1,439/1,439 fuzz tests)
- maintainer warning-as-error build
- `clang-format -i libqpdf/QPDFJob_config.cc`
- `git diff --check`
