### PR TITLE
Add Linux ARM64 and macOS release binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,12 +84,36 @@ jobs:
           name: distribution-windows-${{ matrix.wordsize }}-${{ matrix.tool }}
           path: distribution
   macOS:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            architecture: x86_64
+          - runner: macos-15
+            architecture: arm64
+    runs-on: ${{ matrix.runner }}
     needs: Prebuild
     steps:
       - uses: actions/checkout@v7
-      - name: 'Mac build and test'
-        run: build-scripts/build-mac
+      - name: 'Mac build, test, and package'
+        run: build-scripts/build-mac ${{ matrix.architecture }}
+      - name: 'Upload binary distribution'
+        uses: actions/upload-artifact@v7
+        with:
+          name: distribution-macos-${{ matrix.architecture }}
+          path: distribution
+  LinuxArm64:
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - name: 'Linux ARM64 build, test, and package'
+        run: build-scripts/build-linux-arm64
+      - name: 'Upload binary distribution'
+        uses: actions/upload-artifact@v7
+        with:
+          name: distribution-linux-arm64
+          path: distribution
   AppImage:
     runs-on: ubuntu-latest
     needs: Prebuild
@@ -171,7 +195,9 @@ jobs:
      needs:
        - Prebuild
        - Linux
+       - LinuxArm64
        - Windows
+       - macOS
        - AppImage
      steps:
        - name: Merge Artifacts

--- a/README-what-to-download.md
+++ b/README-what-to-download.md
@@ -46,6 +46,18 @@ Ubuntu. However, there are some downloads available for Linux as well.
   and was initially created for that purpose. The executables have their runpath set to looks for the qpdf library
   in `../lib` relative to the location of the executables, which makes this distribution relocatable.
 
+* `qpdf-<version>-bin-linux-arm64.zip` - This is the ARM64 equivalent of the Linux binary distribution. The qpdf,
+  libjpeg, zlib, and C++ runtime libraries are statically linked, leaving only standard system-library dependencies.
+
+macOS Binaries
+
+The macOS binary distributions contain qpdf command-line tools that depend only on system libraries supplied with
+macOS 11 or newer. Choose the archive that matches your Mac's processor:
+
+* `qpdf-<version>-bin-macos-arm64.zip` - Use this for Apple Silicon Macs.
+
+* `qpdf-<version>-bin-macos-x86_64.zip` - Use this for Intel Macs.
+
 Windows Build Support
 
 If you are building on Windows and want to use pre-built external static libraries, you should obtain current versions

--- a/build-scripts/build-linux-arm64
+++ b/build-scripts/build-linux-arm64
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -ex
+cd "$(dirname "$0")/.."
+
+sudo apt-get update
+sudo apt-get -y install \
+    build-essential cmake file libjpeg-dev unzip zlib1g-dev zip zsh
+
+architecture=$(uname -m)
+job_count=$(nproc)
+if [ "$architecture" != "aarch64" ]; then
+    echo "Expected aarch64 runner, but runner architecture is $architecture"
+    exit 2
+fi
+
+multiarch=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
+export PKG_CONFIG_LIBDIR=$PWD/build.arm64/empty-pkgconfig
+mkdir -p "$PKG_CONFIG_LIBDIR"
+
+cmake -S . -B build.arm64 -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON \
+      -DUSE_IMPLICIT_CRYPTO=OFF -DREQUIRE_CRYPTO_NATIVE=ON \
+      -DREQUIRE_SHELLS=1 \
+      -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+      -DZLIB_H_PATH=/usr/include \
+      "-DZLIB_LIB_PATH=/usr/lib/$multiarch/libz.a" \
+      -DLIBJPEG_H_PATH=/usr/include \
+      "-DLIBJPEG_LIB_PATH=/usr/lib/$multiarch/libjpeg.a"
+cmake --build build.arm64 --verbose -j"$job_count" -- -k
+(cd build.arm64; ctest --verbose)
+
+version=$(build.arm64/qpdf/qpdf --version | awk 'NR == 1 {print $3}')
+package_name=qpdf-$version-bin-linux-arm64
+stage=$PWD/build.arm64/$package_name
+archive=$PWD/distribution/$package_name-ci.zip
+rm -rf "$stage" distribution
+mkdir -p "$stage" distribution
+cmake --install build.arm64 --prefix "$stage" --component cli
+
+for executable in qpdf fix-qdf zlib-flate; do
+    executable_path=$stage/bin/$executable
+    file "$executable_path" | grep -F 'ELF 64-bit LSB pie executable, ARM aarch64'
+    if readelf -d "$executable_path" | grep -E '(RPATH|RUNPATH)'; then
+        echo "Unexpected runtime search path in $executable_path"
+        exit 2
+    fi
+    if readelf -d "$executable_path" | grep NEEDED | \
+           grep -E 'lib(qpdf|jpeg|z|stdc\+\+|gcc_s)'; then
+        echo "Unexpected bundled-library dependency in $executable_path"
+        exit 2
+    fi
+done
+
+(cd "$stage"; zip -9 -r "$archive" bin)
+smoke_test=$PWD/build.arm64/package-smoke-test
+rm -rf "$smoke_test"
+mkdir -p "$smoke_test"
+unzip -q "$archive" -d "$smoke_test"
+"$smoke_test/bin/qpdf" --version | grep -E "^qpdf version $version$"
+"$smoke_test/bin/fix-qdf" --version | grep -E "^fix-qdf from qpdf version $version$"
+"$smoke_test/bin/zlib-flate" --version | grep -E "^zlib-flate from qpdf version $version$"
+sha256sum "$archive"

--- a/build-scripts/build-linux-arm64
+++ b/build-scripts/build-linux-arm64
@@ -15,6 +15,7 @@ fi
 
 multiarch=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
 export PKG_CONFIG_LIBDIR=$PWD/build.arm64/empty-pkgconfig
+export PKG_CONFIG_PATH=
 mkdir -p "$PKG_CONFIG_LIBDIR"
 
 cmake -S . -B build.arm64 -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release \

--- a/build-scripts/build-mac
+++ b/build-scripts/build-mac
@@ -9,7 +9,6 @@ if [ -n "$1" ] && [ "$architecture" != "$1" ]; then
     exit 2
 fi
 
-sdk_path=$(xcrun --show-sdk-path)
 build_dir=build.release-macos
 dependency_dir=build.release-macos-deps
 jpeg_version=3.2.0
@@ -19,18 +18,36 @@ jpeg_build=$PWD/$dependency_dir/libjpeg-turbo-$jpeg_version-build
 jpeg_prefix=$PWD/$dependency_dir/libjpeg-turbo-$jpeg_version-install
 jpeg_url=https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$jpeg_version
 jpeg_url=$jpeg_url/libjpeg-turbo-$jpeg_version.tar.gz
+zlib_version=1.3.2
+zlib_archive=$PWD/$dependency_dir/zlib-$zlib_version.tar.gz
+zlib_source=$PWD/$dependency_dir/zlib-$zlib_version
+zlib_build=$PWD/$dependency_dir/zlib-$zlib_version-build
+zlib_prefix=$PWD/$dependency_dir/zlib-$zlib_version-install
+zlib_url=https://github.com/madler/zlib/releases/download/v$zlib_version
+zlib_url=$zlib_url/zlib-$zlib_version.tar.gz
 mkdir -p "$dependency_dir"
 curl --fail --location --retry 3 "$jpeg_url" --output "$jpeg_archive"
+curl --fail --location --retry 3 "$zlib_url" --output "$zlib_archive"
 echo "6f30092cef9fb839779646608f4ee14ae3cbac989c47fa05e841b0841f09878e  $jpeg_archive" | \
     shasum -a 256 --check
-rm -rf "$jpeg_source"
+echo "bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16  $zlib_archive" | \
+    shasum -a 256 --check
+rm -rf "$jpeg_source" "$zlib_source"
 tar xzf "$jpeg_archive" -C "$dependency_dir"
+tar xzf "$zlib_archive" -C "$dependency_dir"
 cmake -S "$jpeg_source" -B "$jpeg_build" \
       -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
       -DCMAKE_INSTALL_PREFIX="$jpeg_prefix" \
       -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_SIMD=OFF \
       -DWITH_TESTS=OFF -DWITH_TOOLS=OFF -DWITH_TURBOJPEG=OFF
 cmake --build "$jpeg_build" --target install \
+      -j"$job_count"
+cmake -S "$zlib_source" -B "$zlib_build" \
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+      -DCMAKE_INSTALL_PREFIX="$zlib_prefix" \
+      -DZLIB_BUILD_SHARED=OFF -DZLIB_BUILD_STATIC=ON \
+      -DZLIB_BUILD_TESTING=OFF
+cmake --build "$zlib_build" --target install \
       -j"$job_count"
 
 export PKG_CONFIG_LIBDIR=$PWD/$build_dir/empty-pkgconfig
@@ -40,8 +57,8 @@ cmake -S . -B "$build_dir" -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON \
       -DUSE_IMPLICIT_CRYPTO=OFF -DREQUIRE_CRYPTO_NATIVE=ON \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
-      -DZLIB_H_PATH="$sdk_path/usr/include" \
-      -DZLIB_LIB_PATH="$sdk_path/usr/lib/libz.tbd" \
+      -DZLIB_H_PATH="$zlib_prefix/include" \
+      -DZLIB_LIB_PATH="$zlib_prefix/lib/libz.a" \
       -DLIBJPEG_H_PATH="$jpeg_prefix/include" \
       -DLIBJPEG_LIB_PATH="$jpeg_prefix/lib/libjpeg.a"
 cmake --build "$build_dir" --verbose -j"$job_count" -- -k

--- a/build-scripts/build-mac
+++ b/build-scripts/build-mac
@@ -51,6 +51,9 @@ cmake --build "$zlib_build" --target install \
       -j"$job_count"
 
 export PKG_CONFIG_LIBDIR=$PWD/$build_dir/empty-pkgconfig
+export PKG_CONFIG_PATH=
+# Keep compiler-default include directories from overriding the pinned headers.
+export CPATH=$jpeg_prefix/include:$zlib_prefix/include
 mkdir -p "$PKG_CONFIG_LIBDIR"
 
 cmake -S . -B "$build_dir" -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release \

--- a/build-scripts/build-mac
+++ b/build-scripts/build-mac
@@ -1,6 +1,77 @@
 #!/bin/bash
 set -ex
-cd $(dirname $0)/..
-cmake -S . -B build -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release
-cmake --build build --verbose -j$(sysctl -n hw.ncpu) -- -k
-(cd build; ctest --verbose)
+cd "$(dirname "$0")/.."
+
+architecture=$(uname -m)
+job_count=$(sysctl -n hw.ncpu)
+if [ -n "$1" ] && [ "$architecture" != "$1" ]; then
+    echo "Expected architecture $1, but runner architecture is $architecture"
+    exit 2
+fi
+
+sdk_path=$(xcrun --show-sdk-path)
+build_dir=build.release-macos
+dependency_dir=build.release-macos-deps
+jpeg_version=3.2.0
+jpeg_archive=$PWD/$dependency_dir/libjpeg-turbo-$jpeg_version.tar.gz
+jpeg_source=$PWD/$dependency_dir/libjpeg-turbo-$jpeg_version
+jpeg_build=$PWD/$dependency_dir/libjpeg-turbo-$jpeg_version-build
+jpeg_prefix=$PWD/$dependency_dir/libjpeg-turbo-$jpeg_version-install
+jpeg_url=https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/$jpeg_version
+jpeg_url=$jpeg_url/libjpeg-turbo-$jpeg_version.tar.gz
+mkdir -p "$dependency_dir"
+curl --fail --location --retry 3 "$jpeg_url" --output "$jpeg_archive"
+echo "6f30092cef9fb839779646608f4ee14ae3cbac989c47fa05e841b0841f09878e  $jpeg_archive" | \
+    shasum -a 256 --check
+rm -rf "$jpeg_source"
+tar xzf "$jpeg_archive" -C "$dependency_dir"
+cmake -S "$jpeg_source" -B "$jpeg_build" \
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+      -DCMAKE_INSTALL_PREFIX="$jpeg_prefix" \
+      -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_SIMD=OFF \
+      -DWITH_TESTS=OFF -DWITH_TOOLS=OFF -DWITH_TURBOJPEG=OFF
+cmake --build "$jpeg_build" --target install \
+      -j"$job_count"
+
+export PKG_CONFIG_LIBDIR=$PWD/$build_dir/empty-pkgconfig
+mkdir -p "$PKG_CONFIG_LIBDIR"
+
+cmake -S . -B "$build_dir" -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON \
+      -DUSE_IMPLICIT_CRYPTO=OFF -DREQUIRE_CRYPTO_NATIVE=ON \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+      -DZLIB_H_PATH="$sdk_path/usr/include" \
+      -DZLIB_LIB_PATH="$sdk_path/usr/lib/libz.tbd" \
+      -DLIBJPEG_H_PATH="$jpeg_prefix/include" \
+      -DLIBJPEG_LIB_PATH="$jpeg_prefix/lib/libjpeg.a"
+cmake --build "$build_dir" --verbose -j"$job_count" -- -k
+(cd "$build_dir"; ctest --verbose)
+
+version=$($build_dir/qpdf/qpdf --version | awk 'NR == 1 {print $3}')
+package_name=qpdf-$version-bin-macos-$architecture
+stage=$PWD/$build_dir/$package_name
+archive=$PWD/distribution/$package_name-ci.zip
+rm -rf "$stage" distribution
+mkdir -p "$stage" distribution
+cmake --install "$build_dir" --prefix "$stage" --component cli
+
+for executable in qpdf fix-qdf zlib-flate; do
+    executable_path=$stage/bin/$executable
+    file "$executable_path" | grep -F "Mach-O 64-bit executable $architecture"
+    otool -l "$executable_path" | grep -A5 LC_BUILD_VERSION | grep -F 'minos 11.0'
+    if otool -L "$executable_path" | tail -n +2 | awk '{print $1}' | \
+           grep -Ev '^(/usr/lib/|/System/Library/)'; then
+        echo "Unexpected non-system dependency in $executable_path"
+        exit 2
+    fi
+done
+
+(cd "$stage"; zip -9 -r "$archive" bin)
+smoke_test=$PWD/$build_dir/package-smoke-test
+rm -rf "$smoke_test"
+mkdir -p "$smoke_test"
+unzip -q "$archive" -d "$smoke_test"
+"$smoke_test/bin/qpdf" --version | grep -E "^qpdf version $version$"
+"$smoke_test/bin/fix-qdf" --version | grep -E "^fix-qdf from qpdf version $version$"
+"$smoke_test/bin/zlib-flate" --version | grep -E "^zlib-flate from qpdf version $version$"
+shasum -a 256 "$archive"

--- a/build-scripts/build-mac
+++ b/build-scripts/build-mac
@@ -35,11 +35,13 @@ echo "bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16  $zlib_ar
 rm -rf "$jpeg_source" "$zlib_source"
 tar xzf "$jpeg_archive" -C "$dependency_dir"
 tar xzf "$zlib_archive" -C "$dependency_dir"
+# Match the libjpeg v8-compatible headers on GitHub's macOS runners.
 cmake -S "$jpeg_source" -B "$jpeg_build" \
       -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
       -DCMAKE_INSTALL_PREFIX="$jpeg_prefix" \
       -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DWITH_SIMD=OFF \
-      -DWITH_TESTS=OFF -DWITH_TOOLS=OFF -DWITH_TURBOJPEG=OFF
+      -DWITH_JPEG8=ON -DWITH_TESTS=OFF -DWITH_TOOLS=OFF \
+      -DWITH_TURBOJPEG=OFF
 cmake --build "$jpeg_build" --target install \
       -j"$job_count"
 cmake -S "$zlib_source" -B "$zlib_build" \
@@ -52,8 +54,6 @@ cmake --build "$zlib_build" --target install \
 
 export PKG_CONFIG_LIBDIR=$PWD/$build_dir/empty-pkgconfig
 export PKG_CONFIG_PATH=
-# Keep compiler-default include directories from overriding the pinned headers.
-export CPATH=$jpeg_prefix/include:$zlib_prefix/include
 mkdir -p "$PKG_CONFIG_LIBDIR"
 
 cmake -S . -B "$build_dir" -DCI_MODE=1 -DCMAKE_BUILD_TYPE=Release \

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -76,7 +76,7 @@ more detail.
   - Build changes
 
     - Add precompiled command-line distributions for Linux ARM64 and for macOS on Intel and Apple
-      Silicon. Fixes :issue:`1588`.
+      Silicon. Fixes GitHub issue #1588.
 
     - The new ``REQUIRE_SHELLS`` CMake option causes completion tests to fail if
       a new enough bash and zsh are not installed. This option is enabled by

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -75,6 +75,9 @@ more detail.
 
   - Build changes
 
+    - Add precompiled command-line distributions for Linux ARM64 and for macOS on Intel and Apple
+      Silicon. Fixes :issue:`1588`.
+
     - The new ``REQUIRE_SHELLS`` CMake option causes completion tests to fail if
       a new enough bash and zsh are not installed. This option is enabled by
       default in maintainer mode.


### PR DESCRIPTION
## Summary

- add a native Ubuntu 22.04 ARM64 build that packages `qpdf`, `fix-qdf`, and `zlib-flate`
- build and upload separate macOS Intel and Apple Silicon command-line distributions
- statically link qpdf and non-system dependencies where appropriate, then verify architecture and runtime dependencies before upload
- merge the new archives into the existing release artifact and document the new download choices

## Testing

- [fork workflow run](https://github.com/Shion1305/qpdf/actions/runs/32959685945) on GitHub-hosted runners: Linux ARM64, macOS Intel, and macOS Apple Silicon all passed their full build, CTest, package validation, and artifact upload jobs
- `build-scripts/build-mac arm64` on Apple Silicon macOS: all 7 CTest groups passed; the generated ZIP was extracted and all three commands were smoke-tested
- `build-scripts/build-linux-arm64` in a native Ubuntu 22.04 ARM64 container: all 7 CTest groups passed; ELF architecture, runtime dependencies, ZIP extraction, and command smoke tests passed
- `shellcheck build-scripts/build-mac build-scripts/build-linux-arm64`
- `bash -n build-scripts/build-mac build-scripts/build-linux-arm64`
- parsed `.github/workflows/main.yml` as YAML

The runner labels come from the current `actions/runner-images` catalog; local actionlint 1.7.7 predates `macos-15-intel` and reports that label as unknown.

This keeps the existing release authentication flow based on signed checksums. It does not add Apple Developer ID signing or notarization for the macOS executables.

Closes #1588