### PR TITLE
Fix InputSource::read_line when a line's EOL run reaches EOF

### DIFF
--- a/libqpdf/InputSource.cc
+++ b/libqpdf/InputSource.cc
@@ -35,7 +35,7 @@ InputSource::read_line(std::string& str, size_t count, qpdf_offset_t at)
     if (eol != std::string::npos) {
         auto next_line = str.find_first_not_of("\n\r"sv, eol);
         str.resize(eol);
-        if (eol != std::string::npos) {
+        if (next_line != std::string::npos) {
             seek(last_offset + static_cast<qpdf_offset_t>(next_line), SEEK_SET);
             return eol;
         }

--- a/libtests/input_source.cc
+++ b/libtests/input_source.cc
@@ -86,5 +86,22 @@ main()
     check("findLast found potato salad", true, is->findLast("potato", 0, 0, f1));
     check("findLast found first one", true, is->tell() == 2056);
 
+    // A line whose EOL run reaches the end of the file has no character after
+    // the terminator for read_line to seek to.
+    BufferInputSource line_at_eof("line at eof", std::string("one\n"));
+    check("line at offset zero", true, line_at_eof.readLine(100) == "one");
+    check("positioned at EOF from offset zero", true, line_at_eof.tell() == 4);
+
+    BufferInputSource lines_at_eof("lines at eof", std::string("one\ntwo\n"));
+    lines_at_eof.readLine(100);
+    check("line before an EOL run at EOF", true, lines_at_eof.readLine(100) == "two");
+    check("positioned at EOF", true, lines_at_eof.tell() == 8);
+
+    // The EOL run can also reach the end of the read window rather than the end
+    // of the file, in which case the next line is still ahead.
+    BufferInputSource within_window("within window", std::string("one\n\n\nx"));
+    check("line filling the read window", true, within_window.readLine(4) == "one");
+    check("positioned at the next line", true, within_window.tell() == 6);
+
     return 0;
 }

--- a/libtests/qtest/input_source/input_source.out
+++ b/libtests/qtest/input_source/input_source.out
@@ -12,3 +12,9 @@ findLast found at EOF: PASS
 potato but not salad salad at EOF: PASS
 findLast found potato salad: PASS
 findLast found first one: PASS
+line at offset zero: PASS
+positioned at EOF from offset zero: PASS
+line before an EOL run at EOF: PASS
+positioned at EOF: PASS
+line filling the read window: PASS
+positioned at the next line: PASS

--- a/manual/release-notes.rst
+++ b/manual/release-notes.rst
@@ -21,6 +21,10 @@ more detail.
     - Detect and warn in check linearization when the xref stream reports the object containing a
       compressed object to itself be a compressed object.
 
+    - Report a file whose only line is a PDF header as damaged instead of failing with a
+      system error. Reading a line whose end-of-line run reaches the end of the file left the
+      input source one byte before the start of that line, which at offset 0 is a seek to -1.
+
   - Enhancements
 
     - Improve uniformity and accuracy of progress reporting when writing linearized files and


### PR DESCRIPTION
The guard before the seek tested eol rather than next_line, so a line with no character after its terminator seeks to last_offset + nposm one byte before the start of the line just read. At offset 0 that is a seek to -1, which fails with EINVAL, so a file whose only line is a PDF header failed with a system error instead of being reported as damaged. At any other offset the result is a valid position, so the input source was left one byte behind with no error at all.

In practice this turns
```
QPDFSystemError: seek to …, offset -1 (0): Invalid argument
```
into
```
QPDFExc: unable to find trailer dictionary while recovering damaged file
```
so a truncated file is reported like any other invalid or corrupt PDF.

Let me know if you would like an integration test for this case.