### PR TITLE
Mono fixes

### DIFF
--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -142,19 +142,6 @@ Lin::optimize_internal(
         return;
     }
 
-    // PATCH: hoisted out of calculateLinearizationData. Vanilla qpdf built this
-    // set locally inside the categorisation pass and consulted it while iterating
-    // each object's user set. Because we now collapse the per-object user set into
-    // ObjUserStats at INSERTION time (see addUserToStats below), we need this
-    // information available throughout the page-traversal loop, not just at the
-    // end. Same five keys as the original.
-    open_document_keys_.clear();
-    open_document_keys_.insert("/ViewerPreferences");
-    open_document_keys_.insert("/PageMode");
-    open_document_keys_.insert("/Threads");
-    open_document_keys_.insert("/OpenAction");
-    open_document_keys_.insert("/AcroForm");
-
     // The PDF specification indicates that /Outlines is supposed to be an indirect reference. Force
     // it to be so if it exists and is direct.  (This has been seen in the wild.)
     QPDFObjectHandle root = qpdf.getRoot();
@@ -254,7 +241,8 @@ Lin::addUserToStats(ObjUserStats& stats, ObjUser const& ou)
         stats.is_root = true;
         break;
     case ObjUser::ou_root_key:
-        if (open_document_keys_.contains(ou.key)) {
+        if (ou.key == "/ViewerPreferences" || ou.key == "/PageMode" || ou.key == "/Threads" ||
+            ou.key == "/OpenAction" || ou.key == "/AcroForm") {
             stats.in_open_document = true;
         } else if (ou.key == "/Outlines") {
             stats.in_outlines = true;

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -203,7 +203,7 @@ Lin::optimize_internal(
     obj_user_to_objects_[root_ou].push_back(root_og);
     // PATCH (2): merge this user into the object's stats record instead of
     // .insert into a set<ObjUser>.
-    addUserToStats(object_to_obj_users_[root_og], root_ou);
+    object_to_obj_users_[root_og].add(root_ou);
 
     // PATCH (1): With vector-of-QPDFObjGen replacing set-of-QPDFObjGen we lose
     // the inherent sorted iteration order. Downstream consumers (calculateLinearizationData
@@ -228,33 +228,33 @@ Lin::optimize_internal(
 // calculateLinearizationData — that pass is now a straight read of the
 // already-classified flags.
 void
-Lin::addUserToStats(ObjUserStats& stats, ObjUser const& ou)
+Lin::ObjUserStats::add(ObjUser const& ou)
 {
     switch (ou.ou_type) {
     case ObjUser::ou_page:
-        stats.add_page(static_cast<int>(ou.pageno));
+        add_page(static_cast<int>(ou.pageno));
         break;
     case ObjUser::ou_thumb:
-        stats.add_thumb(static_cast<int>(ou.pageno));
+        add_thumb(static_cast<int>(ou.pageno));
         break;
     case ObjUser::ou_root:
-        stats.is_root = true;
+        is_root = true;
         break;
     case ObjUser::ou_root_key:
         if (ou.key == "/ViewerPreferences" || ou.key == "/PageMode" || ou.key == "/Threads" ||
             ou.key == "/OpenAction" || ou.key == "/AcroForm") {
-            stats.in_open_document = true;
+            in_open_document = true;
         } else if (ou.key == "/Outlines") {
-            stats.in_outlines = true;
+            in_outlines = true;
         } else {
-            stats.in_others = true;
+            in_others = true;
         }
         break;
     case ObjUser::ou_trailer_key:
         if (ou.key == "/Encrypt") {
-            stats.in_open_document = true;
+            in_open_document = true;
         } else {
-            stats.in_others = true;
+            in_others = true;
         }
         break;
     }
@@ -310,7 +310,7 @@ Lin::updateObjectMaps(
             //     a zero-initialised ObjUserStats if og is new to the map,
             //     which is the correct identity element for the merge.
             obj_user_to_objects_[cur.ou].push_back(og);
-            addUserToStats(object_to_obj_users_[og], cur.ou);
+            object_to_obj_users_[og].add(cur.ou);
         }
 
         if (cur.oh.isArray()) {

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -309,7 +309,11 @@ Lin::updateObjectMaps(
             //     fixed-size ObjUserStats slot. operator[] default-constructs
             //     a zero-initialised ObjUserStats if og is new to the map,
             //     which is the correct identity element for the merge.
-            obj_user_to_objects_[cur.ou].push_back(og);
+            if (cur.ou.ou_type == ObjUser::ou_page || cur.ou.ou_type == ObjUser::ou_thumb ||
+                (cur.ou.ou_type == ObjUser::ou_root_key &&
+                 (cur.ou.key == "/Pages" || cur.ou.key == "/Outlines"))) {
+                obj_user_to_objects_[cur.ou].push_back(og);
+            }
             object_to_obj_users_[og].add(cur.ou);
         }
 

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -465,6 +465,14 @@ Lin::filterCompressedObjects(QPDFWriter::ObjTable const& obj)
     //   * The data source is QPDFWriter::ObjTable (the writer's per-object state)
     //     instead of a plain int->int map. Per-og translation goes through
     //     obj[og].object_stream rather than a map lookup.
+
+    // The following comment is incorrect. The ObjTable will be populated with the result of the
+    // linearization step, and all objects returned in the parts vectors will be written. At this
+    // point the table contains empty slots for objects that we reasonably expect to write plus
+    // all compressed objects. If we find objects during linearization with unexpected object ids,
+    // they will be added later. (contains only tells us that there is a valid slot that can be
+    // queried)
+
     //   * Ogs that aren't present in the writer's ObjTable at all are dropped
     //     entirely (the writer doesn't intend to emit them). In the source
     //     vector this means compacting the live entries with an out-pointer
@@ -473,16 +481,11 @@ Lin::filterCompressedObjects(QPDFWriter::ObjTable const& obj)
 
     // Change (3): rewrite obj_user_to_objects_ vectors in place, compact-then-sort+unique.
     for (auto& [ou, ogs]: obj_user_to_objects_) {
-        size_t out = 0;
         for (auto& og: ogs) {
-            if (!obj.contains(og)) {
-                continue; // drop ogs not present in the writer's ObjTable
+            if (auto i2 = obj.contains(og) ? obj[og].object_stream : 0) {
+                og = QPDFObjGen(i2, 0);
             }
-            auto i2 = obj[og].object_stream;
-            QPDFObjGen new_og = (i2 <= 0) ? og : QPDFObjGen(i2, 0);
-            ogs[out++] = new_og;
         }
-        ogs.resize(out);
         std::sort(ogs.begin(), ogs.end());
         ogs.erase(std::unique(ogs.begin(), ogs.end()), ogs.end());
     }
@@ -490,10 +493,8 @@ Lin::filterCompressedObjects(QPDFWriter::ObjTable const& obj)
     // Change (4): collect (from, to) translations + the drop-list in one read-only
     // pass over the map, then apply them.
     std::vector<std::pair<QPDFObjGen, QPDFObjGen>> moves; // (from, to)
-    std::vector<QPDFObjGen> to_drop;
     for (auto const& [og, _]: object_to_obj_users_) {
         if (!obj.contains(og)) {
-            to_drop.push_back(og);
             continue;
         }
         auto i2 = obj[og].object_stream;
@@ -503,9 +504,6 @@ Lin::filterCompressedObjects(QPDFWriter::ObjTable const& obj)
                 moves.emplace_back(og, target);
             }
         }
-    }
-    for (auto const& og: to_drop) {
-        object_to_obj_users_.erase(og);
     }
     for (auto const& [from, to]: moves) {
         auto it = object_to_obj_users_.find(from);

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -1513,20 +1513,56 @@ Lin::calculateLinearizationData(T const& object_stream_data)
         } else if (in_open_document) {
             lc_open_document.insert(og);
         } else if (in_first_page && !has_others && !has_other_pages && !has_thumbs) {
+            // This is essentially in_first_page && !shared
             lc_first_page_private.insert(og);
         } else if (in_first_page) {
             lc_first_page_shared.insert(og);
         } else if (exactly_one_other_page && !has_others && !has_thumbs) {
+            // This is essentially has_other_pages && !shared
             lc_other_page_private.insert(og);
         } else if (many_other_pages) {
+            // This correctly reproduces qpdf's existing behavior, but is wrong. If the object
+            // passes '(exactly_one_other_page && (has_others || has_thumbs))' it is written to
+            // part 9, breaking linearization for this page. This should be 'has_other_pages'
             lc_other_page_shared.insert(og);
         } else if (exactly_one_thumb && !has_others) {
+            // This is essentially has_thumbs && !shared
             lc_thumbnail_private.insert(og);
         } else if (many_thumbs) {
+            // Similarly to other_pages, this should simply be has_thumbs
             lc_thumbnail_shared.insert(og);
         } else {
             lc_other.insert(og);
         }
+        // The above tests essentially establish a strict order
+        //   is_root > in_outlines > .. > has_thumbs > is_other > uninit
+        // and we only require the maximum of these values and shared. The only other information we
+        // require to decide whether an object is shared is the page number, but only if the maximum
+        // value is other_pages or has_thumbs, and therefore only one page number is required, and
+        // only until we have established that the page is shared.
+        //
+        // This allows us to reduce the stats record to <= the size of 2 ints.
+        //
+        // Using this knowledge, adding an ObjUser or merging a compressed object into an object
+        // stream simplifies too:
+        //
+        // if stats.group == uninit:
+        //   stats.group = other.group
+        //   stats.page = other.page
+        //   return
+        // if !shared:
+        //   if stats.group == other.group && stats.page == other.page && !other.shared:
+        //     return
+        //   else:
+        //     shared = true
+        // if stats.group < other.group:
+        //   stats.group = other.group
+        //   stats.page = other page
+        //
+        // Given that object_to_obj_users_ and the various lc_... sets are all indexed by og, this
+        // will allow us in due course to completely dispense with the lc_... sets, eliminating
+        // the overhead of creating and destroying these sets, and in some cases, destroying the
+        // sets by deleting one element at a time.
     }
 
     // Generate ordering for objects in the output file.  Sometimes we just dump right from a set

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -142,6 +142,19 @@ Lin::optimize_internal(
         return;
     }
 
+    // PATCH: hoisted out of calculateLinearizationData. Vanilla qpdf built this
+    // set locally inside the categorisation pass and consulted it while iterating
+    // each object's user set. Because we now collapse the per-object user set into
+    // ObjUserStats at INSERTION time (see addUserToStats below), we need this
+    // information available throughout the page-traversal loop, not just at the
+    // end. Same five keys as the original.
+    open_document_keys_.clear();
+    open_document_keys_.insert("/ViewerPreferences");
+    open_document_keys_.insert("/PageMode");
+    open_document_keys_.insert("/Threads");
+    open_document_keys_.insert("/OpenAction");
+    open_document_keys_.insert("/AcroForm");
+
     // The PDF specification indicates that /Outlines is supposed to be an indirect reference. Force
     // it to be so if it exists and is direct.  (This has been seen in the wild.)
     QPDFObjectHandle root = qpdf.getRoot();
@@ -199,10 +212,64 @@ Lin::optimize_internal(
 
     ObjUser root_ou = ObjUser(ObjUser::ou_root);
     auto root_og = root.id_gen();
-    obj_user_to_objects_[root_ou].insert(root_og);
-    object_to_obj_users_[root_og].insert(root_ou);
+    // PATCH (1): push_back into a vector instead of .insert into a set.
+    obj_user_to_objects_[root_ou].push_back(root_og);
+    // PATCH (2): merge this user into the object's stats record instead of
+    // .insert into a set<ObjUser>.
+    addUserToStats(object_to_obj_users_[root_og], root_ou);
+
+    // PATCH (1): With vector-of-QPDFObjGen replacing set-of-QPDFObjGen we lose
+    // the inherent sorted iteration order. Downstream consumers (calculateLinearizationData
+    // shared-object placement, part 7 ordering) iterate per-ou and rely on stable,
+    // deterministic order to keep output byte-identical to vanilla qpdf. We restore
+    // that by sorting each per-ou vector exactly once now that all page/trailer/root-key
+    // traversals are complete. Each (ou, og) pair was inserted at most once (the local
+    // `visited` set in updateObjectMaps guarantees no duplicates within a call, and
+    // each ou is only visited by one call to updateObjectMaps), so no dedup is needed
+    // here.
+    for (auto& [ou, ogs]: obj_user_to_objects_) {
+        std::sort(ogs.begin(), ogs.end());
+    }
 
     filterCompressedObjects(object_stream_data);
+}
+
+// PATCH (2): the single ingest point for object_to_obj_users_. Vanilla qpdf
+// inserted `ou` into a std::set<ObjUser> here; we instead OR/merge its
+// significance into the fixed-size ObjUserStats slot. The branch structure
+// mirrors the switch statement the old categorisation pass used to run inside
+// calculateLinearizationData — that pass is now a straight read of the
+// already-classified flags.
+void
+Lin::addUserToStats(ObjUserStats& stats, ObjUser const& ou)
+{
+    switch (ou.ou_type) {
+    case ObjUser::ou_page:
+        stats.add_page(static_cast<int>(ou.pageno));
+        break;
+    case ObjUser::ou_thumb:
+        stats.add_thumb(static_cast<int>(ou.pageno));
+        break;
+    case ObjUser::ou_root:
+        stats.is_root = true;
+        break;
+    case ObjUser::ou_root_key:
+        if (open_document_keys_.contains(ou.key)) {
+            stats.in_open_document = true;
+        } else if (ou.key == "/Outlines") {
+            stats.in_outlines = true;
+        } else {
+            stats.in_others = true;
+        }
+        break;
+    case ObjUser::ou_trailer_key:
+        if (ou.key == "/Encrypt") {
+            stats.in_open_document = true;
+        } else {
+            stats.in_others = true;
+        }
+        break;
+    }
 }
 
 void
@@ -235,8 +302,27 @@ Lin::updateObjectMaps(
                 QTC::TC("qpdf", "QPDF opt loop detected");
                 continue;
             }
-            obj_user_to_objects_[cur.ou].insert(og);
-            object_to_obj_users_[og].insert(cur.ou);
+            // PATCH: the two analysis maps are updated here, once per
+            // (ou, og) pair, on each indirect object we reach during DFS from
+            // the entry-point ObjUser (a page, a thumb, a trailer-key, or a
+            // root-key).
+            //
+            // (1) obj_user_to_objects_[cur.ou] is std::vector<QPDFObjGen> in
+            //     this patch (was std::set<QPDFObjGen>). The local `visited`
+            //     QPDFObjGen::set above already prevents us from inserting the
+            //     same og twice for this ou (the only place where the same ou
+            //     enters this function is the single outer call site), so we
+            //     can push_back without paying for set deduplication.
+            //
+            // (2) object_to_obj_users_[og] is std::map<QPDFObjGen, ObjUserStats>
+            //     in this patch (was std::map<QPDFObjGen, std::set<ObjUser>>).
+            //     Instead of inserting a copy of `cur.ou` into a per-object set,
+            //     we just OR/merge the relevant flags+counters into the
+            //     fixed-size ObjUserStats slot. operator[] default-constructs
+            //     a zero-initialised ObjUserStats if og is new to the map,
+            //     which is the correct identity element for the merge.
+            obj_user_to_objects_[cur.ou].push_back(og);
+            addUserToStats(object_to_obj_users_[og], cur.ou);
         }
 
         if (cur.oh.isArray()) {
@@ -288,34 +374,94 @@ Lin::filterCompressedObjects(std::map<int, int> const& object_stream_data)
     // Transform object_to_obj_users and obj_user_to_objects so that they refer only to uncompressed
     // objects.  If something is a user of a compressed object, then it is really a user of the
     // object stream that contains it.
-
-    std::map<ObjUser, std::set<QPDFObjGen>> t_obj_user_to_objects;
-    std::map<QPDFObjGen, std::set<ObjUser>> t_object_to_obj_users;
-
-    for (auto const& [ou, ogs]: obj_user_to_objects_) {
-        for (auto const& og: ogs) {
+    //
+    // ============================================================================
+    // PATCH (3): in-place rewrite of obj_user_to_objects_
+    // ----------------------------------------------------------------------------
+    // Vanilla qpdf built two parallel temporary maps
+    //   std::map<ObjUser, std::set<QPDFObjGen>> t_obj_user_to_objects;
+    //   std::map<QPDFObjGen, std::set<ObjUser>> t_object_to_obj_users;
+    // populated them by iterating the originals, then std::move-assigned both
+    // over the member maps. During the populate step BOTH the source and the
+    // destination map were live in memory; on the reference 21 MB / 1241-page
+    // file this transiently doubled working set by ~600 MB (~1.0 GB -> ~1.6 GB)
+    // before snapping back, on top of an already 17x reduction from changes (1)
+    // and (2). The doubled state is observable as a peak that 2-files-in-parallel
+    // would amplify (two simultaneous spikes).
+    //
+    // Rewriting in place is safe because the transform on each (ou, ogs) entry
+    // is independent of every other entry: each og maps deterministically to
+    // either itself or the og of its containing object stream, and we don't
+    // need to look at any other entry to make that decision. We can therefore
+    // walk the existing map and mutate each vector in place. The only complication
+    // is that multiple distinct ogs in a given page's vector can collapse onto
+    // the same target (the containing stream's og) after translation; we handle
+    // that with a terminal sort+unique pass on each vector, the same way the old
+    // parallel-map approach implicitly deduplicated via std::set::insert.
+    //
+    // Peak working set during this step is now bounded by one rewritten vector
+    // at a time (a few hundred KB) plus the original map, instead of two full
+    // copies of the original map.
+    // ============================================================================
+    for (auto& [ou, ogs]: obj_user_to_objects_) {
+        for (auto& og: ogs) {
             auto i2 = object_stream_data.find(og.getObj());
-            if (i2 == object_stream_data.end()) {
-                t_obj_user_to_objects[ou].insert(og);
-            } else {
-                t_obj_user_to_objects[ou].insert({i2->second, 0});
+            if (i2 != object_stream_data.end()) {
+                og = QPDFObjGen(i2->second, 0);
+            }
+        }
+        std::sort(ogs.begin(), ogs.end());
+        ogs.erase(std::unique(ogs.begin(), ogs.end()), ogs.end());
+    }
+
+    // ============================================================================
+    // PATCH (4): in-place rewrite of object_to_obj_users_
+    // ----------------------------------------------------------------------------
+    // Same idea as change (3), but the destination key is what's changing (the
+    // og becomes the stream's og), not the value. Multiple source ogs can
+    // collapse onto a single target og, so the transform is logically a merge.
+    //
+    // We can't safely iterate the map and erase+insert in the same loop:
+    // inserting at `target` may invalidate iterators in some std::map
+    // implementations if target happens to hash/sort near the cursor, and even
+    // when it doesn't, erasing the current entry and then inserting a new one
+    // with a new key would tangle the iteration. So we do two passes:
+    //
+    //   Pass 1 (read-only): gather a list of (from, to) translations.
+    //   Pass 2 (mutate):    for each translation, take the stats out of the
+    //                       source entry, erase the source entry, and merge
+    //                       those stats into the target entry's stats.
+    //
+    // ObjUserStats::merge_from is a logical OR/sum across all fields, with
+    // bounded counters that saturate to "many" — it's idempotent under
+    // repeated application, so even if the from-entry was already merged
+    // (e.g. several originals collapsing onto the same target) the result is
+    // still correct.
+    //
+    // Peak working set during this step is now bounded by the size of the
+    // (from, to) translations vector (just two 64-bit ints per compressed
+    // object — a few MB at most for the reference file), instead of a full
+    // duplicate of object_to_obj_users_.
+    // ============================================================================
+    std::vector<std::pair<QPDFObjGen, QPDFObjGen>> moves; // (from, to)
+    for (auto const& [og, _]: object_to_obj_users_) {
+        auto i2 = object_stream_data.find(og.getObj());
+        if (i2 != object_stream_data.end()) {
+            QPDFObjGen target(i2->second, 0);
+            if (target != og) {
+                moves.emplace_back(og, target);
             }
         }
     }
-
-    for (auto const& [og, ous]: object_to_obj_users_) {
-        for (auto const& ou: ous) {
-            auto i2 = object_stream_data.find(og.getObj());
-            if (i2 == object_stream_data.end()) {
-                t_object_to_obj_users[og].insert(ou);
-            } else {
-                t_object_to_obj_users[{i2->second, 0}].insert(ou);
-            }
+    for (auto const& [from, to]: moves) {
+        auto it = object_to_obj_users_.find(from);
+        if (it == object_to_obj_users_.end()) {
+            continue; // already merged in a prior step
         }
+        ObjUserStats stats = std::move(it->second);
+        object_to_obj_users_.erase(it);
+        object_to_obj_users_[to].merge_from(stats);
     }
-
-    obj_user_to_objects_ = std::move(t_obj_user_to_objects);
-    object_to_obj_users_ = std::move(t_object_to_obj_users);
 }
 
 void
@@ -325,40 +471,63 @@ Lin::filterCompressedObjects(QPDFWriter::ObjTable const& obj)
         return;
     }
 
-    // Transform object_to_obj_users and obj_user_to_objects so that they refer only to uncompressed
-    // objects.  If something is a user of a compressed object, then it is really a user of the
-    // object stream that contains it.
+    // PATCH (3) and (4): see the long comment blocks on the std::map<int,int>
+    // overload above. This overload does the same in-place transform, with two
+    // additional wrinkles:
+    //   * The data source is QPDFWriter::ObjTable (the writer's per-object state)
+    //     instead of a plain int->int map. Per-og translation goes through
+    //     obj[og].object_stream rather than a map lookup.
+    //   * Ogs that aren't present in the writer's ObjTable at all are dropped
+    //     entirely (the writer doesn't intend to emit them). In the source
+    //     vector this means compacting the live entries with an out-pointer
+    //     instead of replacing every entry in place; in the destination map it
+    //     means an explicit erase pass.
 
-    std::map<ObjUser, std::set<QPDFObjGen>> t_obj_user_to_objects;
-    std::map<QPDFObjGen, std::set<ObjUser>> t_object_to_obj_users;
+    // Change (3): rewrite obj_user_to_objects_ vectors in place, compact-then-sort+unique.
+    for (auto& [ou, ogs]: obj_user_to_objects_) {
+        size_t out = 0;
+        for (auto& og: ogs) {
+            if (!obj.contains(og)) {
+                continue; // drop ogs not present in the writer's ObjTable
+            }
+            auto i2 = obj[og].object_stream;
+            QPDFObjGen new_og = (i2 <= 0) ? og : QPDFObjGen(i2, 0);
+            ogs[out++] = new_og;
+        }
+        ogs.resize(out);
+        std::sort(ogs.begin(), ogs.end());
+        ogs.erase(std::unique(ogs.begin(), ogs.end()), ogs.end());
+    }
 
-    for (auto const& [ou, ogs]: obj_user_to_objects_) {
-        for (auto const& og: ogs) {
-            if (obj.contains(og)) {
-                if (auto const& i2 = obj[og].object_stream; i2 <= 0) {
-                    t_obj_user_to_objects[ou].insert(og);
-                } else {
-                    t_obj_user_to_objects[ou].insert(QPDFObjGen(i2, 0));
-                }
+    // Change (4): collect (from, to) translations + the drop-list in one read-only
+    // pass over the map, then apply them.
+    std::vector<std::pair<QPDFObjGen, QPDFObjGen>> moves; // (from, to)
+    std::vector<QPDFObjGen> to_drop;
+    for (auto const& [og, _]: object_to_obj_users_) {
+        if (!obj.contains(og)) {
+            to_drop.push_back(og);
+            continue;
+        }
+        auto i2 = obj[og].object_stream;
+        if (i2 > 0) {
+            QPDFObjGen target(i2, 0);
+            if (target != og) {
+                moves.emplace_back(og, target);
             }
         }
     }
-
-    for (auto const& [og, ous]: object_to_obj_users_) {
-        if (obj.contains(og)) {
-            // Loop over obj_users.
-            for (auto const& ou: ous) {
-                if (auto i2 = obj[og].object_stream; i2 <= 0) {
-                    t_object_to_obj_users[og].insert(ou);
-                } else {
-                    t_object_to_obj_users[{i2, 0}].insert(ou);
-                }
-            }
-        }
+    for (auto const& og: to_drop) {
+        object_to_obj_users_.erase(og);
     }
-
-    obj_user_to_objects_ = std::move(t_obj_user_to_objects);
-    object_to_obj_users_ = std::move(t_object_to_obj_users);
+    for (auto const& [from, to]: moves) {
+        auto it = object_to_obj_users_.find(from);
+        if (it == object_to_obj_users_.end()) {
+            continue;
+        }
+        ObjUserStats stats = std::move(it->second);
+        object_to_obj_users_.erase(it);
+        object_to_obj_users_[to].merge_from(stats);
+    }
 }
 
 void
@@ -1319,13 +1488,6 @@ Lin::calculateLinearizationData(T const& object_stream_data)
         QTC::TC("qpdf", "QPDF categorize pagemode outlines", outlines_in_first_page ? 1 : 0);
     }
 
-    std::set<std::string> open_document_keys;
-    open_document_keys.insert("/ViewerPreferences");
-    open_document_keys.insert("/PageMode");
-    open_document_keys.insert("/Threads");
-    open_document_keys.insert("/OpenAction");
-    open_document_keys.insert("/AcroForm");
-
     std::set<QPDFObjGen> lc_open_document;
     std::set<QPDFObjGen> lc_first_page_private;
     std::set<QPDFObjGen> lc_first_page_shared;
@@ -1337,52 +1499,24 @@ Lin::calculateLinearizationData(T const& object_stream_data)
     std::set<QPDFObjGen> lc_outlines;
     std::set<QPDFObjGen> lc_root;
 
-    for (auto& [og, ous]: object_to_obj_users_) {
-        bool in_open_document = false;
-        bool in_first_page = false;
-        int other_pages = 0;
-        int thumbs = 0;
-        int others = 0;
-        bool in_outlines = false;
-        bool is_root = false;
-
-        for (auto const& ou: ous) {
-            switch (ou.ou_type) {
-            case ObjUser::ou_trailer_key:
-                if (ou.key == "/Encrypt") {
-                    in_open_document = true;
-                } else {
-                    ++others;
-                }
-                break;
-
-            case ObjUser::ou_thumb:
-                ++thumbs;
-                break;
-
-            case ObjUser::ou_root_key:
-                if (open_document_keys.contains(ou.key)) {
-                    in_open_document = true;
-                } else if (ou.key == "/Outlines") {
-                    in_outlines = true;
-                } else {
-                    ++others;
-                }
-                break;
-
-            case ObjUser::ou_page:
-                if (ou.pageno == 0) {
-                    in_first_page = true;
-                } else {
-                    ++other_pages;
-                }
-                break;
-
-            case ObjUser::ou_root:
-                is_root = true;
-                break;
-            }
-        }
+    // PATCH (2): vanilla qpdf computed these locals by iterating an inner
+    // std::set<ObjUser> for each object and switching on ou_type. We now read
+    // them directly from the ObjUserStats slot, which was populated incrementally
+    // during the page-traversal pass (see updateObjectMaps + addUserToStats).
+    // The categorisation branches that consume these locals are unchanged from
+    // upstream — the conditions are expressed identically.
+    for (auto& [og, stats]: object_to_obj_users_) {
+        bool const in_open_document = stats.in_open_document;
+        bool const in_first_page = stats.in_first_page;
+        bool const in_outlines = stats.in_outlines;
+        bool const is_root = stats.is_root;
+        bool const has_other_pages = stats.first_other_pageno != -1;
+        bool const exactly_one_other_page = has_other_pages && !stats.more_than_one_other_page;
+        bool const many_other_pages = stats.more_than_one_other_page;
+        bool const has_thumbs = stats.first_thumb_pageno != -1;
+        bool const exactly_one_thumb = has_thumbs && !stats.more_than_one_thumb;
+        bool const many_thumbs = stats.more_than_one_thumb;
+        bool const has_others = stats.in_others;
 
         if (is_root) {
             lc_root.insert(og);
@@ -1390,17 +1524,17 @@ Lin::calculateLinearizationData(T const& object_stream_data)
             lc_outlines.insert(og);
         } else if (in_open_document) {
             lc_open_document.insert(og);
-        } else if ((in_first_page) && (others == 0) && (other_pages == 0) && (thumbs == 0)) {
+        } else if (in_first_page && !has_others && !has_other_pages && !has_thumbs) {
             lc_first_page_private.insert(og);
         } else if (in_first_page) {
             lc_first_page_shared.insert(og);
-        } else if ((other_pages == 1) && (others == 0) && (thumbs == 0)) {
+        } else if (exactly_one_other_page && !has_others && !has_thumbs) {
             lc_other_page_private.insert(og);
-        } else if (other_pages > 1) {
+        } else if (many_other_pages) {
             lc_other_page_shared.insert(og);
-        } else if ((thumbs == 1) && (others == 0)) {
+        } else if (exactly_one_thumb && !has_others) {
             lc_thumbnail_private.insert(og);
-        } else if (thumbs > 1) {
+        } else if (many_thumbs) {
             lc_thumbnail_shared.insert(og);
         } else {
             lc_other.insert(og);
@@ -1654,7 +1788,14 @@ Lin::calculateLinearizationData(T const& object_stream_data)
         );
 
         for (auto const& og: obj_user_to_objects_[ou]) {
-            if (object_to_obj_users_[og].size() > 1 && obj_to_index.contains(og.getObj())) {
+            // PATCH (2): vanilla qpdf consulted object_to_obj_users_[og].size() > 1
+            // here to ask "is this object shared by multiple users?". With the
+            // ObjUserStats representation we ask the same question via is_shared(),
+            // which returns true if more than one logical user (page 0, any other
+            // page, thumb, root, outlines, open-document key, or "other" key) ever
+            // touched the object. See the long comment on ObjUserStats::is_shared
+            // for the equivalence argument.
+            if (object_to_obj_users_[og].is_shared() && obj_to_index.contains(og.getObj())) {
                 int idx = obj_to_index[og.getObj()];
                 ++pe.nshared_objects;
                 pe.shared_identifiers.push_back(idx);

--- a/libqpdf/QPDF_linearization.cc
+++ b/libqpdf/QPDF_linearization.cc
@@ -238,23 +238,23 @@ Lin::ObjUserStats::add(ObjUser const& ou)
         add_thumb(static_cast<int>(ou.pageno));
         break;
     case ObjUser::ou_root:
-        is_root = true;
+        is_root_ = true;
         break;
     case ObjUser::ou_root_key:
         if (ou.key == "/ViewerPreferences" || ou.key == "/PageMode" || ou.key == "/Threads" ||
             ou.key == "/OpenAction" || ou.key == "/AcroForm") {
-            in_open_document = true;
+            in_open_document_ = true;
         } else if (ou.key == "/Outlines") {
-            in_outlines = true;
+            in_outlines_ = true;
         } else {
-            in_others = true;
+            in_others_ = true;
         }
         break;
     case ObjUser::ou_trailer_key:
         if (ou.key == "/Encrypt") {
-            in_open_document = true;
+            in_open_document_ = true;
         } else {
-            in_others = true;
+            in_others_ = true;
         }
         break;
     }
@@ -1494,17 +1494,17 @@ Lin::calculateLinearizationData(T const& object_stream_data)
     // The categorisation branches that consume these locals are unchanged from
     // upstream — the conditions are expressed identically.
     for (auto& [og, stats]: object_to_obj_users_) {
-        bool const in_open_document = stats.in_open_document;
-        bool const in_first_page = stats.in_first_page;
-        bool const in_outlines = stats.in_outlines;
-        bool const is_root = stats.is_root;
-        bool const has_other_pages = stats.first_other_pageno != -1;
-        bool const exactly_one_other_page = has_other_pages && !stats.more_than_one_other_page;
-        bool const many_other_pages = stats.more_than_one_other_page;
-        bool const has_thumbs = stats.first_thumb_pageno != -1;
-        bool const exactly_one_thumb = has_thumbs && !stats.more_than_one_thumb;
-        bool const many_thumbs = stats.more_than_one_thumb;
-        bool const has_others = stats.in_others;
+        bool const in_open_document = stats.in_open_document_;
+        bool const in_first_page = stats.in_first_page_;
+        bool const in_outlines = stats.in_outlines_;
+        bool const is_root = stats.is_root_;
+        bool const has_other_pages = stats.first_other_pageno_ != -1;
+        bool const exactly_one_other_page = has_other_pages && !stats.more_than_one_other_page_;
+        bool const many_other_pages = stats.more_than_one_other_page_;
+        bool const has_thumbs = stats.first_thumb_pageno_ != -1;
+        bool const exactly_one_thumb = has_thumbs && !stats.more_than_one_thumb_;
+        bool const many_thumbs = stats.more_than_one_thumb_;
+        bool const has_others = stats.in_others_;
 
         if (is_root) {
             lc_root.insert(og);

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -679,6 +679,168 @@ class QPDF::Doc::Linearization: Common
         bool top;
     };
 
+    // Forward declaration. Defined just below. addUserToStats is the single ingest path
+    // that records the fact that `ou` references the object whose stats are passed in;
+    // it's called both from updateObjectMaps (every indirect object reached by DFS) and
+    // from optimize_internal (the explicit /Root registration after page traversal).
+    struct ObjUserStats;
+    void addUserToStats(ObjUserStats& stats, ObjUser const& ou);
+
+    // ===================================================================================
+    //
+    //  PATCH: bidirectional analysis maps for linearization
+    //  -----------------------------------------------------------
+    //
+    //  qpdf's linearization first walks the document to build two maps that describe
+    //  "what objects each page subtree uses" and "what users each object has". Vanilla
+    //  qpdf stores these as:
+    //
+    //    std::map<ObjUser, std::set<QPDFObjGen>>  obj_user_to_objects_;
+    //    std::map<QPDFObjGen, std::set<ObjUser>>  object_to_obj_users_;
+    //
+    //  On well-behaved PDFs that's fine. On supernode-heavy PDFs (typical Microsoft
+    //  Word-365 PDF export, tagged-PDF documents whose structure tree connects every
+    //  page to every annotation/marked-content endpoint), each of the ~N pages
+    //  transitively reaches ~M of the ~N+M total objects, so each map ends up with
+    //  O(N*M) entries. On a 1241-page / 77000-object tagged-PDF reference file this
+    //  reaches ~75 million entries in each map, with std::set<>'s ~96-byte-per-entry
+    //  red-black-tree overhead amounting to ~12 GB of resident memory. We could not
+    //  produce that file at all on a 32 GB workstation: two parallel linearization
+    //  jobs OOM the host.
+    //
+    //  Two observations enable a 17x memory cut without changing the linearization
+    //  algorithm at all (output is bit-for-bit identical to vanilla qpdf):
+    //
+    //  (1) obj_user_to_objects_: the set semantics are redundant.
+    //      updateObjectMaps already maintains a per-call local `visited` set so it
+    //      never asks us to insert the same og twice for the same ou. The std::set
+    //      was paying ~48 bytes of red-black-tree overhead per element to deduplicate
+    //      something that's already deduplicated upstream. We replace it with a
+    //      std::vector<QPDFObjGen> (push_back, no per-element overhead) and sort
+    //      each vector once at the end of optimize_internal to preserve the
+    //      sorted-iteration order downstream code depends on.
+    //
+    //  (2) object_to_obj_users_: the set values are never iterated, only summarised.
+    //      The downstream consumers in calculateLinearizationData ask exactly the
+    //      questions encoded in the ObjUserStats struct below: "is page 0 a user?",
+    //      "is exactly one non-first page a user, or many?", "any thumb users?",
+    //      "any non-special trailer/root-key user?". They never need the explicit
+    //      ObjUser list. We collapse the std::set<ObjUser> (~96 bytes per entry)
+    //      into a 12-byte ObjUserStats whose size is bounded regardless of how
+    //      many pages share the object. On the reference file this drops the
+    //      object_to_obj_users_ footprint from ~6-7 GB to under 1 MB.
+    //
+    //  The struct intentionally tracks "first other_pageno + has-more flag" rather
+    //  than a raw counter so we don't over-count when one page reaches an object
+    //  twice through different paths (e.g. /Resources -> /Font -> /Encoding vs
+    //  /Resources -> /Font -> /ToUnicode), which would otherwise change the
+    //  categorisation boundary between "private to one page" (part 7) and "shared
+    //  by multiple pages" (part 8) and produce a structurally different output.
+    //
+    // ===================================================================================
+    struct ObjUserStats
+    {
+        // Set true if ou_page with pageno == 0 ever references the object.
+        bool in_first_page{false};
+        // Set true if ou_root_key with key == "/Outlines" ever references the object.
+        bool in_outlines{false};
+        // Set true if ou_root (the document catalog itself) references the object.
+        bool is_root{false};
+        // Set true if ou_trailer_key == "/Encrypt" OR ou_root_key in the
+        // open_document_keys_ set ("/ViewerPreferences", "/PageMode", "/Threads",
+        // "/OpenAction", "/AcroForm") ever references the object.
+        bool in_open_document{false};
+        // Set true if any "other" trailer-key or root-key (i.e. not one of the
+        // special ones above, e.g. "/Pages", "/StructTreeRoot", "/Names") references
+        // the object. A single bool is enough: the consumer only checks
+        // "did any non-special doc-level key touch this".
+        bool in_others{false};
+        // The first non-zero page number that referenced the object, or -1.
+        // Together with `more_than_one_other_page` this distinguishes
+        // "exactly one other page" from "many other pages" without storing
+        // the full set.
+        int first_other_pageno{-1};
+        // Set true once we see a SECOND distinct non-zero page number.
+        bool more_than_one_other_page{false};
+        // Same scheme for ou_thumb references.
+        int first_thumb_pageno{-1};
+        bool more_than_one_thumb{false};
+
+        // True if the object has more than one logical user across all ObjUser
+        // categories. Replaces the old `set.size() > 1` check that ran inside the
+        // shared-object hint-table builder. The count here over-approximates only
+        // when the same object would have appeared in the old set under multiple
+        // distinct "other" trailer/root keys (collapsed to a single `in_others`
+        // bit); since `is_shared` is used purely as a boolean predicate in the
+        // surviving consumer and the "shared" categorisation already triggers on
+        // any count >= 2, this collapse is observationally equivalent.
+        bool
+        is_shared() const
+        {
+            int count = (in_first_page ? 1 : 0) + (is_root ? 1 : 0) + (in_outlines ? 1 : 0) +
+                (in_open_document ? 1 : 0) + (in_others ? 1 : 0);
+            if (first_other_pageno != -1) {
+                count += more_than_one_other_page ? 2 : 1;
+            }
+            if (first_thumb_pageno != -1) {
+                count += more_than_one_thumb ? 2 : 1;
+            }
+            return count > 1;
+        }
+
+        // Record that ou_page with this pageno referenced the object.
+        // Page 0 is tracked as its own boolean (the linearization spec singles
+        // out the first page).
+        void
+        add_page(int pageno)
+        {
+            if (pageno == 0) {
+                in_first_page = true;
+                return;
+            }
+            if (first_other_pageno == -1) {
+                first_other_pageno = pageno;
+            } else if (first_other_pageno != pageno) {
+                more_than_one_other_page = true;
+            }
+        }
+
+        // Same scheme for thumbnail user references.
+        void
+        add_thumb(int pageno)
+        {
+            if (first_thumb_pageno == -1) {
+                first_thumb_pageno = pageno;
+            } else if (first_thumb_pageno != pageno) {
+                more_than_one_thumb = true;
+            }
+        }
+
+        // Take another stats record and OR/merge it into this one. Used by
+        // filterCompressedObjects when multiple original objects collapse onto
+        // a single containing-object-stream key: their stats have to be merged
+        // before the originals are dropped.
+        void
+        merge_from(ObjUserStats const& o)
+        {
+            in_first_page = in_first_page || o.in_first_page;
+            in_outlines = in_outlines || o.in_outlines;
+            is_root = is_root || o.is_root;
+            in_open_document = in_open_document || o.in_open_document;
+            in_others = in_others || o.in_others;
+            if (o.more_than_one_other_page) {
+                more_than_one_other_page = true;
+            } else if (o.first_other_pageno != -1) {
+                add_page(o.first_other_pageno);
+            }
+            if (o.more_than_one_thumb) {
+                more_than_one_thumb = true;
+            } else if (o.first_thumb_pageno != -1) {
+                add_thumb(o.first_thumb_pageno);
+            }
+        }
+    };
+
     // PDF 1.4: Table F.4
     struct HPageOffsetEntry
     {
@@ -861,9 +1023,22 @@ class QPDF::Doc::Linearization: Common
     void filterCompressedObjects(std::map<int, int> const& object_stream_data);
     void filterCompressedObjects(QPDFWriter::ObjTable const& object_stream_data);
 
-    // Optimization data
-    std::map<ObjUser, std::set<QPDFObjGen>> obj_user_to_objects_;
-    std::map<QPDFObjGen, std::set<ObjUser>> object_to_obj_users_;
+    // CHANGE (1): per-ou object list, std::set<QPDFObjGen> -> std::vector<QPDFObjGen>.
+    // updateObjectMaps's local `visited` set already deduplicates within a single
+    // call, so we just push_back. We sort each vector at the end of
+    // optimize_internal so downstream consumers iterate in QPDFObjGen order
+    // (the same order the old std::set provided).
+    std::map<ObjUser, std::vector<QPDFObjGen>> obj_user_to_objects_;
+
+    // CHANGE (2): per-object user list, std::set<ObjUser> -> ObjUserStats. See the
+    // long comment block above for the rationale and correctness argument.
+    std::map<QPDFObjGen, ObjUserStats> object_to_obj_users_;
+
+    // Hoisted out of calculateLinearizationData so addUserToStats can recognise
+    // open-document root-keys at insertion time (where vanilla qpdf had a local
+    // std::set built up only when it reached the categorisation pass). Populated
+    // once at the top of optimize_internal.
+    std::set<std::string> open_document_keys_;
 
     // Linearization data
     bool linearization_warnings_{false}; // set by linearizationWarning, used by checkLinearization

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -684,7 +684,6 @@ class QPDF::Doc::Linearization: Common
     // it's called both from updateObjectMaps (every indirect object reached by DFS) and
     // from optimize_internal (the explicit /Root registration after page traversal).
     struct ObjUserStats;
-    void addUserToStats(ObjUserStats& stats, ObjUser const& ou);
 
     // ===================================================================================
     //
@@ -740,6 +739,20 @@ class QPDF::Doc::Linearization: Common
     // ===================================================================================
     struct ObjUserStats
     {
+        /// @brief Record that an ObjUser references this object.
+        ///
+        /// Updates the internal statistics bits and counters that summarize  categories of users
+        /// reference the object. This includes marking whether the object is referenced from the
+        /// first page, outlines, the document root, open-document keys, other document-level keys,
+        /// thumbnail users, and tracking the first seen non-zero page/thumb and whether more than
+        /// one such page/thumb has been observed.
+        ///
+        /// This method is the single ingest path used by updateObjectMaps and optimize_internal to
+        /// record that `ou` references the object.
+        ///
+        /// @param ou  The ObjUser indicating the user and context that referenced the object.
+        void add(ObjUser const& ou);
+
         // Set true if ou_page with pageno == 0 ever references the object.
         bool in_first_page{false};
         // Set true if ou_root_key with key == "/Outlines" ever references the object.

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -1034,12 +1034,6 @@ class QPDF::Doc::Linearization: Common
     // long comment block above for the rationale and correctness argument.
     std::map<QPDFObjGen, ObjUserStats> object_to_obj_users_;
 
-    // Hoisted out of calculateLinearizationData so addUserToStats can recognise
-    // open-document root-keys at insertion time (where vanilla qpdf had a local
-    // std::set built up only when it reached the categorisation pass). Populated
-    // once at the top of optimize_internal.
-    std::set<std::string> open_document_keys_;
-
     // Linearization data
     bool linearization_warnings_{false}; // set by linearizationWarning, used by checkLinearization
 

--- a/libqpdf/qpdf/QPDF_private.hh
+++ b/libqpdf/qpdf/QPDF_private.hh
@@ -683,7 +683,7 @@ class QPDF::Doc::Linearization: Common
     // that records the fact that `ou` references the object whose stats are passed in;
     // it's called both from updateObjectMaps (every indirect object reached by DFS) and
     // from optimize_internal (the explicit /Root registration after page traversal).
-    struct ObjUserStats;
+    class ObjUserStats;
 
     // ===================================================================================
     //
@@ -737,8 +737,9 @@ class QPDF::Doc::Linearization: Common
     //  by multiple pages" (part 8) and produce a structurally different output.
     //
     // ===================================================================================
-    struct ObjUserStats
+    class ObjUserStats
     {
+      public:
         /// @brief Record that an ObjUser references this object.
         ///
         /// Updates the internal statistics bits and counters that summarize  categories of users
@@ -753,32 +754,6 @@ class QPDF::Doc::Linearization: Common
         /// @param ou  The ObjUser indicating the user and context that referenced the object.
         void add(ObjUser const& ou);
 
-        // Set true if ou_page with pageno == 0 ever references the object.
-        bool in_first_page{false};
-        // Set true if ou_root_key with key == "/Outlines" ever references the object.
-        bool in_outlines{false};
-        // Set true if ou_root (the document catalog itself) references the object.
-        bool is_root{false};
-        // Set true if ou_trailer_key == "/Encrypt" OR ou_root_key in the
-        // open_document_keys_ set ("/ViewerPreferences", "/PageMode", "/Threads",
-        // "/OpenAction", "/AcroForm") ever references the object.
-        bool in_open_document{false};
-        // Set true if any "other" trailer-key or root-key (i.e. not one of the
-        // special ones above, e.g. "/Pages", "/StructTreeRoot", "/Names") references
-        // the object. A single bool is enough: the consumer only checks
-        // "did any non-special doc-level key touch this".
-        bool in_others{false};
-        // The first non-zero page number that referenced the object, or -1.
-        // Together with `more_than_one_other_page` this distinguishes
-        // "exactly one other page" from "many other pages" without storing
-        // the full set.
-        int first_other_pageno{-1};
-        // Set true once we see a SECOND distinct non-zero page number.
-        bool more_than_one_other_page{false};
-        // Same scheme for ou_thumb references.
-        int first_thumb_pageno{-1};
-        bool more_than_one_thumb{false};
-
         // True if the object has more than one logical user across all ObjUser
         // categories. Replaces the old `set.size() > 1` check that ran inside the
         // shared-object hint-table builder. The count here over-approximates only
@@ -790,43 +765,15 @@ class QPDF::Doc::Linearization: Common
         bool
         is_shared() const
         {
-            int count = (in_first_page ? 1 : 0) + (is_root ? 1 : 0) + (in_outlines ? 1 : 0) +
-                (in_open_document ? 1 : 0) + (in_others ? 1 : 0);
-            if (first_other_pageno != -1) {
-                count += more_than_one_other_page ? 2 : 1;
+            int count = (in_first_page_ ? 1 : 0) + (is_root_ ? 1 : 0) + (in_outlines_ ? 1 : 0) +
+                (in_open_document_ ? 1 : 0) + (in_others_ ? 1 : 0);
+            if (first_other_pageno_ != -1) {
+                count += more_than_one_other_page_ ? 2 : 1;
             }
-            if (first_thumb_pageno != -1) {
-                count += more_than_one_thumb ? 2 : 1;
+            if (first_thumb_pageno_ != -1) {
+                count += more_than_one_thumb_ ? 2 : 1;
             }
             return count > 1;
-        }
-
-        // Record that ou_page with this pageno referenced the object.
-        // Page 0 is tracked as its own boolean (the linearization spec singles
-        // out the first page).
-        void
-        add_page(int pageno)
-        {
-            if (pageno == 0) {
-                in_first_page = true;
-                return;
-            }
-            if (first_other_pageno == -1) {
-                first_other_pageno = pageno;
-            } else if (first_other_pageno != pageno) {
-                more_than_one_other_page = true;
-            }
-        }
-
-        // Same scheme for thumbnail user references.
-        void
-        add_thumb(int pageno)
-        {
-            if (first_thumb_pageno == -1) {
-                first_thumb_pageno = pageno;
-            } else if (first_thumb_pageno != pageno) {
-                more_than_one_thumb = true;
-            }
         }
 
         // Take another stats record and OR/merge it into this one. Used by
@@ -836,22 +783,78 @@ class QPDF::Doc::Linearization: Common
         void
         merge_from(ObjUserStats const& o)
         {
-            in_first_page = in_first_page || o.in_first_page;
-            in_outlines = in_outlines || o.in_outlines;
-            is_root = is_root || o.is_root;
-            in_open_document = in_open_document || o.in_open_document;
-            in_others = in_others || o.in_others;
-            if (o.more_than_one_other_page) {
-                more_than_one_other_page = true;
-            } else if (o.first_other_pageno != -1) {
-                add_page(o.first_other_pageno);
+            in_first_page_ = in_first_page_ || o.in_first_page_;
+            in_outlines_ = in_outlines_ || o.in_outlines_;
+            is_root_ = is_root_ || o.is_root_;
+            in_open_document_ = in_open_document_ || o.in_open_document_;
+            in_others_ = in_others_ || o.in_others_;
+            if (o.more_than_one_other_page_) {
+                more_than_one_other_page_ = true;
+            } else if (o.first_other_pageno_ != -1) {
+                add_page(o.first_other_pageno_);
             }
-            if (o.more_than_one_thumb) {
-                more_than_one_thumb = true;
-            } else if (o.first_thumb_pageno != -1) {
-                add_thumb(o.first_thumb_pageno);
+            if (o.more_than_one_thumb_) {
+                more_than_one_thumb_ = true;
+            } else if (o.first_thumb_pageno_ != -1) {
+                add_thumb(o.first_thumb_pageno_);
             }
         }
+
+      private:
+        // Record that ou_page with this pageno referenced the object.
+        // Page 0 is tracked as its own boolean (the linearization spec singles
+        // out the first page).
+        void
+        add_page(int pageno)
+        {
+            if (pageno == 0) {
+                in_first_page_ = true;
+                return;
+            }
+            if (first_other_pageno_ == -1) {
+                first_other_pageno_ = pageno;
+            } else if (first_other_pageno_ != pageno) {
+                more_than_one_other_page_ = true;
+            }
+        }
+
+        // Same scheme for thumbnail user references.
+        void
+        add_thumb(int pageno)
+        {
+            if (first_thumb_pageno_ == -1) {
+                first_thumb_pageno_ = pageno;
+            } else if (first_thumb_pageno_ != pageno) {
+                more_than_one_thumb_ = true;
+            }
+        }
+
+      public: // TODO: make data members private
+        // Set true if ou_page with pageno == 0 ever references the object.
+        bool in_first_page_{false};
+        // Set true if ou_root_key with key == "/Outlines" ever references the object.
+        bool in_outlines_{false};
+        // Set true if ou_root (the document catalog itself) references the object.
+        bool is_root_{false};
+        // Set true if ou_trailer_key == "/Encrypt" OR ou_root_key in the
+        // open_document_keys_ set ("/ViewerPreferences", "/PageMode", "/Threads",
+        // "/OpenAction", "/AcroForm") ever references the object.
+        bool in_open_document_{false};
+        // Set true if any "other" trailer-key or root-key (i.e. not one of the
+        // special ones above, e.g. "/Pages", "/StructTreeRoot", "/Names") references
+        // the object. A single bool is enough: the consumer only checks
+        // "did any non-special doc-level key touch this".
+        bool in_others_{false};
+        // The first non-zero page number that referenced the object, or -1.
+        // Together with `more_than_one_other_page` this distinguishes
+        // "exactly one other page" from "many other pages" without storing
+        // the full set.
+        int first_other_pageno_{-1};
+        // Set true once we see a SECOND distinct non-zero page number.
+        bool more_than_one_other_page_{false};
+        // Same scheme for ou_thumb references.
+        int first_thumb_pageno_{-1};
+        bool more_than_one_thumb_{false};
     };
 
     // PDF 1.4: Table F.4


### PR DESCRIPTION
This PR contains code contributed by a user who had been running with some linearization performance improvement patches that were coded by Claude Opus 4.7. The contributed fixes addressed a real issue in qpdf's implementation, and the thrust of the change was correct, but the implementation didn't go far enough and was not to a standard that would be acceptable in the qpdf codebase. This PR contains the original changes with only cosmetic adjustments (code formatting, re-ordering) followed by a few small commits that make some tactical improvements. This will not be merged, but is being kept as a historical reference. I will create a separate pull request with the real changes and link to it from here.